### PR TITLE
Add support for relative paths for execution envs

### DIFF
--- a/README.md
+++ b/README.md
@@ -421,6 +421,40 @@ parameters: {
 }
 ```
 
+It is also possible to provide the execution environment path relative to the
+model folder in model repository:
+
+```
+name: "model_a"
+backend: "python"
+
+...
+
+parameters: {
+  key: "EXECUTION_ENV_PATH",
+  value: {string_value: "$$TRITON_MODEL_DIRECTORY/python3.6.tar.gz"}
+}
+```
+
+In this case, `python3.tar.gz` should be placed in the model folder and the
+model repository should look like below:
+
+```
+models
+|-- model_a
+|   |-- 1
+|   |   `-- model.py
+|   |-- config.pbtxt
+|   |-- python3.6.tar.gz
+|   `-- triton_python_backend_stub
+```
+
+In the example above, `$$TRITON_MODEL_DIRECTORY` is resolved to `$pwd/models/model_a`.
+
+This is useful if you want to use S3, GCS, or Azure and you do not have access
+to the absolute path of the execution env that is stored in the cloud object
+storage service.
+
 ### Important Notes
 
 1. The version of the Python interpreter in the execution environment must match


### PR DESCRIPTION
Closes triton-inference-server/server#3097 and triton-inference-server/server#3227. `$$TRITON_MODEL_DIRECTORY` can be used for pointing to the model folder in model repository.