### PR TITLE
Fix BLS support for sequence models

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -39,10 +39,12 @@ InferRequest::InferRequest(
     const std::string& request_id, uint64_t correlation_id,
     const std::vector<std::shared_ptr<PbTensor>>& inputs,
     const std::vector<std::string>& requested_output_names,
-    const std::string& model_name, const int64_t model_version)
+    const std::string& model_name, const int64_t model_version,
+    bool sequence_start, bool sequence_end)
     : request_id_(request_id), correlation_id_(correlation_id), inputs_(inputs),
       requested_output_names_(requested_output_names), model_name_(model_name),
-      model_version_(model_version)
+      model_version_(model_version), sequence_start_(sequence_start),
+      sequence_end_(sequence_end)
 {
 }
 
@@ -82,6 +84,18 @@ InferRequest::ModelVersion()
   return model_version_;
 }
 
+bool
+InferRequest::SequenceStart()
+{
+  return sequence_start_;
+}
+
+bool
+InferRequest::SequenceEnd()
+{
+  return sequence_end_;
+}
+
 void
 InferRequest::SaveToSharedMemory(
     std::unique_ptr<SharedMemory>& shm_pool, Request* request_shm)
@@ -97,6 +111,8 @@ InferRequest::SaveToSharedMemory(
       (char**)&requested_output_names,
       sizeof(off_t) * request_shm->requested_output_count,
       requested_output_names_offset);
+  request_shm->sequence_end = SequenceEnd();
+  request_shm->sequence_start = SequenceStart();
 
   request_shm->requested_output_names = requested_output_names_offset;
   size_t i = 0;
@@ -150,7 +166,8 @@ InferRequest::LoadFromSharedMemory(
   LoadStringFromSharedMemory(shm_pool, request->model_name, model_name);
   return std::make_unique<InferRequest>(
       id, request->correlation_id, std::move(py_input_tensors),
-      requested_output_names, model_name, request->model_version);
+      requested_output_names, model_name, request->model_version,
+      request->sequence_start, request->sequence_end);
 }
 
 #ifdef TRITON_PB_STUB

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -38,19 +38,24 @@ class InferRequest {
   std::vector<std::string> requested_output_names_;
   std::string model_name_;
   int64_t model_version_;
+  bool sequence_start_;
+  bool sequence_end_;
 
  public:
   InferRequest(
       const std::string& request_id, uint64_t correlation_id,
       const std::vector<std::shared_ptr<PbTensor>>& inputs,
       const std::vector<std::string>& requested_output_names,
-      const std::string& model_name, const int64_t model_version);
+      const std::string& model_name, const int64_t model_version,
+      bool sequence_start = false, bool sequence_end = false);
 
   const std::vector<std::shared_ptr<PbTensor>>& Inputs();
   const std::string& RequestId();
   uint64_t CorrelationId();
   const std::string& ModelName();
   int64_t ModelVersion();
+  bool SequenceStart();
+  bool SequenceEnd();
   const std::vector<std::string>& RequestedOutputNames();
 
   /// Save an Inference Request to shared memory.

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -38,8 +38,7 @@ class InferRequest {
   std::vector<std::string> requested_output_names_;
   std::string model_name_;
   int64_t model_version_;
-  bool sequence_start_;
-  bool sequence_end_;
+  uint32_t flags_;
 
  public:
   InferRequest(
@@ -47,15 +46,15 @@ class InferRequest {
       const std::vector<std::shared_ptr<PbTensor>>& inputs,
       const std::vector<std::string>& requested_output_names,
       const std::string& model_name, const int64_t model_version,
-      bool sequence_start = false, bool sequence_end = false);
+      const uint32_t flags = 0);
 
   const std::vector<std::shared_ptr<PbTensor>>& Inputs();
   const std::string& RequestId();
   uint64_t CorrelationId();
   const std::string& ModelName();
   int64_t ModelVersion();
-  bool SequenceStart();
-  bool SequenceEnd();
+  uint32_t Flags();
+  void SetFlags(uint32_t flags);
   const std::vector<std::string>& RequestedOutputNames();
 
   /// Save an Inference Request to shared memory.

--- a/src/pb_main_utils.cc
+++ b/src/pb_main_utils.cc
@@ -206,17 +206,8 @@ RequestExecutor::Infer(
     THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetCorrelationId(
         irequest, infer_request->CorrelationId()));
 
-    uint32_t flags = 0;
-    if (infer_request->SequenceStart()) {
-      flags |= TRITONSERVER_REQUEST_FLAG_SEQUENCE_START;
-    }
-
-    if (infer_request->SequenceEnd()) {
-      flags |= TRITONSERVER_REQUEST_FLAG_SEQUENCE_END;
-    }
-
-    THROW_IF_TRITON_ERROR(
-        TRITONSERVER_InferenceRequestSetFlags(irequest, flags));
+    THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetFlags(
+        irequest, infer_request->Flags()));
 
     THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetReleaseCallback(
         irequest, InferRequestComplete, nullptr /* request_release_userp */));

--- a/src/pb_main_utils.cc
+++ b/src/pb_main_utils.cc
@@ -203,6 +203,21 @@ RequestExecutor::Infer(
     THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetId(
         irequest, infer_request->RequestId().c_str()));
 
