### PR TITLE
Fix: ModelInstanceState name_ property should not set #2457

### DIFF
--- a/src/python.cc
+++ b/src/python.cc
@@ -130,8 +130,6 @@ class ModelInstanceState : public BackendModelInstance {
   std::string pymodule_path_;
   ModelState* model_state_;
   std::string domain_socket_;
-  TRITONBACKEND_ModelInstance* triton_model_instance_;
-  const std::string name_;
   bool connected_ = false;
 
  private:


### PR DESCRIPTION
fix https://github.com/triton-inference-server/server/issues/2457