### PR TITLE
Add support for custom python environments

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -80,6 +80,15 @@ FetchContent_Declare(
 )
 FetchContent_MakeAvailable(pybind11)
 
+find_package(ZLIB REQUIRED)
+
+#
+# Boost
+#
+find_package(Boost REQUIRED COMPONENTS filesystem iostreams)
+message(STATUS "Using Boost ${Boost_VERSION}")
+include_directories(${Boost_INCLUDE_DIRS})
+
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
@@ -89,11 +98,13 @@ configure_file(src/libtriton_python.ldscript libtriton_python.ldscript COPYONLY)
 
 add_library(
   triton-python-backend SHARED
+  src/python.cc
   src/pb_utils.cc
   src/pb_utils.h
+  src/pb_env.cc
+  src/pb_env.h
   src/shm_manager.cc
   src/shm_manager.h
-  src/python.cc
 )
 
 add_executable(
@@ -136,6 +147,9 @@ target_link_libraries(
   PRIVATE
     triton-core-serverstub  # from repo-core
     triton-backend-utils    # from repo-backend
+    ZLIB::ZLIB
+    -larchive               # shared memory 
+    ${Boost_LIBRARIES}
 )
 
 target_link_libraries(
@@ -145,6 +159,7 @@ target_link_libraries(
    Threads::Threads
    pybind11::embed
    triton-backend-utils    # from repo-backend
+   -larchive               # libarchive
    -lrt                    # shared memory 
 )
 

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -81,12 +81,9 @@ FetchContent_Declare(
 FetchContent_MakeAvailable(pybind11)
 
 find_package(ZLIB REQUIRED)
-
-include_directories(${CMAKE_CURRENT_BINARY_DIR})
-
-find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
 find_package(Threads REQUIRED)
 
+include_directories(${CMAKE_CURRENT_BINARY_DIR})
 configure_file(src/libtriton_python.ldscript libtriton_python.ldscript COPYONLY)
 
 add_library(
@@ -108,7 +105,6 @@ add_executable(
   src/shm_manager.cc
   src/shm_manager.h
 )
-
 set_property(TARGET triton-python-backend-stub PROPERTY OUTPUT_NAME triton_python_backend_stub)
 
 add_library(
@@ -147,7 +143,6 @@ target_link_libraries(
 target_link_libraries(
   triton-python-backend-stub
   PRIVATE
-   Python3::Python
    Threads::Threads
    pybind11::embed
    triton-backend-utils    # from repo-backend

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,13 +82,6 @@ FetchContent_MakeAvailable(pybind11)
 
 find_package(ZLIB REQUIRED)
 
-#
-# Boost
-#
-find_package(Boost REQUIRED COMPONENTS filesystem iostreams)
-message(STATUS "Using Boost ${Boost_VERSION}")
-include_directories(${Boost_INCLUDE_DIRS})
-
 include_directories(${CMAKE_CURRENT_BINARY_DIR})
 
 find_package(Python3 COMPONENTS Interpreter Development REQUIRED)
@@ -149,7 +142,6 @@ target_link_libraries(
     triton-backend-utils    # from repo-backend
     ZLIB::ZLIB
     -larchive               # shared memory 
-    ${Boost_LIBRARIES}
 )
 
 target_link_libraries(

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -101,7 +101,7 @@ EnvironmentManager::EnvironmentManager()
 }
 
 std::string
-EnvironmentManager::ExtractIfNotExists(std::string env_path)
+EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
 {
   // Lock the mutex. Only a single thread should modify the map.
   std::lock_guard<std::mutex> lk(mutex_);

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -41,7 +41,6 @@
 
 namespace triton { namespace backend { namespace python {
 
-
 void
 RecursiveDirectoryDelete(const char* dir)
 {
@@ -102,7 +101,7 @@ EnvironmentManager::EnvironmentManager()
 }
 
 std::string
-EnvironmentManager::Extract(std::string env_path)
+EnvironmentManager::ExtractIfNotExists(std::string env_path)
 {
   // Lock the mutex. Only a single thread should modify the map.
   std::lock_guard<std::mutex> lk(mutex_);

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -119,10 +119,12 @@ EnvironmentManager::Extract(std::string env_path)
     std::string dst_env_path(
         std::string(base_path_) + "/" + std::to_string(env_map_.size()));
 
+    std::string canonical_env_path_str(canonical_env_path);
+
     int status =
         mkdir(dst_env_path.c_str(), S_IRWXU | S_IRWXG | S_IROTH | S_IXOTH);
     if (status == 0) {
-      ExtractTarFile(canonical_env_path, dst_env_path);
+      ExtractTarFile(canonical_env_path_str, dst_env_path);
     } else {
       throw PythonBackendException(
           std::string("Failed to create environment directory for '") +

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -94,11 +94,11 @@ EnvironmentManager::EnvironmentManager()
   strcpy(tmp_dir_template, "/tmp/python_env_XXXXXX");
 
   char* env_path = mkdtemp(tmp_dir_template);
-  if (tmp_dir_template == nullptr) {
+  if (env_path == nullptr) {
     throw PythonBackendException(
         "Failed to create temporary directory for Python environments.");
   }
-  strcpy(base_path_, env_path);
+  strcpy(base_path_, tmp_dir_template);
 }
 
 std::string

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -1,0 +1,90 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pb_env.h"
+
+#include <archive.h>
+#include <archive_entry.h>
+#include <boost/filesystem.hpp>
+#include <boost/iostreams/copy.hpp>
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/iostreams/filtering_streambuf.hpp>
+#include <cstdlib>
+#include <cstring>
+#include <iostream>
+#include "pb_utils.h"
+
+
+namespace triton { namespace backend { namespace python {
+
+EnvironmentManager::EnvironmentManager()
+{
+  char tmp_dir_template[PATH_MAX];
+  strcpy(tmp_dir_template, "/tmp/python_env_XXXXXX");
+
+  char* env_path = mkdtemp(tmp_dir_template);
+  if (tmp_dir_template == nullptr) {
+    throw PythonBackendException(
+        "Failed to create temporary directory for Python environments.");
+  }
+  strcpy(base_path_, env_path);
+}
+
+std::string
+EnvironmentManager::Extract(std::string env_path)
+{
+  std::lock_guard<std::mutex> lk(mutex_);
+  boost::filesystem::path canonical_env_path =
+      boost::filesystem::canonical(env_path);
+
+  // Extract only if the env has not been extracted yet.
+  if (env_map_.find(canonical_env_path.string()) == env_map_.end()) {
+    boost::filesystem::path dst_env_path(
+        std::string(base_path_) + "/" + std::to_string(env_map_.size()));
+
+    bool directory_created = boost::filesystem::create_directory(dst_env_path);
+    if (directory_created) {
+      ExtractTarFile(canonical_env_path.string(), dst_env_path.string());
+    } else {
+      throw PythonBackendException(
+          std::string("Failed to create environment directory for '") +
+          dst_env_path.c_str() + "'.");
+    }
+
+    // Add the path to the list of environments
+    env_map_.insert({canonical_env_path.string(), dst_env_path.string()});
+    return dst_env_path.string();
+  } else {
+    return env_map_.find(canonical_env_path.string())->second;
+  }
+}
+
+EnvironmentManager::~EnvironmentManager()
+{
+  boost::filesystem::remove_all(base_path_);
+}
+
+}}}  // namespace triton::backend::python

--- a/src/pb_env.h
+++ b/src/pb_env.h
@@ -45,7 +45,7 @@ class EnvironmentManager {
 
   // Extracts the tar.gz file in the 'env_path' if it has not been
   // already extracted.
-  std::string ExtractIfNotExists(std::string env_path);
+  std::string ExtractIfNotExtracted(std::string env_path);
   ~EnvironmentManager();
 };
 

--- a/src/pb_env.h
+++ b/src/pb_env.h
@@ -42,7 +42,10 @@ class EnvironmentManager {
 
  public:
   EnvironmentManager();
-  std::string Extract(std::string env_path);
+
+  // Extracts the tar.gz file in the 'env_path' if it has not been
+  // already extracted.
+  std::string ExtractIfNotExists(std::string env_path);
   ~EnvironmentManager();
 };
 

--- a/src/pb_env.h
+++ b/src/pb_env.h
@@ -1,0 +1,47 @@
+// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+#include <string>
+#include <map>
+#include <mutex>
+#include <boost/iostreams/filter/gzip.hpp>
+#include <boost/filesystem.hpp>
+
+namespace triton { namespace backend { namespace python {
+
+class EnvironmentManager {
+    std::map<std::string, std::string> env_map_;
+    char base_path_[PATH_MAX];
+    std::mutex mutex_;
+
+public:
+    EnvironmentManager();
+    std::string Extract(std::string env_path);
+    ~EnvironmentManager();
+};
+
+}}}

--- a/src/pb_env.h
+++ b/src/pb_env.h
@@ -25,23 +25,25 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
-#include <string>
+#include <climits>
 #include <map>
 #include <mutex>
-#include <boost/iostreams/filter/gzip.hpp>
-#include <boost/filesystem.hpp>
+#include <string>
 
 namespace triton { namespace backend { namespace python {
 
+//
+// A class that manages Python environments
+//
 class EnvironmentManager {
-    std::map<std::string, std::string> env_map_;
-    char base_path_[PATH_MAX];
-    std::mutex mutex_;
+  std::map<std::string, std::string> env_map_;
+  char base_path_[PATH_MAX + 1];
+  std::mutex mutex_;
 
-public:
-    EnvironmentManager();
-    std::string Extract(std::string env_path);
-    ~EnvironmentManager();
+ public:
+  EnvironmentManager();
+  std::string Extract(std::string env_path);
+  ~EnvironmentManager();
 };
 
-}}}
+}}}  // namespace triton::backend::python

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -551,7 +551,7 @@ class Stub {
     return 0;
   }
 
-  void Initialize(std::string& model_version, std::string python_stub_path)
+  void Initialize(std::string& model_version, std::string triton_install_path)
   {
     try {
       try {
@@ -563,8 +563,7 @@ class Stub {
             model_path_.substr(0, model_path_.find_last_of("/"));
         std::string model_path_parent_parent =
             model_path_parent.substr(0, model_path_parent.find_last_of("/"));
-        std::string python_backend_folder =
-            python_stub_path.substr(0, python_stub_path.find_last_of("/"));
+        std::string python_backend_folder = triton_install_path;
         sys.attr("path").attr("append")(model_path_parent);
         sys.attr("path").attr("append")(model_path_parent_parent);
         sys.attr("path").attr("append")(python_backend_folder);
@@ -630,8 +629,8 @@ extern "C" {
 int
 main(int argc, char** argv)
 {
-  if (argc < 5) {
-    LOG_INFO << "Expected 5 arguments, found " << argc << " arguments.";
+  if (argc < 7) {
+    LOG_INFO << "Expected 7 arguments, found " << argc << " arguments.";
     exit(1);
   }
   signal(SIGINT, SignalHandler);
@@ -662,6 +661,7 @@ main(int argc, char** argv)
   std::string model_version = model_path_tokens[model_path_tokens.size() - 2];
   int64_t shm_growth_size = std::stoi(argv[4]);
   pid_t parent_pid = std::stoi(argv[5]);
+  std::string triton_install_path = argv[6];
 
   std::unique_ptr<Stub> stub;
   try {
@@ -678,7 +678,7 @@ main(int argc, char** argv)
   // Start the Python Interpreter
   py::scoped_interpreter guard{};
 
-  stub->Initialize(model_version, argv[0] /* python stub path*/);
+  stub->Initialize(model_version, argv[6] /* triton install path */);
 
   bool background_thread_running = true;
   std::thread background_thread([&parent_pid, &background_thread_running,

--- a/src/pb_utils.cc
+++ b/src/pb_utils.cc
@@ -226,7 +226,7 @@ CopySingleArchiveEntry(archive* input_archive, archive* output_archive)
 }
 
 void
-ExtractTarFile(std::string archive_path, std::string dst_path)
+ExtractTarFile(std::string &archive_path, std::string &dst_path)
 {
   char current_directory[PATH_MAX];
   getcwd(current_directory, PATH_MAX);
@@ -285,6 +285,14 @@ ExtractTarFile(std::string archive_path, std::string dst_path)
 
   archive_write_close(output_archive);
   archive_write_free(output_archive);
+
+  // Revert the directory change.
+  chdir(current_directory);
+}
+
+bool FileExists(std::string &path) {
+  struct stat buffer;
+  return stat(path.c_str(), &buffer) == 0;
 }
 
 }}}  // namespace triton::backend::python

--- a/src/pb_utils.cc
+++ b/src/pb_utils.cc
@@ -226,7 +226,7 @@ CopySingleArchiveEntry(archive* input_archive, archive* output_archive)
 }
 
 void
-ExtractTarFile(std::string &archive_path, std::string &dst_path)
+ExtractTarFile(std::string& archive_path, std::string& dst_path)
 {
   char current_directory[PATH_MAX];
   getcwd(current_directory, PATH_MAX);
@@ -290,7 +290,9 @@ ExtractTarFile(std::string &archive_path, std::string &dst_path)
   chdir(current_directory);
 }
 
-bool FileExists(std::string &path) {
+bool
+FileExists(std::string& path)
+{
   struct stat buffer;
   return stat(path.c_str(), &buffer) == 0;
 }

--- a/src/pb_utils.cc
+++ b/src/pb_utils.cc
@@ -25,6 +25,9 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "pb_utils.h"
+
+#include <archive.h>
+#include <archive_entry.h>
 #include <errno.h>
 #include <fcntl.h>
 #include <pthread.h>
@@ -41,6 +44,15 @@
 #include "shm_manager.h"
 
 namespace triton { namespace backend { namespace python {
+
+#define THROW_IF_ERROR(MSG, X)           \
+  do {                                   \
+    int return__ = (X);                  \
+    if (return__ != 0) {                 \
+      throw PythonBackendException(MSG); \
+    }                                    \
+  } while (false)
+
 void
 CreateIPCMutex(pthread_mutex_t** mutex)
 {
@@ -178,6 +190,101 @@ SaveTensorToSharedMemory(
   for (size_t j = 0; j < dims_count; ++j) {
     tensor_dims[j] = dims[j];
   }
+}
+
+void
+CopySingleArchiveEntry(archive* input_archive, archive* output_archive)
+{
+  const void* buff;
+  size_t size;
+#if ARCHIVE_VERSION_NUMBER >= 3000000
+  int64_t offset;
+#else
+  off_t offset;
+#endif
+
+  for (;;) {
+    int return_status;
+    return_status =
+        archive_read_data_block(input_archive, &buff, &size, &offset);
+    if (return_status == ARCHIVE_EOF)
+      break;
+    if (return_status != ARCHIVE_OK)
+      throw PythonBackendException(
+          "archive_read_data_block() failed with error code = " +
+          std::to_string(return_status));
+
+    return_status =
+        archive_write_data_block(output_archive, buff, size, offset);
+    if (return_status != ARCHIVE_OK) {
+      throw PythonBackendException(
+          "archive_write_data_block() failed with error code = " +
+          std::to_string(return_status) + ", error message is " +
+          archive_error_string(output_archive));
+    }
+  }
+}
+
+void
+ExtractTarFile(std::string archive_path, std::string dst_path)
+{
+  char current_directory[PATH_MAX];
+  getcwd(current_directory, PATH_MAX);
+  chdir(dst_path.c_str());
+  struct archive_entry* entry;
+  int flags = ARCHIVE_EXTRACT_TIME;
+
+  struct archive* input_archive = archive_read_new();
+  struct archive* output_archive = archive_write_disk_new();
+  archive_write_disk_set_options(output_archive, flags);
+
+  archive_read_support_filter_gzip(input_archive);
+  archive_read_support_format_tar(input_archive);
+
+  if (archive_path.size() == 0) {
+    throw PythonBackendException("The archive path is empty.");
+  }
+
+  THROW_IF_ERROR(
+      "archive_read_open_filename() failed.",
+      archive_read_open_filename(
+          input_archive, archive_path.c_str(), 10240 /* block_size */));
+
+  while (true) {
+    int read_status = archive_read_next_header(input_archive, &entry);
+    if (read_status == ARCHIVE_EOF)
+      break;
+    if (read_status != ARCHIVE_OK) {
+      throw PythonBackendException(
+          std::string("archive_read_next_header() failed with error code = ") +
+          std::to_string(read_status) + std::string(" error message is ") +
+          archive_error_string(input_archive));
+    }
+
+    read_status = archive_write_header(output_archive, entry);
+    if (read_status != ARCHIVE_OK) {
+      throw PythonBackendException(std::string(
+          "archive_write_header() failed with error code = " +
+          std::to_string(read_status) + std::string(" error message is ") +
+          archive_error_string(output_archive)));
+    }
+
+    CopySingleArchiveEntry(input_archive, output_archive);
+
+    read_status = archive_write_finish_entry(output_archive);
+    if (read_status != ARCHIVE_OK) {
+      throw PythonBackendException(std::string(
+          "archive_write_finish_entry() failed with error code = " +
+          std::to_string(read_status) + std::string(" error message is ") +
+          archive_error_string(output_archive)));
+    }
+  }
+
+  archive_read_close(input_archive);
+  archive_read_free(input_archive);
+
+  archive_write_close(output_archive);
+  archive_write_free(output_archive);
 }
 
 }}}  // namespace triton::backend::python

--- a/src/pb_utils.cc
+++ b/src/pb_utils.cc
@@ -229,8 +229,15 @@ void
 ExtractTarFile(std::string& archive_path, std::string& dst_path)
 {
   char current_directory[PATH_MAX];
-  getcwd(current_directory, PATH_MAX);
-  chdir(dst_path.c_str());
+  if (getcwd(current_directory, PATH_MAX) == nullptr) {
+    throw PythonBackendException(
+        "Failed to get the current working directory.");
+  }
+  if (chdir(dst_path.c_str()) == 0) {
+    throw PythonBackendException(
+        (std::string("Failed to change the directory to ") + dst_path).c_str());
+  }
+
   struct archive_entry* entry;
   int flags = ARCHIVE_EXTRACT_TIME;
 
@@ -287,7 +294,11 @@ ExtractTarFile(std::string& archive_path, std::string& dst_path)
   archive_write_free(output_archive);
 
   // Revert the directory change.
-  chdir(current_directory);
+  if (chdir(current_directory) == 0) {
+    throw PythonBackendException(
+        (std::string("Failed to change the directory to ") + current_directory)
+            .c_str());
+  }
 }
 
 bool

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -31,6 +31,7 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
+#include <climits>
 #include <vector>
 #include "shm_manager.h"
 #include "triton/backend/backend_common.h"

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -198,6 +198,8 @@ void LoadTensorFromSharedMemory(
     std::unique_ptr<SharedMemory>& shm_pool, off_t tensor_shm_offset,
     Tensor& tensor);
 
-void ExtractTarFile(std::string archive_path, std::string dst_path);
+void ExtractTarFile(std::string &archive_path, std::string &dst_path);
+
+bool FileExists(std::string &path);
 
 }}}  // namespace triton::backend::python

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -149,13 +149,6 @@ struct Dict {
 };
 
 //
-// PythonBackendError
-//
-struct PythonBackendError {
-  std::string error_message;
-};
-
-//
 // PythonBackendException
 //
 // Exception thrown if error occurs in PythonBackend.

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <pthread.h>
+#include <exception>
 #include <memory>
 #include <string>
 #include <unordered_map>
@@ -37,30 +38,28 @@
 
 namespace triton { namespace backend { namespace python {
 
-#define STUB_SET_RESPONSE_ERROR_IF_ERROR(SHM_POOL, RESPONSE, R, X)        \
-  do {                                                                    \
-    try {                                                                 \
-      (X);                                                                \
-    }                                                                     \
-    catch (cont PythonBackendException & pb_exception) {                  \
-      off_t string_offset__;                                              \
-      try {                                                               \
-        SaveStringToSharedMemory(                                         \
-            SHM_POOL, string_offset__, pb_exception->err_.error_message); \
-        RESPONSE->has_error = true;                                       \
-        RESPONSE->error = string_offset__;                                \
-        if (R)                                                            \
-          return;                                                         \
-      }                                                                   \
-      catch (cont PythonBackendException & pb2_exception) {               \
-        printf(TRITONSERVER_ErrorMessage(                                 \
-            pb_exception->err_.error_message.c_str()));                   \
-        printf(                                                           \
-            TRITONSERVER_LOG_ERROR,                                       \
-            TRITONSERVER_ErrorMessage(                                    \
-                pb2_exception->err_.error_message.c_str()));              \
-      }                                                                   \
-    }                                                                     \
+#define STUB_SET_RESPONSE_ERROR_IF_ERROR(SHM_POOL, RESPONSE, R, X) \
+  do {                                                             \
+    try {                                                          \
+      (X);                                                         \
+    }                                                              \
+    catch (cont PythonBackendException & pb_exception) {           \
+      off_t string_offset__;                                       \
+      try {                                                        \
+        SaveStringToSharedMemory(                                  \
+            SHM_POOL, string_offset__, pb_exception.what());       \
+        RESPONSE->has_error = true;                                \
+        RESPONSE->error = string_offset__;                         \
+        if (R)                                                     \
+          return;                                                  \
+      }                                                            \
+      catch (cont PythonBackendException & pb2_exception) {        \
+        printf(TRITONSERVER_ErrorMessage(pb_exception.what()));    \
+        printf(                                                    \
+            TRITONSERVER_LOG_ERROR,                                \
+            TRITONSERVER_ErrorMessage(pb2_exception.what()));      \
+      }                                                            \
+    }                                                              \
     while (false)
 
 // Create a conditional variable.
@@ -160,12 +159,12 @@ struct PythonBackendError {
 //
 // Exception thrown if error occurs in PythonBackend.
 //
-struct PythonBackendException {
-  PythonBackendException(std::unique_ptr<PythonBackendError> err)
-      : err_(std::move(err))
-  {
-  }
-  std::unique_ptr<PythonBackendError> err_;
+struct PythonBackendException : std::exception {
+  PythonBackendException(std::string message) : message_(message) {}
+
+  const char* what() const throw() { return message_.c_str(); }
+
+  std::string message_;
 };
 
 void SaveMapToSharedMemory(
@@ -198,5 +197,7 @@ void SaveTensorToSharedMemory(
 void LoadTensorFromSharedMemory(
     std::unique_ptr<SharedMemory>& shm_pool, off_t tensor_shm_offset,
     Tensor& tensor);
+
+void ExtractTarFile(std::string archive_path, std::string dst_path);
 
 }}}  // namespace triton::backend::python

--- a/src/python.cc
+++ b/src/python.cc
@@ -802,6 +802,11 @@ ModelInstanceState::SetupChildProcess()
             .c_str());
   }
 
+  std::string python_execution_env = "none";
+  if (model_state->PythonExecutionEnv() != "") {
+    python_execution_env = model_state->StateForBackend()->env_manager->Extract(
+        model_state->PythonExecutionEnv());
+  }
   parent_pid_ = getpid();
   pthread_mutex_lock(parent_mutex_);
 
@@ -828,14 +833,11 @@ ModelInstanceState::SetupChildProcess()
 
     std::string bash_argument;
     bash_argument = ss.str();
-    std::string python_execution_env = "none";
     if (model_state->PythonExecutionEnv() != "") {
       ss.seekp(0);
-      python_execution_env =
-          model_state->StateForBackend()->env_manager->Extract(
-              model_state->PythonExecutionEnv());
       // TODO: Check if /bin/activate exits in the path
-      bash_argument = "source " + python_execution_env + "/bin/activate && " + bash_argument;
+      bash_argument = "source " + python_execution_env + "/bin/activate && " +
+                      bash_argument;
       std::cout << bash_argument << std::endl;
     }
 

--- a/src/python.cc
+++ b/src/python.cc
@@ -818,7 +818,7 @@ ModelInstanceState::SetupChildProcess()
   if (model_state->PythonExecutionEnv() != "") {
     try {
       python_execution_env =
-          model_state->StateForBackend()->env_manager->ExtractIfNotExists(
+          model_state->StateForBackend()->env_manager->ExtractIfNotExtracted(
               model_state->PythonExecutionEnv());
     }
     catch (PythonBackendException& pb_exception) {

--- a/src/python.cc
+++ b/src/python.cc
@@ -44,6 +44,7 @@
 #include <string>
 #include <thread>
 #include <vector>
+#include "pb_env.h"
 #include "pb_utils.h"
 #include "shm_manager.h"
 #include "triton/backend/backend_common.h"
@@ -66,17 +67,17 @@
     }                                                                  \
   } while (false)
 
-#define RESPOND_ALL_AND_RETURN_IF_EXCEPTION(RESPONSES, RESPONSES_COUNT, X)     \
-  do {                                                                         \
-    try {                                                                      \
-      (X);                                                                     \
-    }                                                                          \
-    catch (const PythonBackendException& exception) {                          \
-      TRITONSERVER_Error* raarie_err__ = TRITONSERVER_ErrorNew(                \
-          TRITONSERVER_ERROR_INTERNAL, exception.err_->error_message.c_str()); \
-      SendErrorForResponses(RESPONSES, RESPONSES_COUNT, raarie_err__);         \
-      return nullptr;                                                          \
-    }                                                                          \
+#define RESPOND_ALL_AND_RETURN_IF_EXCEPTION(RESPONSES, RESPONSES_COUNT, X) \
+  do {                                                                     \
+    try {                                                                  \
+      (X);                                                                 \
+    }                                                                      \
+    catch (const PythonBackendException& exception) {                      \
+      TRITONSERVER_Error* raarie_err__ = TRITONSERVER_ErrorNew(            \
+          TRITONSERVER_ERROR_INTERNAL, exception.what());                  \
+      SendErrorForResponses(RESPONSES, RESPONSES_COUNT, raarie_err__);     \
+      return nullptr;                                                      \
+    }                                                                      \
   } while (false)
 
 #define RESPOND_AND_RETURN_IF_ERROR(REQUEST, X)                         \
@@ -98,27 +99,27 @@
     }                                                                   \
   } while (false)
 
-#define RESPOND_AND_RETURN_IF_EXCEPTION(REQUEST, X)                            \
-  do {                                                                         \
-    try {                                                                      \
-      (X);                                                                     \
-    }                                                                          \
-    catch (const PythonBackendException& exception) {                          \
-      TRITONSERVER_Error* rarie_err__ = TRITONSERVER_ErrorNew(                 \
-          TRITONSERVER_ERROR_INTERNAL, exception.err_->error_message.c_str()); \
-      TRITONBACKEND_Response* rarie_response__ = nullptr;                      \
-      LOG_IF_ERROR(                                                            \
-          TRITONBACKEND_ResponseNew(&rarie_response__, REQUEST),               \
-          "failed to create response");                                        \
-      if (rarie_response__ != nullptr) {                                       \
-        LOG_IF_ERROR(                                                          \
-            TRITONBACKEND_ResponseSend(                                        \
-                rarie_response__, TRITONSERVER_RESPONSE_COMPLETE_FINAL,        \
-                rarie_err__),                                                  \
-            "failed to send error response");                                  \
-      }                                                                        \
-      return rarie_err__;                                                      \
-    }                                                                          \
+#define RESPOND_AND_RETURN_IF_EXCEPTION(REQUEST, X)                     \
+  do {                                                                  \
+    try {                                                               \
+      (X);                                                              \
+    }                                                                   \
+    catch (const PythonBackendException& exception) {                   \
+      TRITONSERVER_Error* rarie_err__ = TRITONSERVER_ErrorNew(          \
+          TRITONSERVER_ERROR_INTERNAL, exception.what());               \
+      TRITONBACKEND_Response* rarie_response__ = nullptr;               \
+      LOG_IF_ERROR(                                                     \
+          TRITONBACKEND_ResponseNew(&rarie_response__, REQUEST),        \
+          "failed to create response");                                 \
+      if (rarie_response__ != nullptr) {                                \
+        LOG_IF_ERROR(                                                   \
+            TRITONBACKEND_ResponseSend(                                 \
+                rarie_response__, TRITONSERVER_RESPONSE_COMPLETE_FINAL, \
+                rarie_err__),                                           \
+            "failed to send error response");                           \
+      }                                                                 \
+      return rarie_err__;                                               \
+    }                                                                   \
   } while (false)
 
 #define GUARDED_RESPOND_IF_ERROR(RESPONSES, IDX, X)                     \
@@ -145,8 +146,7 @@
       }                                                                 \
       catch (const PythonBackendException& pb_exception) {              \
         TRITONSERVER_Error* err__ = TRITONSERVER_ErrorNew(              \
-            TRITONSERVER_ERROR_INTERNAL,                                \
-            pb_exception.err_->error_message.c_str());                  \
+            TRITONSERVER_ERROR_INTERNAL, pb_exception.what());          \
         LOG_IF_ERROR(                                                   \
             TRITONBACKEND_ResponseSend(                                 \
                 (RESPONSES)[IDX], TRITONSERVER_RESPONSE_COMPLETE_FINAL, \
@@ -165,8 +165,7 @@
     }                                                          \
     catch (const PythonBackendException& pb_exception) {       \
       TRITONSERVER_Error* rarie_err__ = TRITONSERVER_ErrorNew( \
-          TRITONSERVER_ERROR_INTERNAL,                         \
-          pb_exception.err_->error_message.c_str());           \
+          TRITONSERVER_ERROR_INTERNAL, pb_exception.what());   \
       return rarie_err__;                                      \
     }                                                          \
   } while (false)
@@ -178,6 +177,7 @@ struct BackendState {
   int64_t shm_default_byte_size;
   int64_t shm_growth_byte_size;
   int64_t stub_timeout_seconds;
+  std::unique_ptr<EnvironmentManager> env_manager;
 };
 
 class ModelState : public BackendModel {
@@ -188,16 +188,20 @@ class ModelState : public BackendModel {
   // Get backend state
   BackendState* StateForBackend() { return backend_state_; }
 
+  // Get the Python execution environment
+  std::string PythonExecutionEnv() { return python_execution_env_; }
+
  private:
   ModelState(TRITONBACKEND_Model* triton_model);
   BackendState* backend_state_;
+  std::string python_execution_env_;
 };
 
 TRITONSERVER_Error*
 CreateTritonErrorFromException(const PythonBackendException& pb_exception)
 {
   return TRITONSERVER_ErrorNew(
-      TRITONSERVER_ERROR_INTERNAL, pb_exception.err_->error_message.c_str());
+      TRITONSERVER_ERROR_INTERNAL, pb_exception.what());
 }
 
 class ModelInstanceState : public BackendModelInstance {
@@ -810,19 +814,33 @@ ModelInstanceState::SetupChildProcess()
 
   // Child process
   if (pid == 0) {
-    const char* stub_args[7];
-    stub_args[6] = nullptr;  // Last argument must be nullptr
+    const char* stub_args[4];
+    stub_args[0] = "bash";
+    stub_args[1] = "-c";
+    stub_args[3] = nullptr;  // Last argument must be nullptr
+
     std::stringstream ss;
     ss << model_state->StateForBackend()->python_lib
        << "/triton_python_backend_stub";
     std::string stub_path = ss.str();
-    stub_args[0] = stub_path.c_str();
-    stub_args[1] = model_path_.c_str();
-    stub_args[2] = shm_region_name.c_str();
-    stub_args[3] = std::to_string(shm_default_size).c_str();
-    stub_args[4] = std::to_string(shm_growth_size).c_str();
-    stub_args[5] = std::to_string(parent_pid_).c_str();
-    if (execvp(stub_args[0], (char**)stub_args) == -1) {
+    ss << " " << model_path_ << " " << shm_region_name << " "
+       << shm_default_size << " " << shm_growth_size << " " << parent_pid_;
+
+    std::string bash_argument;
+    bash_argument = ss.str();
+    std::string python_execution_env = "none";
+    if (model_state->PythonExecutionEnv() != "") {
+      ss.seekp(0);
+      python_execution_env =
+          model_state->StateForBackend()->env_manager->Extract(
+              model_state->PythonExecutionEnv());
+      // TODO: Check if /bin/activate exits in the path
+      bash_argument = "source " + python_execution_env + "/bin/activate && " + bash_argument;
+      std::cout << bash_argument << std::endl;
+    }
+
+    stub_args[2] = bash_argument.c_str();
+    if (execvp("bash", (char**)stub_args) == -1) {
       std::stringstream ss;
       ss << "Failed to run python backend stub. Errno = " << errno << '\n'
          << "Python backend stub path: " << stub_path << '\n'
@@ -851,7 +869,7 @@ ModelInstanceState::SetupChildProcess()
     if (pthread_cond_timedwait(parent_cond_, parent_mutex_, &ts) != 0) {
       return TRITONSERVER_ErrorNew(
           TRITONSERVER_ERROR_INTERNAL,
-          (std::string("Timed out occured while waiting for the stub process. "
+          (std::string("Timed out occurred while waiting for the stub process. "
                        "Failed to initialize model instance ") +
            Name())
               .c_str());
@@ -1003,10 +1021,23 @@ ModelState::ModelState(TRITONBACKEND_Model* triton_model)
   TRITONBACKEND_ArtifactType artifact_type;
   THROW_IF_BACKEND_MODEL_ERROR(
       TRITONBACKEND_ModelRepository(triton_model, &artifact_type, &path));
+  python_execution_env_ = "";
 
   void* bstate;
   THROW_IF_BACKEND_MODEL_ERROR(TRITONBACKEND_BackendState(backend, &bstate));
   backend_state_ = reinterpret_cast<BackendState*>(bstate);
+  triton::common::TritonJson::Value params;
+  if (model_config_.Find("parameters", &params)) {
+    // Skip the EXECUTION_ENV_PATH variable if it doesn't exist.
+    TRITONSERVER_Error* error =
+        GetParameterValue(params, "EXECUTION_ENV_PATH", &python_execution_env_);
+    if (error == nullptr) {
+      LOG_MESSAGE(
+          TRITONSERVER_LOG_INFO,
+          (std::string("Using Python execution env ") + python_execution_env_)
+              .c_str());
+    }
+  }
 
   if (artifact_type != TRITONBACKEND_ARTIFACT_FILESYSTEM) {
     throw triton::backend::BackendModelException(TRITONSERVER_ErrorNew(
@@ -1145,6 +1176,7 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
   RETURN_IF_ERROR(
       TRITONBACKEND_BackendArtifacts(backend, &artifact_type, &location));
   backend_state->python_lib = location;
+  backend_state->env_manager = std::make_unique<EnvironmentManager>();
 
   RETURN_IF_ERROR(TRITONBACKEND_BackendSetState(
       backend, reinterpret_cast<void*>(backend_state.get())));

--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "shm_manager.h"
+
 #include <errno.h>
 #include <fcntl.h>
 #include <sys/mman.h>
@@ -56,9 +57,12 @@ SharedMemory::SharedMemory(
   int res = posix_fallocate(shm_fd_, 0, default_byte_size);
   if (res != 0) {
     std::string error_message =
-        ("unable to initialize shared-memory key '" + shm_key +
-         "' to requested size: " + std::to_string(default_byte_size) +
-         " bytes");
+        ("Unable to initialize shared memory key '" + shm_key +
+         "' to requested size (" + std::to_string(default_byte_size) +
+         " bytes). If you are running Triton inside docker, use '--shm-size' "
+         "flag to control the shared memory region size. Each Python backend "
+         "model instance requires at least 64MBs of shared memory. Flag "
+         "'--shm-size=5G' should be sufficient for common usecases.");
     throw PythonBackendException(std::move(error_message));
   }
 
@@ -131,7 +135,9 @@ SharedMemory::Map(char** shm_addr, size_t byte_size, off_t& offset)
       *capacity_ -= shm_bytes_added;
       std::string error_message =
           ("Failed to increase the shared memory pool size for key '" +
-           shm_key_ + "' to " + std::to_string(*capacity_) + " bytes.");
+           shm_key_ + "' to " + std::to_string(*capacity_) +
+           " bytes. If you are running Triton inside docker, use '--shm-size' "
+           "flag to control the shared memory region size.");
       throw PythonBackendException(error_message);
     }
   }

--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -46,36 +46,31 @@ SharedMemory::SharedMemory(
     shm_fd_ = shm_open(shm_key.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
   }
   if (shm_fd_ == -1) {
-    std::unique_ptr<PythonBackendError> err =
-        std::make_unique<PythonBackendError>();
-    err->error_message =
+
+      std::string error_message = 
         ("unable to get shared memory descriptor for shared-memory key '" +
          shm_key + "'");
-    throw PythonBackendException(std::move(err));
+    throw PythonBackendException(error_message);
   }
 
   shm_growth_bytes_ = shm_growth_bytes;
   int res = posix_fallocate(shm_fd_, 0, default_byte_size);
   if (res != 0) {
-    std::unique_ptr<PythonBackendError> err =
-        std::make_unique<PythonBackendError>();
-    err->error_message =
+    std::string error_message = 
         ("unable to initialize shared-memory key '" + shm_key +
          "' to requested size: " + std::to_string(default_byte_size) +
          " bytes");
-    throw PythonBackendException(std::move(err));
+    throw PythonBackendException(std::move(error_message));
   }
 
   void* map_addr = mmap(
       NULL, default_byte_size, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd_, 0);
 
   if (map_addr == MAP_FAILED) {
-    std::unique_ptr<PythonBackendError> err =
-        std::make_unique<PythonBackendError>();
-    err->error_message =
+    std::string error_message =
         ("unable to process address space or shared-memory descriptor: " +
          std::to_string(shm_fd_));
-    throw PythonBackendException(std::move(err));
+    throw PythonBackendException(error_message);
   }
   shm_addr_ = (char*)map_addr;
 
@@ -99,31 +94,24 @@ SharedMemory::~SharedMemory() noexcept(false)
   for (auto& pair : old_shm_addresses_) {
     int status = munmap(pair.second, pair.first);
     if (status == -1) {
-      std::unique_ptr<PythonBackendError> err =
-          std::make_unique<PythonBackendError>();
-      err->error_message = "unable to munmap shared memory region";
-      throw PythonBackendException(std::move(err));
+      std::string error_message = "unable to munmap shared memory region";
+      throw PythonBackendException(error_message);
     }
   }
 
   // Close fd
   if (close(shm_fd_) == -1) {
-    std::unique_ptr<PythonBackendError> err =
-        std::make_unique<PythonBackendError>();
-    err->error_message =
-        ("unable to close shared-memory descriptor: " +
+    std::string error_message = ("unable to close shared-memory descriptor: " +
          std::to_string(shm_fd_));
-    throw PythonBackendException(std::move(err));
+    throw PythonBackendException(error_message);
   }
 
   // Unlink shared memory
   int error = shm_unlink(shm_key_.c_str());
   if (error == -1) {
-    std::unique_ptr<PythonBackendError> err =
-        std::make_unique<PythonBackendError>();
-    err->error_message =
+    std::string error_message = 
         ("unable to unlink shared memory for key '" + shm_key_ + "'");
-    throw PythonBackendException(std::move(err));
+    throw PythonBackendException(error_message);
   }
 }
 
@@ -141,12 +129,10 @@ SharedMemory::Map(char** shm_addr, size_t byte_size, off_t& offset)
     if (posix_fallocate(shm_fd_, 0, *capacity_) != 0) {
       // Revert the capacity to the previous value
       *capacity_ -= shm_bytes_added;
-      std::unique_ptr<PythonBackendError> err =
-          std::make_unique<PythonBackendError>();
-      err->error_message =
+      std::string error_message = 
           ("Failed to increase the shared memory pool size for key '" +
            shm_key_ + "' to " + std::to_string(*capacity_) + " bytes.");
-      throw PythonBackendException(std::move(err));
+      throw PythonBackendException(error_message);
     }
   }
 
@@ -166,12 +152,10 @@ SharedMemory::UpdateSharedMemory()
         mmap(NULL, *capacity_, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd_, 0);
 
     if (map_addr == MAP_FAILED) {
-      std::unique_ptr<PythonBackendError> err =
-          std::make_unique<PythonBackendError>();
-      err->error_message =
+      std::string error_message = 
           ("unable to process address space or shared-memory descriptor: " +
            std::to_string(shm_fd_));
-      throw PythonBackendException(std::move(err));
+      throw PythonBackendException(error_message);
     }
 
     old_shm_addresses_.push_back({current_capacity_, shm_addr_});

--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -46,8 +46,7 @@ SharedMemory::SharedMemory(
     shm_fd_ = shm_open(shm_key.c_str(), O_RDWR | O_CREAT, S_IRUSR | S_IWUSR);
   }
   if (shm_fd_ == -1) {
-
-      std::string error_message = 
+    std::string error_message =
         ("unable to get shared memory descriptor for shared-memory key '" +
          shm_key + "'");
     throw PythonBackendException(error_message);
@@ -56,7 +55,7 @@ SharedMemory::SharedMemory(
   shm_growth_bytes_ = shm_growth_bytes;
   int res = posix_fallocate(shm_fd_, 0, default_byte_size);
   if (res != 0) {
-    std::string error_message = 
+    std::string error_message =
         ("unable to initialize shared-memory key '" + shm_key +
          "' to requested size: " + std::to_string(default_byte_size) +
          " bytes");
@@ -101,7 +100,8 @@ SharedMemory::~SharedMemory() noexcept(false)
 
   // Close fd
   if (close(shm_fd_) == -1) {
-    std::string error_message = ("unable to close shared-memory descriptor: " +
+    std::string error_message =
+        ("unable to close shared-memory descriptor: " +
          std::to_string(shm_fd_));
     throw PythonBackendException(error_message);
   }
@@ -109,7 +109,7 @@ SharedMemory::~SharedMemory() noexcept(false)
   // Unlink shared memory
   int error = shm_unlink(shm_key_.c_str());
   if (error == -1) {
-    std::string error_message = 
+    std::string error_message =
         ("unable to unlink shared memory for key '" + shm_key_ + "'");
     throw PythonBackendException(error_message);
   }
@@ -129,7 +129,7 @@ SharedMemory::Map(char** shm_addr, size_t byte_size, off_t& offset)
     if (posix_fallocate(shm_fd_, 0, *capacity_) != 0) {
       // Revert the capacity to the previous value
       *capacity_ -= shm_bytes_added;
-      std::string error_message = 
+      std::string error_message =
           ("Failed to increase the shared memory pool size for key '" +
            shm_key_ + "' to " + std::to_string(*capacity_) + " bytes.");
       throw PythonBackendException(error_message);
@@ -152,7 +152,7 @@ SharedMemory::UpdateSharedMemory()
         mmap(NULL, *capacity_, PROT_READ | PROT_WRITE, MAP_SHARED, shm_fd_, 0);
 
     if (map_addr == MAP_FAILED) {
-      std::string error_message = 
+      std::string error_message =
           ("unable to process address space or shared-memory descriptor: " +
            std::to_string(shm_fd_));
       throw PythonBackendException(error_message);


### PR DESCRIPTION
Directory structure of Python models using custom Python backend stubs:

```
.
├── python_3_6
│   ├── 1
│   │   ├── model.py
│   │   └── __pycache__
│   │       └── model.cpython-36.pyc
│   ├── config.pbtxt
│   └── triton_python_backend_stub
└── python_3_9
    ├── 1
    │   ├── model.py
    │   └── __pycache__
    │       └── model.cpython-39.pyc
    ├── config.pbtxt
    └── triton_python_backend_stub
```

An example model configuration:
```
name: "python_3_6"
backend: "python"

input [
  {
    name: "INPUT"
    data_type: TYPE_FP32
    dims: [ 1 ]
  }
]
output [
  {
    name: "OUTPUT"
    data_type: TYPE_FP32
    dims: [ 1 ]
  }
]

instance_group [{ kind: KIND_CPU }]
parameters: {key: "EXECUTION_ENV_PATH", value: {string_value: "/opt/tritonserver/qa/L0_backend_python/python3.6.tar.gz"}}
```