+    THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetCorrelationId(
+        irequest, infer_request->CorrelationId()));
+
+    uint32_t flags = 0;
+    if (infer_request->SequenceStart()) {
+      flags |= TRITONSERVER_REQUEST_FLAG_SEQUENCE_START;
+    }
+
+    if (infer_request->SequenceEnd()) {
+      flags |= TRITONSERVER_REQUEST_FLAG_SEQUENCE_END;
+    }
+
+    THROW_IF_TRITON_ERROR(
+        TRITONSERVER_InferenceRequestSetFlags(irequest, flags));
+
     THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetReleaseCallback(
         irequest, InferRequestComplete, nullptr /* request_release_userp */));
 
@@ -238,7 +253,6 @@ RequestExecutor::Infer(
       response = completed.get();
       *triton_response = response;
       delete_inference_request = false;
-
       THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceResponseError(response));
 
       uint32_t output_count;

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -698,15 +698,18 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
               const std::string&, uint64_t,
               const std::vector<std::shared_ptr<PbTensor>>&,
               const std::vector<std::string>&, const std::string&,
-              const int64_t>(),
+              const int64_t, bool, bool>(),
           py::arg("request_id") = "", py::arg("correlation_id") = 0,
           py::arg("inputs"), py::arg("requested_output_names"),
-          py::arg("model_name"), py::arg("model_version") = -1)
+          py::arg("model_name"), py::arg("model_version") = -1,
+          py::arg("sequence_start") = false, py::arg("sequence_end") = false)
       .def(
           "inputs", &InferRequest::Inputs,
           py::return_value_policy::reference_internal)
       .def("request_id", &InferRequest::RequestId)
       .def("correlation_id", &InferRequest::CorrelationId)
+      .def("sequence_start", &InferRequest::SequenceStart)
+      .def("sequence_end", &InferRequest::SequenceEnd)
       .def("exec", &InferRequest::Exec)
       .def(
           "async_exec",

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -698,18 +698,18 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
               const std::string&, uint64_t,
               const std::vector<std::shared_ptr<PbTensor>>&,
               const std::vector<std::string>&, const std::string&,
-              const int64_t, bool, bool>(),
+              const int64_t, const uint32_t>(),
           py::arg("request_id") = "", py::arg("correlation_id") = 0,
           py::arg("inputs"), py::arg("requested_output_names"),
           py::arg("model_name"), py::arg("model_version") = -1,
-          py::arg("sequence_start") = false, py::arg("sequence_end") = false)
+          py::arg("flags") = 0)
       .def(
           "inputs", &InferRequest::Inputs,
           py::return_value_policy::reference_internal)
       .def("request_id", &InferRequest::RequestId)
       .def("correlation_id", &InferRequest::CorrelationId)
-      .def("sequence_start", &InferRequest::SequenceStart)
-      .def("sequence_end", &InferRequest::SequenceEnd)
+      .def("flags", &InferRequest::Flags)
+      .def("set_flags", &InferRequest::SetFlags)
       .def("exec", &InferRequest::Exec)
       .def(
           "async_exec",

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -145,6 +145,8 @@ struct Request {
   uint32_t requested_output_count;
   off_t model_name;
   int64_t model_version;
+  bool sequence_start;
+  bool sequence_end;
 };
 
 struct Response {

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -145,8 +145,7 @@ struct Request {
   uint32_t requested_output_count;
   off_t model_name;
   int64_t model_version;
-  bool sequence_start;
-  bool sequence_end;
+  uint32_t flags;
 };
 
 struct Response {

--- a/src/python.cc
+++ b/src/python.cc
@@ -784,9 +784,13 @@ ModelInstanceState::ProcessRequests(
         responses, request_count,
         TRITONBACKEND_RequestCorrelationId(request, &correlation_id));
 
+    uint32_t flags;
+    RESPOND_ALL_AND_RETURN_IF_ERROR(
+        responses, request_count, TRITONBACKEND_RequestFlags(request, &flags));
+
     InferRequest infer_request(
         id, correlation_id, pb_input_tensors, requested_output_names,
-        model_state->Name(), model_state->Version());
+        model_state->Name(), model_state->Version(), flags);
     RESPOND_ALL_AND_RETURN_IF_EXCEPTION(
         responses, request_count,
         infer_request.SaveToSharedMemory(shm_pool_, python_infer_request));

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -273,3 +273,7 @@ def numpy_to_triton_type(data_type):
 
 def triton_string_to_numpy(triton_type_string):
     return TRITON_STRING_TO_NUMPY[triton_type_string]
+
+
+TRITONSERVER_REQUEST_FLAG_SEQUENCE_START = 1
+TRITONSERVER_REQUEST_FLAG_SEQUENCE_END = 2


### PR DESCRIPTION
Fix the support for sequence models in BLS. New `sequence_start` and `sequence_end` flags have been added to indicate the starting and ending of sequences in BLS requests. An example BLS request for sequence models:

```python
 infer_request = pb_utils.InferenceRequest(
            model_name='onnx_nobatch_sequence_int32',
            inputs=[input],
            requested_output_names=['OUTPUT'],
            sequence_start=True,
            sequence_end=False,
            correlation_id=correlation_id)
```

Testing in the server PR:

https://github.com/triton-inference-server/server/pull/3826

Closes https://github.com/triton-inference-server/server/issues/3770