### PR TITLE
pb_utils.Tensor.from_dlpack() — correct signature in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -707,7 +707,7 @@ class TritonPythonModel:
 
     # Create a Python backend tensor from the DLPack encoding of a PyTorch
     # tensor.
-    input0 = pb_utils.Tensor.from_dlpack(to_dlpack(pytorch_tensor))
+    input0 = pb_utils.Tensor.from_dlpack("INPUT0", to_dlpack(pytorch_tensor))
 ```
 
 This method only supports contiguous Tensors that are in C-order. If the tensor


### PR DESCRIPTION
pb_utils.Tensor.from_dlpack()  is implemented in https://github.com/triton-inference-server/python_backend/blob/main/src/pb_tensor.h#L135 and takes the tensor name as its first argument.

However, in the README it is shown as taking only a PyCapsule, this results in errors like
```
from_dlpack(): incompatible function arguments.
```