### PR TITLE
Fix np.object_ for TYPE_STRING

### DIFF
--- a/src/resources/startup.py
+++ b/src/resources/startup.py
@@ -305,7 +305,7 @@ class PythonHost(PythonInterpreterServicer):
                 output_shape = output_np_array.shape
 
                 # We need to serialize TYPE_STRING
-                if output_np_array.dtype.type is np.object or output_np_array.dtype.type is np.bytes_:
+                if output_np_array.dtype.type is np.object_ or output_np_array.dtype.type is np.bytes_:
                     output_np_array = serialize_byte_tensor(output_np_array)
 
                 tensor = Tensor(name=output_tensor.name(),

--- a/src/resources/startup.py
+++ b/src/resources/startup.py
@@ -305,7 +305,7 @@ class PythonHost(PythonInterpreterServicer):
                 output_shape = output_np_array.shape
 
                 # We need to serialize TYPE_STRING
-                if output_np_array.dtype.type == np.object_ or output_np_array.dtype.type is np.bytes_:
+                if output_np_array.dtype == np.object or output_np_array.dtype.type is np.bytes_:
                     output_np_array = serialize_byte_tensor(output_np_array)
 
                 tensor = Tensor(name=output_tensor.name(),

--- a/src/resources/startup.py
+++ b/src/resources/startup.py
@@ -305,7 +305,7 @@ class PythonHost(PythonInterpreterServicer):
                 output_shape = output_np_array.shape
 
                 # We need to serialize TYPE_STRING
-                if output_np_array.dtype.type is np.object_ or output_np_array.dtype.type is np.bytes_:
+                if output_np_array.dtype.type == np.object_ or output_np_array.dtype.type is np.bytes_:
                     output_np_array = serialize_byte_tensor(output_np_array)
 
                 tensor = Tensor(name=output_tensor.name(),

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -52,7 +52,7 @@ TRITON_TO_NUMPY_TYPE = {
     # TRITONSERVER_TYPE_FP64
     12: np.float64,
     # TRITONSERVER_TYPE_STRING
-    13: np.bytes_
+    13: np.object
 }
 
 TRITON_STRING_TO_NUMPY = {
@@ -68,7 +68,7 @@ TRITON_STRING_TO_NUMPY = {
     'TYPE_FP16': np.float16,
     'TYPE_FP32': np.float32,
     'TYPE_FP64': np.float64,
-    'TYPE_STRING': np.bytes_
+    'TYPE_STRING': np.object
 }
 
 NUMPY_TO_TRITON_TYPE = {v: k for k, v in TRITON_TO_NUMPY_TYPE.items()}


### PR DESCRIPTION
`np.object` is `<class 'object'>`, while here, if I understand correctly the logic, we expect `<class 'numpy.object_'>`.
Note that this can alternatively be resolved by using the `==` operator (same value) instead of `is` (same reference).

```
>>> import numpy as np
>>> data = np.asarray(['text']).astype('object')
>>> data.dtype
dtype('O')
>>> data.dtype==np.object
True
>>> data.dtype==np.object_  
True
>>> data.dtype is np.object_
False
>>> data.dtype.type is np.object_
True
>>> np.object
<class 'object'>
>>> np.object_
<class 'numpy.object_'>
```

With this change I'm able to use the python backend for TYPE_STRING output.