### PR TITLE
Fix changing the stub execute permission

### DIFF
--- a/src/python.cc
+++ b/src/python.cc
@@ -1210,7 +1210,7 @@ ModelInstanceState::StartStubProcess()
     // If running stub process without any arguments returns any status code,
     // other than 1, it can indicate a permission issue as a result of
     // downloading the stub process from a cloud object storage service.
-    if (stub_status_code != 1) {
+    if (WEXITSTATUS(stub_status_code) != 1) {
       // Give the execute permission for the triton_python_backend_stub to the
       // owner.
       int error = chmod(python_backend_stub.c_str(), S_IXUSR);


### PR DESCRIPTION
Closes triton-inference-server/server#3608.