### PR TITLE
Delete redundant source code

### DIFF
--- a/src/python.cc
+++ b/src/python.cc
@@ -1034,7 +1034,6 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
        std::to_string(TRITONBACKEND_API_VERSION_MINOR))
           .c_str());
 
-  TRITONBACKEND_ApiVersion(&api_version_major, &api_version_minor);
   if ((api_version_major != TRITONBACKEND_API_VERSION_MAJOR) ||
       (api_version_minor < TRITONBACKEND_API_VERSION_MINOR)) {
     return TRITONSERVER_ErrorNew(


### PR DESCRIPTION
Two varaibles `api_version_major` and `api_version_minor` are already initialized in line [1029](https://github.com/triton-inference-server/python_backend/blob/main/src/python.cc#L1029).