### PR TITLE
Fix background thread sleep

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -790,7 +790,7 @@ main(int argc, char** argv)
           // shared memory and will be set to false by the parent process.
           // The parent process expects that the stub process sets this
           // variable to true within 1 second.
-          sleep(0.3);
+          std::this_thread::sleep_for(std::chrono::milliseconds(300));
 
           stub->UpdateHealth();
 


### PR DESCRIPTION
I made a mistake and it looks like `sleep` function only accepts an unsigned int as the argument.

Closes https://github.com/triton-inference-server/server/issues/3779.

It should probably fix https://github.com/triton-inference-server/server/issues/3386 too.