### PR TITLE
Move the execute function to use the new interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,8 +131,14 @@ set(
   src/message_queue.h
   src/ipc_message.cc
   src/ipc_message.h
+  src/pb_string.cc
+  src/pb_string.h
+  src/pb_map.cc
+  src/pb_map.h
   src/pb_error.cc
   src/pb_error.h
+  src/pb_memory.cc
+  src/pb_memory.h
   src/pb_tensor.cc
   src/pb_tensor.h
   src/pb_utils.cc
@@ -148,8 +154,6 @@ set(
   src/pb_env.h
   src/pb_metric_reporter.cc
   src/pb_metric_reporter.h
-  src/request_executor.cc
-  src/request_executor.h
 )
 
 list(APPEND
@@ -164,10 +168,10 @@ add_library(
 
 set(
   PYTHNON_BACKEND_STUB_SRCS
-  src/pb_stub_utils.cc
   src/pb_stub_utils.h
-  src/pb_stub.cc
+  src/pb_stub_utils.cc
   src/pb_stub.h
+  src/pb_stub.cc
 )
 
 list(APPEND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ project(tritonpythonbackend LANGUAGES C CXX)
 #
 option(TRITON_ENABLE_GPU "Enable GPU support in backend" ON)
 option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
+option(TRITON_ENABLE_NVTX "Include nvtx markers collection in backend." OFF)
 
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
@@ -114,6 +115,10 @@ if(${TRITON_ENABLE_GPU})
 elseif()
   message(WARNING "TRITON_ENABLE_GPU is OFF, GPU Tensor support will be disabled")
 endif() # TRITON_ENABLE_GPU
+
+if(${TRITON_ENABLE_NVTX})
+  add_definitions(-DTRITON_ENABLE_NVTX=1)
+endif() # TRITON_ENABLE_NVTX
 
 find_package(ZLIB REQUIRED)
 find_package(Threads REQUIRED)

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -145,6 +145,7 @@ set(
   src/pb_utils.h
   src/shm_manager.cc
   src/shm_manager.h
+  src/pb_exception.h
 )
 
 set(

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -29,7 +29,6 @@
 
 #include "pb_utils.h"
 #ifdef TRITON_PB_STUB
-#include "infer_response.h"
 #include "pb_stub.h"
 #endif
 
@@ -96,204 +95,155 @@ InferRequest::SetFlags(uint32_t flags)
 }
 
 void
-InferRequest::SaveToSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, Request* request_shm)
+InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {
-  request_shm->correlation_id = this->CorrelationId();
-  off_t id_offset;
-  SaveStringToSharedMemory(shm_pool, id_offset, this->RequestId().c_str());
-  request_shm->id = id_offset;
-  request_shm->requested_output_count = this->RequestedOutputNames().size();
-  off_t requested_output_names_offset;
-  off_t* requested_output_names;
-  shm_pool->Map(
-      (char**)&requested_output_names,
-      sizeof(off_t) * request_shm->requested_output_count,
-      requested_output_names_offset);
-  request_shm->flags = Flags();
+  AllocatedSharedMemory<InferRequestShm> infer_request_shm =
+      shm_pool->Construct<InferRequestShm>();
 
-  request_shm->requested_output_names = requested_output_names_offset;
+  infer_request_shm.data_->correlation_id = CorrelationId();
+
+  std::unique_ptr<PbString> request_id_shm =
+      PbString::Create(shm_pool, RequestId());
+
+  infer_request_shm.data_->id = request_id_shm->ShmOffset();
+  infer_request_shm.data_->requested_output_count =
+      RequestedOutputNames().size();
+
+  AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
+      output_names_handle =
+          shm_pool->ConstructMany<bi::managed_external_buffer::handle_t>(
+              RequestedOutputNames().size());
+  infer_request_shm.data_->requested_output_names = output_names_handle.handle_;
+
   size_t i = 0;
+  std::vector<std::unique_ptr<PbString>> requested_output_names_shm(
+      RequestedOutputNames().size());
   for (auto& requested_output_name : requested_output_names_) {
-    SaveStringToSharedMemory(
-        shm_pool, requested_output_names[i], requested_output_name.c_str());
+    std::unique_ptr<PbString> requested_output_name_shm =
+        PbString::Create(shm_pool, requested_output_name);
+    (output_names_handle.data_.get())[i] =
+        requested_output_name_shm->ShmOffset();
+    requested_output_names_shm.emplace_back(
+        std::move(requested_output_name_shm));
     i++;
   }
 
-  request_shm->requested_input_count = this->Inputs().size();
-  request_shm->model_version = this->model_version_;
-  SaveStringToSharedMemory(
-      shm_pool, request_shm->model_name, this->model_name_.c_str());
+  infer_request_shm.data_->input_count = Inputs().size();
+  infer_request_shm.data_->model_version = model_version_;
+
+  std::unique_ptr<PbString> model_name_shm =
+      PbString::Create(shm_pool, ModelName());
+  infer_request_shm.data_->model_name = model_name_shm->ShmOffset();
+
+  AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
+      input_tensors_handle =
+          shm_pool->ConstructMany<bi::managed_external_buffer::handle_t>(
+              Inputs().size());
+
+  infer_request_shm.data_->inputs = input_tensors_handle.handle_;
+  i = 0;
+  for (auto& input : Inputs()) {
+    input->SaveToSharedMemory(shm_pool);
+    (input_tensors_handle.data_.get())[i] = input->ShmOffset();
+    i++;
+  }
+
+
+  // Save the references to shared memory.
+  infer_request_shm_ = std::move(infer_request_shm);
+  infer_request_shm_ptr_ = infer_request_shm.data_.get();
+  request_id_shm_ = std::move(request_id_shm);
+  output_names_handle_shm_ = std::move(output_names_handle);
+  requested_output_names_shm_ = std::move(requested_output_names_shm);
+  input_tensors_handle_ = std::move(input_tensors_handle);
+  input_tensors_handle_ptr_ = input_tensors_handle.data_.get();
 }
 
 std::unique_ptr<InferRequest>
 InferRequest::LoadFromSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, off_t request_offset,
-    std::shared_ptr<std::mutex>& cuda_ipc_open_mutex,
-    std::shared_ptr<std::mutex>& cuda_ipc_close_mutex)
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t request_offset)
 {
-  Request* request;
-  shm_pool->MapOffset((char**)&request, request_offset);
+  AllocatedSharedMemory<InferRequestShm> infer_request_shm =
+      shm_pool->Load<InferRequestShm>(request_offset);
+  std::unique_ptr<PbString> request_id_shm =
+      PbString::LoadFromSharedMemory(shm_pool, infer_request_shm.data_->id);
 
-  char* id = nullptr;
-  LoadStringFromSharedMemory(shm_pool, request->id, id);
+  AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
+      input_tensors_handle =
+          shm_pool->Load<bi::managed_external_buffer::handle_t>(
+              infer_request_shm.data_->inputs);
 
-  uint32_t requested_input_count = request->requested_input_count;
+  AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
+      output_names_handle =
+          shm_pool->Load<bi::managed_external_buffer::handle_t>(
+              infer_request_shm.data_->requested_output_names);
 
-  std::vector<std::shared_ptr<PbTensor>> py_input_tensors;
-  for (size_t input_idx = 0; input_idx < requested_input_count; ++input_idx) {
-    std::shared_ptr<PbTensor> pb_input_tensor = PbTensor::LoadFromSharedMemory(
-        shm_pool, request->inputs + sizeof(Tensor) * input_idx,
-        cuda_ipc_open_mutex, cuda_ipc_close_mutex);
-    py_input_tensors.emplace_back(std::move(pb_input_tensor));
-  }
-
-  std::vector<std::string> requested_output_names;
-  uint32_t requested_output_count = request->requested_output_count;
-  off_t* output_names;
-  shm_pool->MapOffset((char**)&output_names, request->requested_output_names);
+  std::vector<std::unique_ptr<PbString>> requested_output_names_shm;
+  uint32_t requested_output_count =
+      infer_request_shm.data_->requested_output_count;
 
   for (size_t output_idx = 0; output_idx < requested_output_count;
        ++output_idx) {
-    char* output_name = nullptr;
-    LoadStringFromSharedMemory(shm_pool, output_names[output_idx], output_name);
-    requested_output_names.emplace_back(output_name);
+    std::unique_ptr<PbString> pb_string = PbString::LoadFromSharedMemory(
+        shm_pool, (output_names_handle.data_.get())[output_idx]);
+    requested_output_names_shm.emplace_back(std::move(pb_string));
   }
 
-  char* model_name;
-  LoadStringFromSharedMemory(shm_pool, request->model_name, model_name);
-  return std::make_unique<InferRequest>(
-      id, request->correlation_id, std::move(py_input_tensors),
-      requested_output_names, model_name, request->model_version,
-      request->flags);
+  std::vector<std::shared_ptr<PbTensor>> input_tensors;
+  for (size_t input_idx = 0; input_idx < infer_request_shm.data_->input_count;
+       ++input_idx) {
+    std::shared_ptr<PbTensor> input_tensor = PbTensor::LoadFromSharedMemory(
+        shm_pool, (input_tensors_handle.data_.get())[input_idx]);
+    input_tensors.emplace_back(std::move(input_tensor));
+  }
+
+  std::unique_ptr<PbString> model_name_shm = PbString::LoadFromSharedMemory(
+      shm_pool, infer_request_shm.data_->model_name);
+
+  return std::unique_ptr<InferRequest>(new InferRequest(
+      infer_request_shm, request_id_shm, requested_output_names_shm,
+      model_name_shm, output_names_handle, input_tensors_handle,
+      input_tensors));
 }
 
-#ifdef TRITON_PB_STUB
-std::unique_ptr<InferResponse>
-InferRequest::Exec()
+InferRequest::InferRequest(
+    AllocatedSharedMemory<InferRequestShm>& infer_request_shm,
+    std::unique_ptr<PbString>& request_id_shm,
+    std::vector<std::unique_ptr<PbString>>& requested_output_names_shm,
+    std::unique_ptr<PbString>& model_name_shm,
+    AllocatedSharedMemory<bi::managed_external_buffer::handle_t>&
+        output_names_handle_shm,
+    AllocatedSharedMemory<bi::managed_external_buffer::handle_t>&
+        input_tensors_handle,
+    std::vector<std::shared_ptr<PbTensor>>& input_tensors)
+    : infer_request_shm_(std::move(infer_request_shm)),
+      request_id_shm_(std::move(request_id_shm)),
+      requested_output_names_shm_(std::move(requested_output_names_shm)),
+      model_name_shm_(std::move(model_name_shm)),
+      output_names_handle_shm_(std::move(output_names_handle_shm)),
+      input_tensors_handle_(std::move(input_tensors_handle))
+
 {
-  ResponseBatch* response_batch = nullptr;
-  bool responses_is_set = false;
-  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
-  std::unique_ptr<SharedMemory>& shm_pool = stub->GetSharedMemory();
+  infer_request_shm_ptr_ = infer_request_shm_.data_.get();
+  output_names_handle_shm_ptr_ = output_names_handle_shm_.data_.get();
+  input_tensors_handle_ptr_ = input_tensors_handle_.data_.get();
+  inputs_ = std::move(input_tensors);
 
-  try {
-    py::gil_scoped_release release;
-    std::unique_ptr<IPCMessage> ipc_message =
-        std::make_unique<IPCMessage>(shm_pool, true /* inline_response */);
-    bool has_exception = false;
-    PythonBackendException pb_exception(std::string{});
-
-    ipc_message->Command() =
-        PYTHONSTUB_CommandType::PYTHONSTUB_InferExecRequest;
-
-    RequestBatch* request_batch;
-    shm_pool->Map(
-        (char**)&request_batch, sizeof(RequestBatch), ipc_message->Args());
-    request_batch->batch_size = 1;
-
-    Request* request;
-    shm_pool->Map((char**)&request, sizeof(Request), request_batch->requests);
-
-    request->requested_input_count = this->Inputs().size();
-    Tensor* tensors;
-    bool has_gpu_tensor = false;
-    shm_pool->Map(
-        (char**)&tensors, sizeof(Tensor) * request->requested_input_count,
-        request->inputs);
-
-    size_t i = 0;
-    for (auto& input_tensor : inputs_) {
-      input_tensor->SaveToSharedMemory(
-          shm_pool, &tensors[i], true /* copy_cpu */, false /* copy_gpu */);
-      if (!input_tensor->IsCPU()) {
-        has_gpu_tensor = true;
-      }
-      ++i;
-    }
-
-    SaveToSharedMemory(shm_pool, request);
-    {
-      bi::scoped_lock<bi::interprocess_mutex> lock{
-          *(ipc_message->ResponseMutex())};
-      stub->SendIPCMessage(ipc_message);
-      ipc_message->ResponseCondition()->wait(lock);
-    }
-
-    if (has_gpu_tensor) {
-      try {
-        for (auto& input_tensor : this->Inputs()) {
-          if (!input_tensor->IsCPU()) {
-#ifdef TRITON_ENABLE_GPU
-            input_tensor->SetCudaIpcMutexes(
-                stub->CudaIpcOpenMutex(), stub->CudaIpcCloseMutex());
-            input_tensor->LoadGPUData(shm_pool);
-#endif  // TRITON_ENABLE_GPU
-          }
-        }
-      }
-      catch (const PythonBackendException& exception) {
-        // We need to catch the exception here. Otherwise, we will not notify
-        // the main process and it will wait for the resposne forever.
-        pb_exception = exception;
-        has_exception = true;
-      }
-
-      {
-        bi::scoped_lock<bi::interprocess_mutex> lock{
-            *(ipc_message->ResponseMutex())};
-        ipc_message->ResponseCondition()->notify_all();
-        ipc_message->ResponseCondition()->wait(lock);
-      }
-    }
-
-    // The exception will be thrown after the message was sent to the main
-    // process.
-    if (has_exception) {
-      throw pb_exception;
-    }
-
-    // Get the response for the current message.
-    std::unique_ptr<IPCMessage> bls_response = IPCMessage::LoadFromSharedMemory(
-        shm_pool, ipc_message->RequestOffset());
-    shm_pool->MapOffset((char**)&response_batch, bls_response->Args());
-    responses_is_set = true;
-
-    if (response_batch->has_error) {
-      if (response_batch->is_error_set) {
-        char* err_string;
-        LoadStringFromSharedMemory(shm_pool, response_batch->error, err_string);
-        return std::make_unique<InferResponse>(
-            std::vector<std::shared_ptr<PbTensor>>{},
-            std::make_shared<PbError>(err_string));
-      } else {
-        return std::make_unique<InferResponse>(
-            std::vector<std::shared_ptr<PbTensor>>{},
-            std::make_shared<PbError>(
-                "An error occurred while performing BLS request."));
-      }
-    }
-  }
-  catch (const PythonBackendException& pb_exception) {
-    return std::make_unique<InferResponse>(
-        std::vector<std::shared_ptr<PbTensor>>{},
-        std::make_shared<PbError>(pb_exception.what()));
+  std::vector<std::string> requested_output_names;
+  for (size_t output_idx = 0;
+       output_idx < infer_request_shm_ptr_->requested_output_count;
+       ++output_idx) {
+    auto& pb_string = requested_output_names_shm[output_idx];
+    requested_output_names.emplace_back(pb_string->String());
   }
 
-  if (responses_is_set) {
-    std::unique_ptr<InferResponse> infer_response =
-        InferResponse::LoadFromSharedMemory(
-            shm_pool, response_batch->responses, stub->CudaIpcOpenMutex(),
-            stub->CudaIpcCloseMutex());
-
-    return infer_response;
-  } else {
-    return std::make_unique<InferResponse>(
-        std::vector<std::shared_ptr<PbTensor>>{},
-        std::make_shared<PbError>(
-            "An error occurred while performing BLS request."));
-  }
+  request_id_ = request_id_shm_->String();
+  requested_output_names_ = std::move(requested_output_names);
+  model_name_ = model_name_shm_->String();
+  flags_ = infer_request_shm_ptr_->flags;
+  model_version_ = infer_request_shm_ptr_->model_version;
+  correlation_id_ = infer_request_shm_ptr_->correlation_id;
 }
 
-#endif
 }}}  // namespace triton::backend::python

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -135,7 +135,7 @@ InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 
   AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
       output_names_handle =
-          shm_pool->ConstructMany<bi::managed_external_buffer::handle_t>(
+          shm_pool->Construct<bi::managed_external_buffer::handle_t>(
               RequestedOutputNames().size());
   infer_request_shm.data_->requested_output_names = output_names_handle.handle_;
 
@@ -160,7 +160,7 @@ InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 
   AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
       input_tensors_handle =
-          shm_pool->ConstructMany<bi::managed_external_buffer::handle_t>(
+          shm_pool->Construct<bi::managed_external_buffer::handle_t>(
               Inputs().size());
 
   infer_request_shm.data_->inputs = input_tensors_handle.handle_;

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -101,24 +101,6 @@ InferRequest::ShmHandle()
 }
 
 void
-InferRequest::Release()
-{
-  infer_request_shm_.data_.release();
-  request_id_shm_->Release();
-  for (auto& requested_output_shm : requested_output_names_shm_) {
-    requested_output_shm->Release();
-  }
-
-  for (auto& input : inputs_) {
-    input->Release();
-  }
-
-  model_name_shm_->Release();
-  output_names_handle_shm_.data_.release();
-  input_tensors_handle_.data_.release();
-}
-
-void
 InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {
   AllocatedSharedMemory<InferRequestShm> infer_request_shm =

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -66,6 +66,7 @@ class InferRequest {
   uint32_t Flags();
   void SetFlags(uint32_t flags);
   const std::vector<std::string>& RequestedOutputNames();
+  void Release();
 
   /// Save an Inference Request to shared memory.
   /// \param shm_pool Shared memory pool to save the inference request.

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -78,6 +78,9 @@ class InferRequest {
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       bi::managed_external_buffer::handle_t request_offset);
 
+  /// Disallow copying the inference request object.
+  DISALLOW_COPY_AND_ASSIGN(InferRequest);
+
  private:
   InferRequest(
       AllocatedSharedMemory<InferRequestShm>& infer_request_shm,

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -67,6 +67,7 @@ class InferRequest {
   void SetFlags(uint32_t flags);
   const std::vector<std::string>& RequestedOutputNames();
   void Release();
+  bi::managed_external_buffer::handle_t ShmOffset();
 
   /// Save an Inference Request to shared memory.
   /// \param shm_pool Shared memory pool to save the inference request.
@@ -115,5 +116,6 @@ class InferRequest {
   AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
       input_tensors_handle_;
   bi::managed_external_buffer::handle_t* input_tensors_handle_ptr_;
+  bi::managed_external_buffer::handle_t shm_offset_;
 };
 }}};  // namespace triton::backend::python

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -35,16 +35,9 @@ namespace triton { namespace backend { namespace python {
 // Inference Request
 //
 struct InferRequestShm {
-  // Handle for the id field.
-  bi::managed_external_buffer::handle_t id;
   uint64_t correlation_id;
-  // Handle for input field.
-  bi::managed_external_buffer::handle_t inputs;
   uint32_t input_count;
-  // Handle for the requested output names
-  bi::managed_external_buffer::handle_t requested_output_names;
   uint32_t requested_output_count;
-  bi::managed_external_buffer::handle_t model_name;
   int64_t model_version;
   uint32_t flags;
 };
@@ -82,16 +75,14 @@ class InferRequest {
   /// Disallow copying the inference request object.
   DISALLOW_COPY_AND_ASSIGN(InferRequest);
 
+  ~InferRequest() {}
+
  private:
   InferRequest(
-      AllocatedSharedMemory<InferRequestShm>& infer_request_shm,
+      AllocatedSharedMemory<char>& infer_request_shm,
       std::unique_ptr<PbString>& request_id_shm,
       std::vector<std::unique_ptr<PbString>>& requested_output_names_shm,
       std::unique_ptr<PbString>& model_name_shm,
-      AllocatedSharedMemory<bi::managed_external_buffer::handle_t>&
-          output_names_handle_shm,
-      AllocatedSharedMemory<bi::managed_external_buffer::handle_t>&
-          input_tensors_handle,
       std::vector<std::shared_ptr<PbTensor>>& input_tensors);
 
   std::string request_id_;
@@ -103,17 +94,13 @@ class InferRequest {
   uint32_t flags_;
 
   // Shared Memory Data Structures
-  AllocatedSharedMemory<InferRequestShm> infer_request_shm_;
+  AllocatedSharedMemory<char> infer_request_shm_;
   InferRequestShm* infer_request_shm_ptr_;
 
   std::unique_ptr<PbString> request_id_shm_;
   std::vector<std::unique_ptr<PbString>> requested_output_names_shm_;
   std::unique_ptr<PbString> model_name_shm_;
-  AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
-      output_names_handle_shm_;
   bi::managed_external_buffer::handle_t* output_names_handle_shm_ptr_;
-  AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
-      input_tensors_handle_;
   bi::managed_external_buffer::handle_t* input_tensors_handle_ptr_;
   bi::managed_external_buffer::handle_t shm_handle_;
 };

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -66,7 +66,6 @@ class InferRequest {
   uint32_t Flags();
   void SetFlags(uint32_t flags);
   const std::vector<std::string>& RequestedOutputNames();
-  void Release();
   bi::managed_external_buffer::handle_t ShmHandle();
 
   /// Save an Inference Request to shared memory.

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -35,13 +35,13 @@ namespace triton { namespace backend { namespace python {
 // Inference Request
 //
 struct InferRequestShm {
-  // Offset for the id field.
+  // Handle for the id field.
   bi::managed_external_buffer::handle_t id;
   uint64_t correlation_id;
-  // Offset for input field.
+  // Handle for input field.
   bi::managed_external_buffer::handle_t inputs;
   uint32_t input_count;
-  // Offset for the requested output names
+  // Handle for the requested output names
   bi::managed_external_buffer::handle_t requested_output_names;
   uint32_t requested_output_count;
   bi::managed_external_buffer::handle_t model_name;
@@ -67,7 +67,7 @@ class InferRequest {
   void SetFlags(uint32_t flags);
   const std::vector<std::string>& RequestedOutputNames();
   void Release();
-  bi::managed_external_buffer::handle_t ShmOffset();
+  bi::managed_external_buffer::handle_t ShmHandle();
 
   /// Save an Inference Request to shared memory.
   /// \param shm_pool Shared memory pool to save the inference request.
@@ -75,10 +75,10 @@ class InferRequest {
 
   /// Create an Inference Request object from shared memory.
   /// \param shm_pool Shared memory pool
-  /// \param request_offset Shared memory offset of the request.
+  /// \param request_handle Shared memory handle of the request.
   static std::unique_ptr<InferRequest> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t request_offset);
+      bi::managed_external_buffer::handle_t request_handle);
 
   /// Disallow copying the inference request object.
   DISALLOW_COPY_AND_ASSIGN(InferRequest);
@@ -116,6 +116,6 @@ class InferRequest {
   AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
       input_tensors_handle_;
   bi::managed_external_buffer::handle_t* input_tensors_handle_ptr_;
-  bi::managed_external_buffer::handle_t shm_offset_;
+  bi::managed_external_buffer::handle_t shm_handle_;
 };
 }}};  // namespace triton::backend::python

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -73,7 +73,7 @@ InferResponse::SaveToSharedMemory(
     response_shm_.data_->outputs_size = 0;
   } else {
     tensor_offset_shm_ =
-        shm_pool->ConstructMany<bi::managed_external_buffer::handle_t>(
+        shm_pool->Construct<bi::managed_external_buffer::handle_t>(
             output_tensor_length);
     response_shm_.data_->outputs = tensor_offset_shm_.handle_;
     response_shm_.data_->outputs_size = output_tensor_length;
@@ -128,7 +128,8 @@ InferResponse::LoadFromSharedMemory(
         PbError::LoadFromSharedMemory(shm_pool, response_shm.data_->error);
   } else if (
       response_shm.data_->has_error && !response_shm.data_->is_error_set) {
-    pb_error = std::make_shared<PbError>("");
+    pb_error =
+        std::make_shared<PbError>("Failed to retrieve the response error.");
   } else {
     tensor_offset_shm = shm_pool->Load<bi::managed_external_buffer::handle_t>(
         response_shm.data_->outputs);

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -86,6 +86,12 @@ InferResponse::SaveToSharedMemory(
   }
 }
 
+bi::managed_external_buffer::handle_t
+InferResponse::ShmOffset()
+{
+  return shm_offset_;
+}
+
 std::unique_ptr<InferResponse>
 InferResponse::LoadFromSharedMemory(
     std::unique_ptr<SharedMemoryManager>& shm_pool,

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -87,21 +87,6 @@ InferResponse::SaveToSharedMemory(
   }
 }
 
-void
-InferResponse::Release()
-{
-  response_shm_.data_.release();
-  if (error_ != nullptr) {
-    error_->Release();
-  }
-
-  for (auto& output_tensor : output_tensors_) {
-    output_tensor->Release();
-  }
-
-  tensor_handle_shm_.data_.release();
-}
-
 bi::managed_external_buffer::handle_t
 InferResponse::ShmHandle()
 {

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -55,6 +55,7 @@ class InferResponse {
   bool HasError();
   std::shared_ptr<PbError>& Error();
   bi::managed_external_buffer::handle_t ShmOffset();
+  void Release();
 
   // Disallow copying the inference response object.
   DISALLOW_COPY_AND_ASSIGN(InferResponse);

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -54,6 +54,7 @@ class InferResponse {
       bi::managed_external_buffer::handle_t response_offset);
   bool HasError();
   std::shared_ptr<PbError>& Error();
+  bi::managed_external_buffer::handle_t ShmOffset();
 
   // Disallow copying the inference response object.
   DISALLOW_COPY_AND_ASSIGN(InferResponse);

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -31,30 +31,45 @@
 #include "pb_utils.h"
 
 namespace triton { namespace backend { namespace python {
-class InferResponse {
-  std::vector<std::shared_ptr<PbTensor>> output_tensors_;
-  std::shared_ptr<PbError> error_;
-  bool is_message_set_ = false;
 
+struct ResponseShm {
+  // Offset for Tensor output.
+  bi::managed_external_buffer::handle_t outputs;
+  uint32_t outputs_size;
+  bi::managed_external_buffer::handle_t error;
+  bool has_error;
+  // Indicates whether this error has a message or not.
+  bool is_error_set;
+};
+
+class InferResponse {
  public:
   InferResponse(
       const std::vector<std::shared_ptr<PbTensor>>& output_tensors,
       std::shared_ptr<PbError> error = nullptr);
-  InferResponse(const std::vector<std::shared_ptr<PbTensor>>& output_tensors);
-  bool IsErrorMessageSet();
   std::vector<std::shared_ptr<PbTensor>>& OutputTensors();
-  void SaveToSharedMemory(
-      std::unique_ptr<SharedMemory>& shm_pool, Response* response_shm,
-      bool copy_cpu, bool copy_gpu);
+  void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
   static std::unique_ptr<InferResponse> LoadFromSharedMemory(
-      std::unique_ptr<SharedMemory>& shm_pool, off_t response_offset,
-      std::shared_ptr<std::mutex>& cuda_ipc_open_mutex,
-      std::shared_ptr<std::mutex>& cuda_ipc_close_mutex);
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      bi::managed_external_buffer::handle_t response_offset);
   bool HasError();
   std::shared_ptr<PbError>& Error();
 
-  // Copying inference response objects is not allowed.
-  InferResponse(const InferResponse& other) = delete;
-  InferResponse& operator=(const InferResponse& other) = delete;
+  // Disallow copying the inference response object.
+  DISALLOW_COPY_AND_ASSIGN(InferResponse);
+
+ private:
+  InferResponse(
+      AllocatedSharedMemory<ResponseShm>& response_shm,
+      std::vector<std::shared_ptr<PbTensor>>& output_tensors,
+      std::shared_ptr<PbError>& pb_error,
+      AllocatedSharedMemory<bi::managed_external_buffer::handle_t>&
+          tensor_offset_shm);
+  std::vector<std::shared_ptr<PbTensor>> output_tensors_;
+  std::shared_ptr<PbError> error_;
+  bi::managed_external_buffer::handle_t shm_offset_;
+  AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
+      tensor_offset_shm_;
+  AllocatedSharedMemory<ResponseShm> response_shm_;
 };
 }}}  // namespace triton::backend::python

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -55,7 +55,6 @@ class InferResponse {
   bool HasError();
   std::shared_ptr<PbError>& Error();
   bi::managed_external_buffer::handle_t ShmHandle();
-  void Release();
 
   // Disallow copying the inference response object.
   DISALLOW_COPY_AND_ASSIGN(InferResponse);

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -33,8 +33,6 @@
 namespace triton { namespace backend { namespace python {
 
 struct ResponseShm {
-  // Handle for Tensor output.
-  bi::managed_external_buffer::handle_t outputs;
   uint32_t outputs_size;
   bi::managed_external_buffer::handle_t error;
   bool has_error;
@@ -61,16 +59,12 @@ class InferResponse {
 
  private:
   InferResponse(
-      AllocatedSharedMemory<ResponseShm>& response_shm,
+      AllocatedSharedMemory<char>& response_shm,
       std::vector<std::shared_ptr<PbTensor>>& output_tensors,
-      std::shared_ptr<PbError>& pb_error,
-      AllocatedSharedMemory<bi::managed_external_buffer::handle_t>&
-          tensor_handle_shm);
+      std::shared_ptr<PbError>& pb_error);
   std::vector<std::shared_ptr<PbTensor>> output_tensors_;
   std::shared_ptr<PbError> error_;
   bi::managed_external_buffer::handle_t shm_handle_;
-  AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
-      tensor_handle_shm_;
-  AllocatedSharedMemory<ResponseShm> response_shm_;
+  AllocatedSharedMemory<char> response_shm_;
 };
 }}}  // namespace triton::backend::python

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -33,7 +33,7 @@
 namespace triton { namespace backend { namespace python {
 
 struct ResponseShm {
-  // Offset for Tensor output.
+  // Handle for Tensor output.
   bi::managed_external_buffer::handle_t outputs;
   uint32_t outputs_size;
   bi::managed_external_buffer::handle_t error;
@@ -51,10 +51,10 @@ class InferResponse {
   void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
   static std::unique_ptr<InferResponse> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t response_offset);
+      bi::managed_external_buffer::handle_t response_handle);
   bool HasError();
   std::shared_ptr<PbError>& Error();
-  bi::managed_external_buffer::handle_t ShmOffset();
+  bi::managed_external_buffer::handle_t ShmHandle();
   void Release();
 
   // Disallow copying the inference response object.
@@ -66,12 +66,12 @@ class InferResponse {
       std::vector<std::shared_ptr<PbTensor>>& output_tensors,
       std::shared_ptr<PbError>& pb_error,
       AllocatedSharedMemory<bi::managed_external_buffer::handle_t>&
-          tensor_offset_shm);
+          tensor_handle_shm);
   std::vector<std::shared_ptr<PbTensor>> output_tensors_;
   std::shared_ptr<PbError> error_;
-  bi::managed_external_buffer::handle_t shm_offset_;
+  bi::managed_external_buffer::handle_t shm_handle_;
   AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
-      tensor_offset_shm_;
+      tensor_handle_shm_;
   AllocatedSharedMemory<ResponseShm> response_shm_;
 };
 }}}  // namespace triton::backend::python

--- a/src/ipc_message.cc
+++ b/src/ipc_message.cc
@@ -40,10 +40,11 @@ IPCMessage::Create(
   AllocatedSharedMemory<bi::interprocess_mutex> response_mutex_shm;
   AllocatedSharedMemory<bi::interprocess_condition> response_cond_shm;
   if (inline_response) {
-    response_mutex_shm =
-        std::move(shm_pool->ConstructAligned<bi::interprocess_mutex>());
+    response_mutex_shm = std::move(shm_pool->Construct<bi::interprocess_mutex>(
+        1 /* count */, true /* aligned */));
     response_cond_shm =
-        std::move(shm_pool->ConstructAligned<bi::interprocess_condition>());
+        std::move(shm_pool->Construct<bi::interprocess_condition>(
+            1 /* count */, true /* aligned */));
 
     ipc_message_shm.data_->response_mutex = response_mutex_shm.handle_;
     ipc_message_shm.data_->response_cond = response_cond_shm.handle_;

--- a/src/ipc_message.cc
+++ b/src/ipc_message.cc
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -57,10 +57,10 @@ IPCMessage::Create(
 std::unique_ptr<IPCMessage>
 IPCMessage::LoadFromSharedMemory(
     std::unique_ptr<SharedMemoryManager>& shm_pool,
-    bi::managed_external_buffer::handle_t message_offset)
+    bi::managed_external_buffer::handle_t message_handle)
 {
   AllocatedSharedMemory<IPCMessageShm> ipc_message_shm =
-      shm_pool->Load<IPCMessageShm>(message_offset);
+      shm_pool->Load<IPCMessageShm>(message_handle);
 
   AllocatedSharedMemory<bi::interprocess_mutex> response_mutex_shm;
   AllocatedSharedMemory<bi::interprocess_condition> response_cond_shm;
@@ -106,13 +106,13 @@ IPCMessage::ResponseMutex()
 }
 
 bi::managed_external_buffer::handle_t&
-IPCMessage::ResponseOffset()
+IPCMessage::ResponseHandle()
 {
-  return ipc_message_shm_ptr_->response_offset;
+  return ipc_message_shm_ptr_->response_handle;
 }
 
 bi::managed_external_buffer::handle_t
-IPCMessage::ShmOffset()
+IPCMessage::ShmHandle()
 {
   return ipc_message_handle_;
 }

--- a/src/ipc_message.h
+++ b/src/ipc_message.h
@@ -51,16 +51,20 @@ typedef enum PYTHONSTUB_commandtype_enum {
 /// Shared memory representation of IPCMessage
 ///
 /// \param command determines the IPC command that is going to be passed.
-/// \param args determines the shared memory offset for the input parameters.
-/// \param is_response determines whether this is a response of another IPC
-/// message. If this parameter is set, it must provide the offset of the
-/// corresponding request in \param response_offset.
-/// \param response_offset determines the request offset.
+/// \param args determines the shared memory handle for the input parameters.
+/// \param inline_response determines whether this is a response of another IPC
+/// message. If this parameter is set, it must provide the handle of the
+/// corresponding request in \param response_handle.
+/// \param response_handle determines the request handle.
+/// \param response_mutex stores the handle for the mutex for the response
+/// object.
+/// \param response_cond stores the handle for the condition variable
+/// for the response object.
 struct IPCMessageShm {
   PYTHONSTUB_CommandType command;
   bi::managed_external_buffer::handle_t args;
   bool inline_response = false;
-  bi::managed_external_buffer::handle_t response_offset;
+  bi::managed_external_buffer::handle_t response_handle;
   bi::managed_external_buffer::handle_t response_mutex;
   bi::managed_external_buffer::handle_t response_cond;
 };
@@ -72,15 +76,15 @@ class IPCMessage {
       bool inline_response);
   static std::unique_ptr<IPCMessage> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t message_offset);
+      bi::managed_external_buffer::handle_t message_handle);
 
   PYTHONSTUB_CommandType& Command();
   bool& InlineResponse();
-  bi::managed_external_buffer::handle_t& ResponseOffset();
+  bi::managed_external_buffer::handle_t& ResponseHandle();
   bi::interprocess_condition* ResponseCondition();
   bi::interprocess_mutex* ResponseMutex();
   bi::managed_external_buffer::handle_t& Args();
-  bi::managed_external_buffer::handle_t ShmOffset();
+  bi::managed_external_buffer::handle_t ShmHandle();
   void Release();
 
  private:

--- a/src/message_queue.cc
+++ b/src/message_queue.cc
@@ -41,7 +41,7 @@ MessageQueue::Create(
   mq_shm.data_->size = message_queue_size;
 
   AllocatedSharedMemory<bi::managed_external_buffer::handle_t> mq_buffer_shm =
-      shm_pool->ConstructMany<bi::managed_external_buffer::handle_t>(
+      shm_pool->Construct<bi::managed_external_buffer::handle_t>(
           message_queue_size);
   mq_shm.data_->buffer = mq_buffer_shm.handle_;
   mq_shm.data_->index = 0;

--- a/src/message_queue.cc
+++ b/src/message_queue.cc
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -198,10 +198,10 @@ MessageQueue::ResetSemaphores()
 std::unique_ptr<MessageQueue>
 MessageQueue::LoadFromSharedMemory(
     std::unique_ptr<SharedMemoryManager>& shm_pool,
-    bi::managed_external_buffer::handle_t message_queue_offset)
+    bi::managed_external_buffer::handle_t message_queue_handle)
 {
   AllocatedSharedMemory<MessageQueueShm> mq_shm =
-      shm_pool->Load<MessageQueueShm>(message_queue_offset);
+      shm_pool->Load<MessageQueueShm>(message_queue_handle);
   AllocatedSharedMemory<bi::managed_external_buffer::handle_t> mq_shm_buffer =
       shm_pool->Load<bi::managed_external_buffer::handle_t>(
           mq_shm.data_->buffer);
@@ -210,7 +210,7 @@ MessageQueue::LoadFromSharedMemory(
 }
 
 bi::managed_external_buffer::handle_t
-MessageQueue::ShmOffset()
+MessageQueue::ShmHandle()
 {
   return mq_handle_;
 }

--- a/src/message_queue.h
+++ b/src/message_queue.h
@@ -45,7 +45,8 @@ struct MessageQueueShm {
   std::size_t size;
   bi::managed_external_buffer::handle_t buffer;
   bi::interprocess_mutex mutex;
-  int index;
+  int head;
+  int tail;
   bi::interprocess_semaphore sem_empty{0};
   bi::interprocess_semaphore sem_full{0};
 };
@@ -90,7 +91,8 @@ class MessageQueue {
   std::size_t& Size() { return mq_shm_ptr_->size; }
   const bi::interprocess_mutex& Mutex() { return mq_shm_ptr_->mutex; }
   bi::interprocess_mutex* MutexMutable() { return &(mq_shm_ptr_->mutex); }
-  int& Index() { return mq_shm_ptr_->index; }
+  int& Head() { return mq_shm_ptr_->head; }
+  int& Tail() { return mq_shm_ptr_->tail; }
   bi::managed_external_buffer::handle_t* Buffer() { return mq_buffer_shm_ptr_; }
   const bi::interprocess_semaphore& SemEmpty()
   {

--- a/src/message_queue.h
+++ b/src/message_queue.h
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -37,7 +37,7 @@ namespace bi = boost::interprocess;
 /// Struct holding the represenation of a message stack inside the shared
 /// memory.
 /// \param size Total size of the message stack.
-/// \param mutex Offset of the mutex variable protecting index.
+/// \param mutex Handle of the mutex variable protecting index.
 /// \param index Used element index.
 /// \param sem_empty Semaphore object counting the number of empty buffer slots.
 /// \param sem_full Semaphore object counting the number of used buffer slots.
@@ -61,10 +61,10 @@ class MessageQueue {
   /// Load an already existing message queue from the shared memory.
   static std::unique_ptr<MessageQueue> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t message_queue_offset);
+      bi::managed_external_buffer::handle_t message_queue_handle);
 
   /// Push a message inside the message queue.
-  /// \param message The shared memory offset of the message.
+  /// \param message The shared memory handle of the message.
   void Push(bi::managed_external_buffer::handle_t message);
   void Push(
       bi::managed_external_buffer::handle_t message, int const& duration,
@@ -72,7 +72,7 @@ class MessageQueue {
 
   /// Pop a message from the message queue. This call will block until there
   /// is a message inside the message queue to return.
-  /// \return the offset of the new message.
+  /// \return the handle of the new message.
   bi::managed_external_buffer::handle_t Pop();
   bi::managed_external_buffer::handle_t Pop(int const& duration, bool& success);
 
@@ -81,8 +81,8 @@ class MessageQueue {
   /// to be restarted so that the message queue is in a proper state.
   void ResetSemaphores();
 
-  /// Get the shared memory offset of MessageQueue
-  bi::managed_external_buffer::handle_t ShmOffset();
+  /// Get the shared memory handle of MessageQueue
+  bi::managed_external_buffer::handle_t ShmHandle();
 
   /// Release the ownership of this object in shared memory.
   void Release();

--- a/src/message_queue.h
+++ b/src/message_queue.h
@@ -108,6 +108,9 @@ class MessageQueue {
     return &(mq_shm_ptr_->sem_full);
   }
 
+  void HeadIncrement();
+  void TailIncrement();
+
   AllocatedSharedMemory<MessageQueueShm> mq_shm_;
   AllocatedSharedMemory<bi::managed_external_buffer::handle_t> mq_buffer_shm_;
 

--- a/src/message_queue.h
+++ b/src/message_queue.h
@@ -34,9 +34,9 @@
 namespace triton { namespace backend { namespace python {
 namespace bi = boost::interprocess;
 
-/// Struct holding the represenation of a message stack inside the shared
+/// Struct holding the represenation of a message queue inside the shared
 /// memory.
-/// \param size Total size of the message stack.
+/// \param size Total size of the message queue.
 /// \param mutex Handle of the mutex variable protecting index.
 /// \param index Used element index.
 /// \param sem_empty Semaphore object counting the number of empty buffer slots.

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/pb_env.h
+++ b/src/pb_env.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -35,7 +35,6 @@ namespace triton { namespace backend { namespace python {
 void ExtractTarFile(std::string& archive_path, std::string& dst_path);
 
 bool FileExists(std::string& path);
-
 
 //
 // A class that manages Python environments

--- a/src/pb_error.cc
+++ b/src/pb_error.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -31,5 +31,33 @@ const std::string&
 PbError::Message()
 {
   return message_;
+}
+
+bi::managed_external_buffer::handle_t
+PbError::ShmOffset()
+{
+  return shm_handle_;
+}
+
+void
+PbError::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
+{
+  message_shm_ = PbString::Create(shm_pool, message_);
+  shm_handle_ = message_shm_->ShmOffset();
+}
+
+std::unique_ptr<PbError>
+PbError::LoadFromSharedMemory(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t shm_offset)
+{
+  std::unique_ptr<PbString> message_shm =
+      PbString::LoadFromSharedMemory(shm_pool, shm_offset);
+  return std::unique_ptr<PbError>(new PbError(message_shm));
+}
+
+PbError::PbError(std::unique_ptr<PbString>& message_shm)
+{
+  message_shm_ = std::move(message_shm);
 }
 }}}  // namespace triton::backend::python

--- a/src/pb_error.cc
+++ b/src/pb_error.cc
@@ -40,20 +40,26 @@ PbError::ShmOffset()
 }
 
 void
+PbError::Release()
+{
+  message_shm_->Release();
+}
+
+void
 PbError::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {
   message_shm_ = PbString::Create(shm_pool, message_);
   shm_handle_ = message_shm_->ShmOffset();
 }
 
-std::unique_ptr<PbError>
+std::shared_ptr<PbError>
 PbError::LoadFromSharedMemory(
     std::unique_ptr<SharedMemoryManager>& shm_pool,
     bi::managed_external_buffer::handle_t shm_offset)
 {
   std::unique_ptr<PbString> message_shm =
       PbString::LoadFromSharedMemory(shm_pool, shm_offset);
-  return std::unique_ptr<PbError>(new PbError(message_shm));
+  return std::shared_ptr<PbError>(new PbError(message_shm));
 }
 
 PbError::PbError(std::unique_ptr<PbString>& message_shm)

--- a/src/pb_error.cc
+++ b/src/pb_error.cc
@@ -40,12 +40,6 @@ PbError::ShmHandle()
 }
 
 void
-PbError::Release()
-{
-  message_shm_->Release();
-}
-
-void
 PbError::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {
   message_shm_ = PbString::Create(shm_pool, message_);

--- a/src/pb_error.cc
+++ b/src/pb_error.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -34,7 +34,7 @@ PbError::Message()
 }
 
 bi::managed_external_buffer::handle_t
-PbError::ShmOffset()
+PbError::ShmHandle()
 {
   return shm_handle_;
 }
@@ -49,16 +49,16 @@ void
 PbError::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {
   message_shm_ = PbString::Create(shm_pool, message_);
-  shm_handle_ = message_shm_->ShmOffset();
+  shm_handle_ = message_shm_->ShmHandle();
 }
 
 std::shared_ptr<PbError>
 PbError::LoadFromSharedMemory(
     std::unique_ptr<SharedMemoryManager>& shm_pool,
-    bi::managed_external_buffer::handle_t shm_offset)
+    bi::managed_external_buffer::handle_t shm_handle)
 {
   std::unique_ptr<PbString> message_shm =
-      PbString::LoadFromSharedMemory(shm_pool, shm_offset);
+      PbString::LoadFromSharedMemory(shm_pool, shm_handle);
   return std::shared_ptr<PbError>(new PbError(message_shm));
 }
 

--- a/src/pb_error.h
+++ b/src/pb_error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -27,13 +27,25 @@
 #pragma once
 
 #include <string>
+#include "pb_string.h"
+#include "pb_utils.h"
 
 namespace triton { namespace backend { namespace python {
 class PbError {
-  std::string message_;
-
  public:
   PbError(const std::string& message) : message_(message) {}
   const std::string& Message();
+  void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
+  bi::managed_external_buffer::handle_t ShmOffset();
+  static std::unique_ptr<PbError> LoadFromSharedMemory(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      bi::managed_external_buffer::handle_t handle);
+  DISALLOW_COPY_AND_ASSIGN(PbError);
+
+ private:
+  PbError(std::unique_ptr<PbString>& pb_error);
+  std::string message_;
+  std::unique_ptr<PbString> message_shm_;
+  bi::managed_external_buffer::handle_t shm_handle_;
 };
 }}};  // namespace triton::backend::python

--- a/src/pb_error.h
+++ b/src/pb_error.h
@@ -37,15 +37,16 @@ class PbError {
   const std::string& Message();
   void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
   bi::managed_external_buffer::handle_t ShmOffset();
-  static std::unique_ptr<PbError> LoadFromSharedMemory(
+  static std::shared_ptr<PbError> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       bi::managed_external_buffer::handle_t handle);
+  void Release();
   DISALLOW_COPY_AND_ASSIGN(PbError);
 
  private:
   PbError(std::unique_ptr<PbString>& pb_error);
   std::string message_;
-  std::unique_ptr<PbString> message_shm_;
+  std::shared_ptr<PbString> message_shm_;
   bi::managed_external_buffer::handle_t shm_handle_;
 };
 }}};  // namespace triton::backend::python

--- a/src/pb_error.h
+++ b/src/pb_error.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -36,7 +36,7 @@ class PbError {
   PbError(const std::string& message) : message_(message) {}
   const std::string& Message();
   void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
-  bi::managed_external_buffer::handle_t ShmOffset();
+  bi::managed_external_buffer::handle_t ShmHandle();
   static std::shared_ptr<PbError> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       bi::managed_external_buffer::handle_t handle);

--- a/src/pb_error.h
+++ b/src/pb_error.h
@@ -40,7 +40,6 @@ class PbError {
   static std::shared_ptr<PbError> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       bi::managed_external_buffer::handle_t handle);
-  void Release();
   DISALLOW_COPY_AND_ASSIGN(PbError);
 
  private:

--- a/src/pb_exception.h
+++ b/src/pb_exception.h
@@ -1,0 +1,46 @@
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <exception>
+
+namespace triton { namespace backend { namespace python {
+
+//
+// PythonBackendException
+//
+// Exception thrown if error occurs in PythonBackend.
+//
+struct PythonBackendException : std::exception {
+  PythonBackendException(const std::string& message) : message_(message) {}
+
+  const char* what() const throw() { return message_.c_str(); }
+
+  std::string message_;
+};
+
+}}}  // namespace triton::backend::python

--- a/src/pb_map.cc
+++ b/src/pb_map.cc
@@ -25,7 +25,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "pb_map.h"
-#include "pb_string.h"
 
 namespace triton { namespace backend { namespace python {
 

--- a/src/pb_map.cc
+++ b/src/pb_map.cc
@@ -38,7 +38,7 @@ PbMap::Create(
   dict_shm.data_->length = map.size();
 
   AllocatedSharedMemory<PairShm> pair_shms =
-      shm_pool->ConstructMany<PairShm>(map.size());
+      shm_pool->Construct<PairShm>(map.size());
   dict_shm.data_->values = pair_shms.handle_;
 
   size_t i = 0;

--- a/src/pb_map.cc
+++ b/src/pb_map.cc
@@ -96,22 +96,6 @@ PbMap::LoadFromSharedMemory(
       new PbMap(pb_strings, dict_shm, pair_shms, map));
 }
 
-void
-PbMap::Release()
-{
-  for (auto& string : strings_) {
-    string->Release();
-  }
-
-  if (dict_shm_.data_ != nullptr) {
-    dict_shm_.data_.release();
-  }
-
-  if (pair_shms_.data_ != nullptr) {
-    pair_shms_.data_.release();
-  }
-}
-
 PbMap::PbMap(
     std::vector<std::unique_ptr<PbString>>& strings,
     AllocatedSharedMemory<DictShm>& dict_shm,

--- a/src/pb_map.cc
+++ b/src/pb_map.cc
@@ -46,8 +46,8 @@ PbMap::Create(
     auto key = PbString::Create(shm_pool, pair.first);
     auto value = PbString::Create(shm_pool, pair.second);
 
-    (pair_shms.data_.get())[i].key = key->ShmOffset();
-    (pair_shms.data_.get())[i].value = value->ShmOffset();
+    (pair_shms.data_.get())[i].key = key->ShmHandle();
+    (pair_shms.data_.get())[i].value = value->ShmHandle();
 
     strings.emplace_back(std::move(key));
     strings.emplace_back(std::move(value));
@@ -64,7 +64,7 @@ PbMap::UnorderedMap()
 }
 
 bi::managed_external_buffer::handle_t
-PbMap::ShmOffset()
+PbMap::ShmHandle()
 {
   return dict_handle_;
 }

--- a/src/pb_map.h
+++ b/src/pb_map.h
@@ -52,7 +52,6 @@ class PbMap {
       bi::managed_external_buffer::handle_t handle);
   const std::unordered_map<std::string, std::string>& UnorderedMap();
   bi::managed_external_buffer::handle_t ShmHandle();
-  void Release();
 
  private:
   PbMap(

--- a/src/pb_map.h
+++ b/src/pb_map.h
@@ -51,7 +51,7 @@ class PbMap {
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       bi::managed_external_buffer::handle_t handle);
   const std::unordered_map<std::string, std::string>& UnorderedMap();
-  bi::managed_external_buffer::handle_t ShmOffset();
+  bi::managed_external_buffer::handle_t ShmHandle();
   void Release();
 
  private:

--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -120,6 +120,15 @@ PbMemory::PbMemory(
       memory_data_shm_(std::move(memory_data_shm)), data_ptr_(data),
       opened_cuda_ipc_handle_(opened_cuda_ipc_handle)
 {
+  memory_shm_ptr_ = memory_shm_.data_.get();
+  memory_data_shm_ptr_ = memory_data_shm_.data_.get();
+  memory_shm_handle_ = memory_shm_.handle_;
+}
+
+bi::managed_external_buffer::handle_t
+PbMemory::ShmOffset()
+{
+  return memory_shm_handle_;
 }
 
 void

--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -1,0 +1,154 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pb_memory.h"
+
+namespace triton { namespace backend { namespace python {
+
+std::unique_ptr<PbMemory>
+PbMemory::Create(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+    uint64_t byte_size, char* data)
+{
+  AllocatedSharedMemory<MemoryShm> memory_shm =
+      shm_pool->Construct<MemoryShm>();
+
+  AllocatedSharedMemory<char> memory_data_shm;
+  if (memory_type == TRITONSERVER_MEMORY_GPU) {
+#ifdef TRITON_ENABLE_GPU
+    memory_data_shm = shm_pool->ConstructMany<char>(sizeof(cudaIpcMemHandle_t));
+    if (data != nullptr) {
+      THROW_IF_CUDA_ERROR(cudaSetDevice(memory_type_id));
+      THROW_IF_CUDA_ERROR(cudaIpcGetMemHandle(
+          reinterpret_cast<cudaIpcMemHandle_t*>(memory_data_shm.data_.get()),
+          data));
+    }
+  }
+#endif
+  else {
+    memory_data_shm = shm_pool->ConstructMany<char>(byte_size);
+    if (data != nullptr) {
+      std::copy(data, data + byte_size, memory_data_shm.data_.get());
+      data = memory_data_shm.data_.get();
+    }
+  }
+
+  memory_shm.data_->byte_size = byte_size;
+  memory_shm.data_->memory_ptr = memory_data_shm.handle_;
+  memory_shm.data_->memory_type_id = memory_type_id;
+  memory_shm.data_->memory_type = memory_type;
+
+  std::unique_ptr<PbMemory> pb_memory(new PbMemory(
+      memory_shm, memory_data_shm, data, false /* opened_cuda_ipc_handle */));
+
+#ifdef TRITON_ENABLE_GPU
+  pb_memory->memory_shm_.data_->gpu_pointer_offset =
+      pb_memory->GetGPUPointerOffset();
+#endif
+
+  return pb_memory;
+}
+
+std::unique_ptr<PbMemory>
+PbMemory::LoadFromSharedMemory(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t handle)
+{
+  AllocatedSharedMemory<MemoryShm> memory_shm =
+      shm_pool->Load<MemoryShm>(handle);
+
+  AllocatedSharedMemory<char> memory_data_shm =
+      shm_pool->Load<char>(memory_shm.data_->memory_ptr);
+
+  char* data_ptr;
+  bool opened_cuda_ipc_handle = false;
+  if (memory_shm.data_->memory_type == TRITONSERVER_MEMORY_GPU) {
+#ifdef TRITON_ENABLE_GPU
+    cudaIpcMemHandle_t* cuda_handle =
+        reinterpret_cast<cudaIpcMemHandle_t*>(memory_data_shm.data_.get());
+
+    // The pointer opened by the cudaIpcOpenMemHandle will refer to the base
+    // address. We need to manually correct the offset.
+    void* data_ptr_base;
+    THROW_IF_CUDA_ERROR(cudaSetDevice(memory_shm.data_->memory_type_id));
+    THROW_IF_CUDA_ERROR(cudaIpcOpenMemHandle(
+        &data_ptr_base, *cuda_handle, cudaIpcMemLazyEnablePeerAccess));
+
+    data_ptr =
+        (reinterpret_cast<char*>(data_ptr_base) +
+         memory_shm.data_->gpu_pointer_offset);
+    opened_cuda_ipc_handle = true;
+#endif
+  }
+
+  return std::unique_ptr<PbMemory>(new PbMemory(
+      memory_shm, memory_data_shm, data_ptr,
+      opened_cuda_ipc_handle /* opened_cuda_ipc_handle */));
+}
+
+PbMemory::PbMemory(
+    AllocatedSharedMemory<MemoryShm>& memory_shm,
+    AllocatedSharedMemory<char>& memory_data_shm, char* data,
+    bool opened_cuda_ipc_handle)
+    : memory_shm_(std::move(memory_shm)),
+      memory_data_shm_(std::move(memory_data_shm)), data_ptr_(data),
+      opened_cuda_ipc_handle_(opened_cuda_ipc_handle)
+{
+}
+
+void*
+PbMemory::GetGPUStartAddress()
+{
+  if (memory_shm_ptr_->memory_type == TRITONSERVER_MEMORY_GPU) {
+    CUDADriverAPI& driver_api = CUDADriverAPI::getInstance();
+    CUdeviceptr start_address;
+
+    driver_api.PointerGetAttribute(
+        &start_address, CU_POINTER_ATTRIBUTE_RANGE_START_ADDR,
+        reinterpret_cast<CUdeviceptr>(data_ptr_));
+
+    return reinterpret_cast<void*>(start_address);
+  }
+
+  throw PythonBackendException(
+      "Calling GetGPUStartAddress function on CPU memory.");
+}
+
+uint64_t
+PbMemory::GetGPUPointerOffset()
+{
+  uint64_t offset;
+  if (memory_shm_ptr_->memory_type == TRITONSERVER_MEMORY_GPU) {
+    offset = data_ptr_ - reinterpret_cast<char*>(GetGPUStartAddress());
+  } else {
+    throw PythonBackendException(
+        "Calling GetGPUPointerOffset function on CPU tensor.");
+  }
+  return offset;
+}
+
+}}}  // namespace triton::backend::python

--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -53,8 +53,8 @@ PbMemory::Create(
     memory_data_shm = shm_pool->ConstructMany<char>(byte_size);
     if (data != nullptr) {
       std::copy(data, data + byte_size, memory_data_shm.data_.get());
-      data = memory_data_shm.data_.get();
     }
+    data = memory_data_shm.data_.get();
   }
 
   memory_shm.data_->byte_size = byte_size;
@@ -66,8 +66,10 @@ PbMemory::Create(
       memory_shm, memory_data_shm, data, false /* opened_cuda_ipc_handle */));
 
 #ifdef TRITON_ENABLE_GPU
-  pb_memory->memory_shm_.data_->gpu_pointer_offset =
-      pb_memory->GetGPUPointerOffset();
+  if (memory_type == TRITONSERVER_MEMORY_GPU) {
+    pb_memory->memory_shm_.data_->gpu_pointer_offset =
+        pb_memory->GetGPUPointerOffset();
+  }
 #endif
 
   return pb_memory;

--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -40,7 +40,7 @@ PbMemory::Create(
   AllocatedSharedMemory<char> memory_data_shm;
   if (memory_type == TRITONSERVER_MEMORY_GPU) {
 #ifdef TRITON_ENABLE_GPU
-    memory_data_shm = shm_pool->ConstructMany<char>(sizeof(cudaIpcMemHandle_t));
+    memory_data_shm = shm_pool->Construct<char>(sizeof(cudaIpcMemHandle_t));
     if (data != nullptr) {
       THROW_IF_CUDA_ERROR(cudaSetDevice(memory_type_id));
       THROW_IF_CUDA_ERROR(cudaIpcGetMemHandle(
@@ -50,7 +50,7 @@ PbMemory::Create(
   }
 #endif
   else {
-    memory_data_shm = shm_pool->ConstructMany<char>(byte_size);
+    memory_data_shm = shm_pool->Construct<char>(byte_size);
     if (data != nullptr) {
       std::copy(data, data + byte_size, memory_data_shm.data_.get());
     }

--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -120,6 +120,13 @@ PbMemory::PbMemory(
 {
 }
 
+void
+PbMemory::Release()
+{
+  memory_shm_.data_.release();
+  memory_data_shm_.data_.release();
+}
+
 void*
 PbMemory::GetGPUStartAddress()
 {
@@ -149,6 +156,30 @@ PbMemory::GetGPUPointerOffset()
         "Calling GetGPUPointerOffset function on CPU tensor.");
   }
   return offset;
+}
+
+TRITONSERVER_MemoryType
+PbMemory::MemoryType() const
+{
+  return memory_shm_ptr_->memory_type;
+}
+
+int64_t
+PbMemory::MemoryTypeId() const
+{
+  return memory_shm_ptr_->memory_type_id;
+}
+
+uint64_t
+PbMemory::ByteSize() const
+{
+  return memory_shm_ptr_->byte_size;
+}
+
+char*
+PbMemory::DataPtr() const
+{
+  return data_ptr_;
 }
 
 }}}  // namespace triton::backend::python

--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -127,7 +127,7 @@ PbMemory::PbMemory(
 }
 
 bi::managed_external_buffer::handle_t
-PbMemory::ShmOffset()
+PbMemory::ShmHandle()
 {
   return memory_shm_handle_;
 }

--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -105,8 +105,9 @@ PbMemory::LoadFromSharedMemory(
          memory_shm.data_->gpu_pointer_offset);
     opened_cuda_ipc_handle = true;
 #endif
+  } else {
+    data_ptr = memory_data_shm.data_.get();
   }
-
   return std::unique_ptr<PbMemory>(new PbMemory(
       memory_shm, memory_data_shm, data_ptr,
       opened_cuda_ipc_handle /* opened_cuda_ipc_handle */));

--- a/src/pb_memory.h
+++ b/src/pb_memory.h
@@ -70,6 +70,22 @@ class PbMemory {
   bi::managed_external_buffer::handle_t ShmOffset();
   void Release();
 
+  /// Get the total byte size of the tensor.
+  uint64_t ByteSize() const;
+
+  /// Get the triton memory type.
+  /// \return the memory type of the tensor.
+  TRITONSERVER_MemoryType MemoryType() const;
+
+  /// Get the pointer.
+  /// \return The location to the memory where the data is stored.
+  char* DataPtr() const;
+
+  /// Get the memory type id.
+  /// \return The memory type id of the tensor.
+  int64_t MemoryTypeId() const;
+
+
  private:
   AllocatedSharedMemory<MemoryShm> memory_shm_;
   MemoryShm* memory_shm_ptr_;

--- a/src/pb_memory.h
+++ b/src/pb_memory.h
@@ -1,0 +1,102 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "pb_utils.h"
+#include "shm_manager.h"
+#include "triton/backend/backend_common.h"
+#include "triton/backend/backend_memory.h"
+
+#ifdef TRITON_ENABLE_GPU
+#include <cuda_runtime_api.h>
+#endif  // TRITON_ENABLE_GPU
+
+namespace triton { namespace backend { namespace python {
+
+//
+// Represents a memory object in shared memory.
+//
+struct MemoryShm {
+  // The shared memory offset of the data. For device pointers this will contain
+  // the offset to the cudaMemHandle_t object.
+  bi::managed_external_buffer::handle_t memory_ptr;
+
+  // If the memory type is a GPU pointer, the offset of the GPU pointer from the
+  // base address. For CPU memory type this field contains garbage data.
+  uint64_t gpu_pointer_offset;
+
+  TRITONSERVER_MemoryType memory_type;
+  int64_t memory_type_id;
+  uint64_t byte_size;
+};
+
+class PbMemory {
+ public:
+  static std::unique_ptr<PbMemory> Create(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+      uint64_t byte_size, char* data);
+  static std::unique_ptr<PbMemory> LoadFromSharedMemory(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      bi::managed_external_buffer::handle_t memory_offset);
+  static std::unique_ptr<PbMemory> Create(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      std::unique_ptr<BackendMemory>& backend_memory);
+
+  bi::managed_external_buffer::handle_t ShmOffset();
+  void Release();
+
+ private:
+  AllocatedSharedMemory<MemoryShm> memory_shm_;
+  MemoryShm* memory_shm_ptr_;
+
+  AllocatedSharedMemory<char> memory_data_shm_;
+  char* memory_data_shm_ptr_;
+
+  // Refers to the pointer that can hold the data. For CPU pointers this will be
+  // the same as memory_data_shm_ptr_.
+  char* data_ptr_;
+
+  bi::managed_external_buffer::handle_t memory_shm_handle_;
+  bool opened_cuda_ipc_handle_;
+
+  /// Calculate the pointer offest from the base address.
+  /// \return The offset of a device pointer.
+  /// \throws PythonBackendException if the tensor is stored in CPU.
+  uint64_t GetGPUPointerOffset();
+
+  /// Get the GPU start address.
+  /// \return The start address of a device pointer.
+  /// \throws PythonBackendException if the tensor is stored in CPU.
+  void* GetGPUStartAddress();
+
+  PbMemory(
+      AllocatedSharedMemory<MemoryShm>& memory_shm,
+      AllocatedSharedMemory<char>& memory_data_shm, char* data,
+      bool opened_cuda_ipc_handle);
+};
+}}}  // namespace triton::backend::python

--- a/src/pb_memory.h
+++ b/src/pb_memory.h
@@ -41,10 +41,6 @@ namespace triton { namespace backend { namespace python {
 // Represents a memory object in shared memory.
 //
 struct MemoryShm {
-  // The shared memory handle of the data. For device pointers this will contain
-  // the handle to the cudaMemHandle_t object.
-  bi::managed_external_buffer::handle_t memory_ptr;
-
   // If the memory type is a GPU pointer, the offset of the GPU pointer from the
   // base address. For CPU memory type this field contains garbage data.
   uint64_t gpu_pointer_offset;
@@ -68,7 +64,6 @@ class PbMemory {
       std::unique_ptr<BackendMemory>& backend_memory);
 
   bi::managed_external_buffer::handle_t ShmHandle();
-  void Release();
 
   /// Get the total byte size of the tensor.
   uint64_t ByteSize() const;
@@ -85,13 +80,9 @@ class PbMemory {
   /// \return The memory type id of the tensor.
   int64_t MemoryTypeId() const;
 
-
  private:
-  AllocatedSharedMemory<MemoryShm> memory_shm_;
+  AllocatedSharedMemory<char> memory_shm_;
   MemoryShm* memory_shm_ptr_;
-
-  AllocatedSharedMemory<char> memory_data_shm_;
-  char* memory_data_shm_ptr_;
 
   // Refers to the pointer that can hold the data. For CPU pointers this will be
   // the same as memory_data_shm_ptr_.
@@ -111,8 +102,7 @@ class PbMemory {
   void* GetGPUStartAddress();
 
   PbMemory(
-      AllocatedSharedMemory<MemoryShm>& memory_shm,
-      AllocatedSharedMemory<char>& memory_data_shm, char* data,
+      AllocatedSharedMemory<char>& memory_shm, char* data,
       bool opened_cuda_ipc_handle);
 };
 }}}  // namespace triton::backend::python

--- a/src/pb_memory.h
+++ b/src/pb_memory.h
@@ -56,14 +56,21 @@ class PbMemory {
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
       uint64_t byte_size, char* data);
+  static std::unique_ptr<PbMemory> Create(
+      TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+      uint64_t byte_size, char* data, char* data_shm,
+      bi::managed_external_buffer::handle_t handle);
+
   static std::unique_ptr<PbMemory> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       bi::managed_external_buffer::handle_t memory_handle);
-  static std::unique_ptr<PbMemory> Create(
-      std::unique_ptr<SharedMemoryManager>& shm_pool,
-      std::unique_ptr<BackendMemory>& backend_memory);
+  static std::unique_ptr<PbMemory> LoadFromSharedMemory(
+      bi::managed_external_buffer::handle_t handle, char* data_shm);
+  static std::size_t ShmStructSize(
+      TRITONSERVER_MemoryType memory_type, uint64_t byte_size);
 
   bi::managed_external_buffer::handle_t ShmHandle();
+
 
   /// Get the total byte size of the tensor.
   uint64_t ByteSize() const;
@@ -101,8 +108,18 @@ class PbMemory {
   /// \throws PythonBackendException if the tensor is stored in CPU.
   void* GetGPUStartAddress();
 
+  static void FillShmData(
+      TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+      uint64_t byte_size, char* data, char* data_shm,
+      bi::managed_external_buffer::handle_t handle);
+
   PbMemory(
       AllocatedSharedMemory<char>& memory_shm, char* data,
+      bool opened_cuda_ipc_handle);
+
+  PbMemory(
+      char* memory_shm, char* data,
+      bi::managed_external_buffer::handle_t handle,
       bool opened_cuda_ipc_handle);
 };
 }}}  // namespace triton::backend::python

--- a/src/pb_memory.h
+++ b/src/pb_memory.h
@@ -41,8 +41,8 @@ namespace triton { namespace backend { namespace python {
 // Represents a memory object in shared memory.
 //
 struct MemoryShm {
-  // The shared memory offset of the data. For device pointers this will contain
-  // the offset to the cudaMemHandle_t object.
+  // The shared memory handle of the data. For device pointers this will contain
+  // the handle to the cudaMemHandle_t object.
   bi::managed_external_buffer::handle_t memory_ptr;
 
   // If the memory type is a GPU pointer, the offset of the GPU pointer from the
@@ -62,12 +62,12 @@ class PbMemory {
       uint64_t byte_size, char* data);
   static std::unique_ptr<PbMemory> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t memory_offset);
+      bi::managed_external_buffer::handle_t memory_handle);
   static std::unique_ptr<PbMemory> Create(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       std::unique_ptr<BackendMemory>& backend_memory);
 
-  bi::managed_external_buffer::handle_t ShmOffset();
+  bi::managed_external_buffer::handle_t ShmHandle();
   void Release();
 
   /// Get the total byte size of the tensor.

--- a/src/pb_string.cc
+++ b/src/pb_string.cc
@@ -37,7 +37,7 @@ PbString::Create(
   string_container_shm.data_->length = string.size();
 
   AllocatedSharedMemory<char> string_shm =
-      shm_pool->ConstructMany<char>(string.size());
+      shm_pool->Construct<char>(string.size());
   std::memcpy(string_shm.data_.get(), string.data(), string.size());
   string_container_shm.data_->data = string_shm.handle_;
 

--- a/src/pb_string.cc
+++ b/src/pb_string.cc
@@ -114,7 +114,13 @@ PbString::ShmHandle()
 std::size_t
 PbString::ShmStructSize(const std::string& string)
 {
-  return string.size() + 1 + sizeof(StringShm);
+  return string.size() + sizeof(StringShm);
+}
+
+std::size_t
+PbString::Size()
+{
+  return string_container_shm_ptr_->length + sizeof(StringShm);
 }
 
 }}}  // namespace triton::backend::python

--- a/src/pb_string.cc
+++ b/src/pb_string.cc
@@ -48,10 +48,10 @@ PbString::Create(
 std::unique_ptr<PbString>
 PbString::LoadFromSharedMemory(
     std::unique_ptr<SharedMemoryManager>& shm_pool,
-    bi::managed_external_buffer::handle_t offset)
+    bi::managed_external_buffer::handle_t handle)
 {
   AllocatedSharedMemory<StringShm> string_container_shm =
-      shm_pool->Load<StringShm>(offset);
+      shm_pool->Load<StringShm>(handle);
   AllocatedSharedMemory<char> string_shm =
       shm_pool->Load<char>(string_container_shm.data_->data);
 
@@ -71,7 +71,7 @@ PbString::PbString(
 }
 
 bi::managed_external_buffer::handle_t
-PbString::ShmOffset()
+PbString::ShmHandle()
 {
   return string_handle_;
 }

--- a/src/pb_string.h
+++ b/src/pb_string.h
@@ -42,11 +42,11 @@ class PbString {
       const std::string& string);
   static std::unique_ptr<PbString> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t offset);
+      bi::managed_external_buffer::handle_t handle);
 
   char* MutableString() { return string_shm_ptr_; }
   const char* String() { return string_shm_ptr_; }
-  bi::managed_external_buffer::handle_t ShmOffset();
+  bi::managed_external_buffer::handle_t ShmHandle();
   void Release();
 
  private:

--- a/src/pb_string.h
+++ b/src/pb_string.h
@@ -57,6 +57,7 @@ class PbString {
         string_shm_ptr_, string_shm_ptr_ + string_container_shm_ptr_->length);
   }
   bi::managed_external_buffer::handle_t ShmHandle();
+  std::size_t Size();
 
  private:
   AllocatedSharedMemory<StringShm> string_container_shm_;

--- a/src/pb_string.h
+++ b/src/pb_string.h
@@ -40,14 +40,23 @@ class PbString {
   static std::unique_ptr<PbString> Create(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       const std::string& string);
+  static std::unique_ptr<PbString> Create(
+      const std::string& string, char* data_shm,
+      bi::managed_external_buffer::handle_t handle);
   static std::unique_ptr<PbString> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       bi::managed_external_buffer::handle_t handle);
+  static std::unique_ptr<PbString> LoadFromSharedMemory(
+      bi::managed_external_buffer::handle_t handle, char* data_shm);
+  static std::size_t ShmStructSize(const std::string& string);
 
   char* MutableString() { return string_shm_ptr_; }
-  const char* String() { return string_shm_ptr_; }
+  std::string String()
+  {
+    return std::string(
+        string_shm_ptr_, string_shm_ptr_ + string_container_shm_ptr_->length);
+  }
   bi::managed_external_buffer::handle_t ShmHandle();
-  void Release();
 
  private:
   AllocatedSharedMemory<StringShm> string_container_shm_;
@@ -61,6 +70,10 @@ class PbString {
   PbString(
       AllocatedSharedMemory<StringShm>& string_container_shm,
       AllocatedSharedMemory<char>& string_shm);
+
+  PbString(
+      StringShm* string_container_shm, char* string_shm,
+      bi::managed_external_buffer::handle_t handle);
 };
 
 }}}  // namespace triton::backend::python

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -40,11 +40,9 @@
 #include <memory>
 #include <thread>
 #include <unordered_map>
-#include "message_queue.h"
 #include "pb_error.h"
 #include "pb_map.h"
 #include "pb_string.h"
-#include "pb_utils.h"
 #include "shm_manager.h"
 
 #ifdef TRITON_ENABLE_GPU

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -304,7 +304,6 @@ Stub::RunCommand()
                   request_batch.data_->batch_size);
       execute_response->Args() = response_batch.handle_;
 
-
       defer execute_finalize(
           nullptr, std::bind([this] { stub_message_queue_->Pop(); }));
       defer _(nullptr, std::bind([this, &execute_response] {

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -590,7 +590,7 @@ Stub::GetOrCreateInstance()
 
 PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
 {
-  py::class_<PbError, std::unique_ptr<PbError>>(module, "TritonError")
+  py::class_<PbError, std::shared_ptr<PbError>>(module, "TritonError")
       .def(py::init<std::string>())
       .def("message", &PbError::Message);
 

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -143,7 +143,7 @@ Stub::Instantiate(
 
   try {
     shm_pool_ = std::make_unique<SharedMemoryManager>(
-        shm_region_name, shm_default_size, false /* create */);
+        shm_region_name, shm_default_size, shm_growth_size, false /* create */);
 
     AllocatedSharedMemory<IPCControlShm> ipc_control =
         shm_pool_->Load<IPCControlShm>(ipc_control_offset);

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -427,17 +427,6 @@ Stub::Initialize(bi::managed_external_buffer::handle_t map_handle)
 void
 Stub::ProcessResponse(InferResponse* response)
 {
-  std::vector<std::shared_ptr<PbTensor>>& output_tensors =
-      response->OutputTensors();
-  for (auto& output_tensor : output_tensors) {
-    if (!output_tensor->IsCPU()) {
-      // #ifdef TRITON_ENABLE_GPU
-      //       AddToTensorsToRemove(output_tensor);
-      // #else
-      //       throw PythonBackendException("GPU tensors is not supported.");
-      // #endif
-    }
-  }
   response->SaveToSharedMemory(shm_pool_);
 }
 

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -33,6 +33,7 @@
 #include <condition_variable>
 #include <memory>
 #include <mutex>
+#include "infer_request.h"
 #include "ipc_message.h"
 #include "message_queue.h"
 #include "pb_utils.h"

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -34,6 +34,7 @@
 #include <memory>
 #include <mutex>
 #include "infer_request.h"
+#include "infer_response.h"
 #include "ipc_message.h"
 #include "message_queue.h"
 #include "pb_utils.h"
@@ -83,6 +84,12 @@ class Stub {
   /// Finalize and terminate the stub process
   void Finalize();
 
+  /// Execute a batch of requests.
+  void Execute(
+      AllocatedSharedMemory<RequestBatch>& request_batch,
+      AllocatedSharedMemory<ResponseBatch>& response_batch);
+
+  void ProcessResponse(InferResponse* response);
   ~Stub();
 
  private:

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -85,9 +85,11 @@ class Stub {
   void Finalize();
 
   /// Execute a batch of requests.
-  void Execute(
+  py::list Execute(
       AllocatedSharedMemory<RequestBatch>& request_batch,
-      AllocatedSharedMemory<ResponseBatch>& response_batch);
+      AllocatedSharedMemory<ResponseBatch>& response_batch,
+      AllocatedSharedMemory<bi::managed_external_buffer::handle_t>&
+          responses_shm_offset);
 
   void ProcessResponse(InferResponse* response);
   ~Stub();

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -86,10 +86,9 @@ class Stub {
 
   /// Execute a batch of requests.
   py::list Execute(
-      AllocatedSharedMemory<RequestBatch>& request_batch,
-      AllocatedSharedMemory<ResponseBatch>& response_batch,
-      AllocatedSharedMemory<bi::managed_external_buffer::handle_t>&
-          responses_shm_handle);
+      RequestBatch* request_batch_shm_ptr,
+      ResponseBatch* response_batch_shm_ptr,
+      bi::managed_external_buffer::handle_t* responses_shm_handle);
 
   void ProcessResponse(InferResponse* response);
   ~Stub();

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -57,7 +57,7 @@ class Stub {
       int64_t shm_growth_size, int64_t shm_default_size,
       const std::string& shm_region_name, const std::string& model_path,
       const std::string& model_version, const std::string& triton_install_path,
-      bi::managed_external_buffer::handle_t ipc_control_offset,
+      bi::managed_external_buffer::handle_t ipc_control_handle,
       const std::string& model_instance_name);
 
   /// Get the health of the stub process.
@@ -70,7 +70,7 @@ class Stub {
   bool RunCommand();
 
   /// Initialize the user's Python code.
-  void Initialize(bi::managed_external_buffer::handle_t map_offset);
+  void Initialize(bi::managed_external_buffer::handle_t map_handle);
 
   /// Send a message to the parent process.
   void SendIPCMessage(std::unique_ptr<IPCMessage>& ipc_message);
@@ -89,7 +89,7 @@ class Stub {
       AllocatedSharedMemory<RequestBatch>& request_batch,
       AllocatedSharedMemory<ResponseBatch>& response_batch,
       AllocatedSharedMemory<bi::managed_external_buffer::handle_t>&
-          responses_shm_offset);
+          responses_shm_handle);
 
   void ProcessResponse(InferResponse* response);
   ~Stub();

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -406,6 +406,7 @@ PbTensor::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
   pb_memory_ = PbMemory::Create(
       shm_pool, memory_type_, memory_type_id_, byte_size_,
       reinterpret_cast<char*>(memory_ptr_));
+  memory_ptr_ = pb_memory_->DataPtr();
 }
 
 std::shared_ptr<PbTensor>
@@ -429,6 +430,12 @@ TRITONSERVER_DataType
 PbTensor::TritonDtype() const
 {
   return dtype_;
+}
+
+void*
+PbTensor::DataPtr()
+{
+  return memory_ptr_;
 }
 
 bi::managed_external_buffer::handle_t

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -33,7 +33,6 @@
 namespace py = pybind11;
 #endif
 #include "pb_tensor.h"
-#include "pb_utils.h"
 
 
 namespace triton { namespace backend { namespace python {
@@ -43,7 +42,6 @@ PbTensor::PbTensor(const std::string& name, py::object numpy_array)
     : name_(name)
 {
   dtype_ = numpy_to_triton_type(numpy_array.attr("dtype"));
-  tensor_type_ = PYTHONBACKEND_NUMPY;
   memory_type_ = TRITONSERVER_MEMORY_CPU;
   memory_type_id_ = 0;
   dl_managed_tensor_ = nullptr;
@@ -105,7 +103,6 @@ PbTensor::PbTensor(
     memory_ptr_ = numpy_array_.request().ptr;
     byte_size_ = numpy_array_.nbytes();
   }
-  tensor_type_ = PYTHONBACKEND_NUMPY;
   memory_type_ = TRITONSERVER_MEMORY_CPU;
   dtype_ = dtype;
 
@@ -125,7 +122,8 @@ PbTensor::PbTensor(
     const std::string& name, const std::vector<int64_t>& dims,
     TRITONSERVER_DataType dtype, TRITONSERVER_MemoryType memory_type,
     int64_t memory_type_id, void* memory_ptr, uint64_t byte_size,
-    DLManagedTensor* dl_managed_tensor, off_t shm_offset)
+    DLManagedTensor* dl_managed_tensor,
+    bi::managed_external_buffer::handle_t shm_offset)
 {
   name_ = name;
   memory_ptr_ = memory_ptr;
@@ -133,7 +131,7 @@ PbTensor::PbTensor(
   memory_type_id_ = memory_type_id;
   dtype_ = dtype;
   dims_ = dims;
-  raw_shm_offset_ = shm_offset;
+  // [FIXME] fix shm_offset
 
 #ifdef TRITON_PB_STUB
   if (memory_type_ == TRITONSERVER_MEMORY_CPU ||
@@ -159,22 +157,13 @@ PbTensor::PbTensor(
 
   byte_size_ = byte_size;
   dl_managed_tensor_ = dl_managed_tensor;
-
-  if (dl_managed_tensor != nullptr) {
-    tensor_type_ = PYTHONBACKEND_DLPACK;
-  } else {
-    tensor_type_ = PYTHONBACKEND_RAW;
-  }
 }
 
 bool
 PbTensor::IsCPU() const
 {
-  if (tensor_type_ == PYTHONBACKEND_NUMPY ||
-      ((tensor_type_ == PYTHONBACKEND_RAW ||
-        tensor_type_ == PYTHONBACKEND_DLPACK) &&
-       (memory_type_ == TRITONSERVER_MEMORY_CPU ||
-        memory_type_ == TRITONSERVER_MEMORY_CPU_PINNED))) {
+  if (memory_type_ == TRITONSERVER_MEMORY_CPU ||
+      memory_type_ == TRITONSERVER_MEMORY_CPU_PINNED) {
     return true;
   } else {
     return false;
@@ -193,11 +182,6 @@ PbTensor::MemoryTypeId() const
   return memory_type_id_;
 }
 
-off_t
-PbTensor::RawShmOffset()
-{
-  return raw_shm_offset_;
-}
 
 uint64_t
 PbTensor::ByteSize() const
@@ -209,12 +193,6 @@ const std::vector<int64_t>&
 PbTensor::Dims() const
 {
   return dims_;
-}
-
-PYTHONBACKEND_TensorType
-PbTensor::TensorType() const
-{
-  return tensor_type_;
 }
 
 #ifdef TRITON_PB_STUB
@@ -297,87 +275,6 @@ PbTensor::DeleteDLPack()
   }
 }
 
-std::shared_ptr<PbTensor>
-PbTensor::LoadFromSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, off_t tensor_offset,
-    std::shared_ptr<std::mutex>& cuda_ipc_open_mutex,
-    std::shared_ptr<std::mutex>& cuda_ipc_close_mutex)
-{
-  Tensor* tensor_shm;
-  shm_pool->MapOffset((char**)&tensor_shm, tensor_offset);
-
-  char* name;
-  LoadStringFromSharedMemory(shm_pool, tensor_shm->name, name);
-  std::string name_str = name;
-
-  size_t dims_count = tensor_shm->dims_count;
-  RawData* raw_data;
-  shm_pool->MapOffset((char**)&raw_data, tensor_shm->raw_data);
-
-  int64_t* dims;
-  shm_pool->MapOffset((char**)&dims, tensor_shm->dims);
-
-  std::string reused_gpu_tensor_name;
-  std::shared_ptr<PbTensor> pb_tensor;
-
-  char* data = nullptr;
-  if (raw_data->memory_type == TRITONSERVER_MEMORY_CPU) {
-    shm_pool->MapOffset((char**)&data, raw_data->memory_ptr);
-    pb_tensor = std::make_shared<PbTensor>(
-        name, std::vector<int64_t>(dims, dims + dims_count), tensor_shm->dtype,
-        raw_data->memory_type, raw_data->memory_type_id, data,
-        raw_data->byte_size, nullptr /* DLManaged Tensor */);
-  } else if (raw_data->memory_type == TRITONSERVER_MEMORY_GPU) {
-#ifdef TRITON_ENABLE_GPU
-    cudaIpcMemHandle_t* cuda_ipc_mem_handle;
-    shm_pool->MapOffset((char**)&cuda_ipc_mem_handle, raw_data->memory_ptr);
-    if (tensor_shm->is_cuda_handle_set) {
-      cudaSetDevice(raw_data->memory_type_id);
-
-      if (cuda_ipc_open_mutex != nullptr)
-        cuda_ipc_open_mutex->lock();
-
-      cudaError_t err = cudaIpcOpenMemHandle(
-          (void**)&data, *cuda_ipc_mem_handle, cudaIpcMemLazyEnablePeerAccess);
-
-      if (cuda_ipc_open_mutex != nullptr)
-        cuda_ipc_open_mutex->unlock();
-
-      if (err != cudaSuccess) {
-        throw PythonBackendException(std::string(
-                                         "failed to open cuda ipc handle: " +
-                                         std::string(cudaGetErrorString(err)))
-                                         .c_str());
-      }
-      // Adjust the offset. cudaIpcOpenMemHandle will map the base address of a
-      // GPU pointer and the offset is not preserved when transferring the
-      // pointer using cudaIpcMemHandle.
-      data = data + raw_data->offset;
-      pb_tensor = std::make_shared<PbTensor>(
-          name, std::vector<int64_t>(dims, dims + dims_count),
-          tensor_shm->dtype, raw_data->memory_type, raw_data->memory_type_id,
-          data, raw_data->byte_size, nullptr /* DLManaged Tensor */);
-      pb_tensor->destruct_cuda_ipc_mem_handle_ = true;
-    } else {
-      pb_tensor = std::make_shared<PbTensor>(
-          name, std::vector<int64_t>(dims, dims + dims_count),
-          tensor_shm->dtype, raw_data->memory_type, raw_data->memory_type_id,
-          data, raw_data->byte_size, nullptr /* DLManaged Tensor */);
-      pb_tensor->destruct_cuda_ipc_mem_handle_ = false;
-      pb_tensor->is_cuda_handle_set_ = false;
-    }
-    pb_tensor->cuda_ipc_mem_handle_ = cuda_ipc_mem_handle;
-    pb_tensor->SetCudaIpcMutexes(cuda_ipc_open_mutex, cuda_ipc_close_mutex);
-#else
-    throw PythonBackendException("GPU Tensor is not supported.");
-#endif  // TRITON_ENABLE_GPU
-  }
-  pb_tensor->tensor_shm_ = tensor_shm;
-  pb_tensor->raw_data_shm_ = raw_data;
-  pb_tensor->shm_offset_ = tensor_offset;
-
-  return pb_tensor;
-}
 
 #ifdef TRITON_PB_STUB
 std::shared_ptr<PbTensor>
@@ -430,7 +327,7 @@ PbTensor::FromDLPack(const std::string& name, const py::capsule& dlpack_tensor)
       memory_type_id = 0;
       break;
     case DLDeviceType::kDLCUDAHost:
-      memory_type = TRITONSERVER_MEMORY_CPU_PINNED;
+      memory_type = TRITONSERVER_MEMORY_CPU;
       memory_type_id = 0;
       break;
     default:
@@ -460,28 +357,6 @@ PbTensor::FromDLPack(const std::string& name, const py::capsule& dlpack_tensor)
 
 PbTensor::~PbTensor() noexcept(false)
 {
-#ifdef TRITON_ENABLE_GPU
-  if (!IsCPU() && cuda_ipc_mem_handle_ != nullptr &&
-      destruct_cuda_ipc_mem_handle_) {
-    // Mutex needs to be used since calls to cudaIpcCloseMemHandle are not
-    // thread safe.
-    if (cuda_ipc_close_mutex_ != nullptr)
-      cuda_ipc_close_mutex_->lock();
-
-    cudaError_t err = cudaIpcCloseMemHandle(GetGPUStartAddress());
-
-    if (cuda_ipc_close_mutex_ != nullptr)
-      cuda_ipc_close_mutex_->unlock();
-
-    cuda_ipc_mem_handle_ = nullptr;
-    if (err != cudaSuccess) {
-      throw PythonBackendException(std::string(
-                                       "failed to close cuda ipc handle: " +
-                                       std::string(cudaGetErrorString(err)))
-                                       .c_str());
-    }
-  }
-#endif  // TRITON_ENABLE_GPU
   DeleteDLPack();
 }
 
@@ -495,7 +370,7 @@ PbTensor::Name() const
 const py::array&
 PbTensor::AsNumpy() const
 {
-  if (this->IsCPU()) {
+  if (IsCPU()) {
     return numpy_array_;
   } else {
     throw PythonBackendException(
@@ -506,282 +381,103 @@ PbTensor::AsNumpy() const
 }
 #endif  // TRITON_PB_STUB
 
-#ifdef TRITON_ENABLE_GPU
-void*
-PbTensor::GetGPUStartAddress()
+void
+PbTensor::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {
-  if (!this->IsCPU()) {
-    CUDADriverAPI& driver_api = CUDADriverAPI::getInstance();
-    CUdeviceptr start_address;
+  AllocatedSharedMemory<TensorShm> tensor_shm =
+      shm_pool->Construct<TensorShm>();
+  tensor_shm_ = std::move(tensor_shm);
+  tensor_shm_ptr_ = tensor_shm_.data_.get();
+  tensor_shm_ptr_->dtype = dtype_;
+  tensor_shm_ptr_->dims_count = dims_.size();
+  shm_offset_ = tensor_shm.handle_;
 
-    driver_api.PointerGetAttribute(
-        &start_address, CU_POINTER_ATTRIBUTE_RANGE_START_ADDR,
-        (CUdeviceptr)this->GetDataPtr());
+  AllocatedSharedMemory<int64_t> dims_shm =
+      shm_pool->ConstructMany<int64_t>(dims_.size());
+  dims_shm_ = std::move(dims_shm);
+  dims_shm_ptr_ = dims_shm_.data_.get();
 
-    return reinterpret_cast<void*>(start_address);
+  // Write the dimensions data to shared memory.
+  for (size_t i = 0; i < dims_.size(); i++) {
+    dims_shm_ptr_[i] = dims_[i];
   }
 
-  throw PythonBackendException(
-      "Calling GetGPUStartAddress function on a CPU tensor.");
+  name_shm_ = PbString::Create(shm_pool, name_);
+  pb_memory_ = PbMemory::Create(
+      shm_pool, memory_type_, memory_type_id_, byte_size_,
+      reinterpret_cast<char*>(memory_ptr_));
 }
 
-void
-PbTensor::SetCudaIpcMutexes(
-    std::shared_ptr<std::mutex>& cuda_ipc_open_mutex,
-    std::shared_ptr<std::mutex>& cuda_ipc_close_mutex)
+std::shared_ptr<PbTensor>
+PbTensor::LoadFromSharedMemory(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t tensor_offset)
 {
-  cuda_ipc_open_mutex_ = cuda_ipc_open_mutex;
-  cuda_ipc_close_mutex_ = cuda_ipc_close_mutex;
+  AllocatedSharedMemory<TensorShm> tensor_shm =
+      shm_pool->Load<TensorShm>(tensor_offset);
+  AllocatedSharedMemory<int64_t> dims_shm =
+      shm_pool->Load<int64_t>(tensor_shm.data_->dims);
+  std::unique_ptr<PbString> name_shm =
+      PbString::LoadFromSharedMemory(shm_pool, tensor_shm.data_->name);
+  std::unique_ptr<PbMemory> pb_memory =
+      PbMemory::LoadFromSharedMemory(shm_pool, tensor_shm.data_->memory);
+  return std::shared_ptr<PbTensor>(
+      new PbTensor(tensor_shm, dims_shm, name_shm, pb_memory));
 }
 
-uint64_t
-PbTensor::GetGPUPointerOffset()
-{
-  if (!this->IsCPU()) {
-    uint64_t offset = reinterpret_cast<char*>(this->GetDataPtr()) -
-                      reinterpret_cast<char*>(this->GetGPUStartAddress());
-    return offset;
-  }
-
-  throw PythonBackendException(
-      "Calling GetGPUPointerOffset function on a CPU tensor.");
-}
-
-const cudaIpcMemHandle_t*
-PbTensor::CudaIpcMemHandle()
-{
-  return cuda_ipc_mem_handle_;
-}
-
-#endif  // TRITON_ENABLE_GPU
-
-void
-PbTensor::SaveToSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, Tensor* tensor_shm, bool copy_cpu,
-    bool copy_gpu)
-{
-  const std::string& tensor_name = this->Name();
-  TRITONSERVER_DataType dtype_triton =
-      static_cast<TRITONSERVER_DataType>(this->TritonDtype());
-  tensor_shm->is_cuda_handle_set = false;
-  TRITONSERVER_MemoryType memory_type = TRITONSERVER_MEMORY_CPU;
-  int64_t memory_type_id = 0;
-  tensor_shm_ = tensor_shm;
-
-  if (IsCPU()) {
-    size_t dims_count = dims_.size();
-    memory_type = TRITONSERVER_MEMORY_CPU;
-    memory_type_id = 0;
-
-    char* data_in_shm;
-    char* data_ptr;
-
-    data_ptr = static_cast<char*>(memory_ptr_);
-
-    uint64_t* ptr_offset;
-    SaveTensorToSharedMemory(
-        shm_pool, tensor_shm, data_in_shm, memory_type, memory_type_id,
-        byte_size_, tensor_name.c_str(), dims_.data(), dims_count, dtype_triton,
-        &ptr_offset, raw_shm_offset_);
-    *ptr_offset = 0;
-
-    if (copy_cpu) {
-      std::copy(data_ptr, data_ptr + byte_size_, data_in_shm);
-    } else {
-      memory_ptr_ = reinterpret_cast<void*>(data_in_shm);
-    }
-  } else {
-#ifdef TRITON_ENABLE_GPU
-    char* cuda_handle;
-    uint64_t* ptr_offset;
-    SaveTensorToSharedMemory(
-        shm_pool, tensor_shm, cuda_handle, this->MemoryType(),
-        this->MemoryTypeId(), this->ByteSize(), tensor_name.c_str(),
-        this->Dims().data(), this->Dims().size(), dtype_triton, &ptr_offset,
-        raw_shm_offset_);
-    cuda_ipc_mem_handle_ = reinterpret_cast<cudaIpcMemHandle_t*>(cuda_handle);
-
-    if (copy_gpu) {
-      tensor_shm->is_cuda_handle_set = true;
-      *ptr_offset = this->GetGPUPointerOffset();
-      cudaSetDevice(this->MemoryTypeId());
-      cudaError_t err = cudaIpcGetMemHandle(
-          reinterpret_cast<cudaIpcMemHandle_t*>(cuda_handle),
-          this->GetDataPtr());
-      if (err != cudaSuccess) {
-        throw PythonBackendException(std::string(
-                                         "failed to get cuda ipc handle: " +
-                                         std::string(cudaGetErrorString(err)))
-                                         .c_str());
-      }
-    }
-#else
-    throw PythonBackendException("GPU tensors are not supported.");
-#endif  // TRITON_ENABLE_GPU
-  }
-
-  shm_pool->MapOffset((char**)&raw_data_shm_, tensor_shm_->raw_data);
-}
-
-#ifdef TRITON_ENABLE_GPU
-void
-PbTensor::LoadGPUData(std::unique_ptr<SharedMemory>& shm_pool)
-{
-  if (!IsCPU()) {
-    if (!tensor_shm_->is_cuda_handle_set) {
-      throw PythonBackendException(
-          std::string("Failed to get cudaIpcMemHandle for tensor '") + name_ +
-          "'.");
-    }
-    char* d_buffer;
-
-    // Sync the memory type id. Since it will be updated by the main process
-    // after providing the GPU buffers.
-    memory_type_id_ = raw_data_shm_->memory_type_id;
-
-    cudaSetDevice(this->MemoryTypeId());
-    shm_pool->MapOffset(
-        (char**)&cuda_ipc_mem_handle_, raw_data_shm_->memory_ptr);
-
-    // Lock the mutex when using cudaIpcOpenMemHandle. This code is only
-    // required in the stub process. In the Triton process, we never use
-    // cudaIpcOpenMemHandle. The mutex is required because cudaIpcOpenMemHandle
-    // is not thread safe.
-    if (cuda_ipc_open_mutex_ != nullptr)
-      cuda_ipc_open_mutex_->lock();
-
-    cudaError_t err = cudaIpcOpenMemHandle(
-        (void**)&d_buffer, *cuda_ipc_mem_handle_,
-        cudaIpcMemLazyEnablePeerAccess);
-
-    if (cuda_ipc_open_mutex_ != nullptr)
-      cuda_ipc_open_mutex_->unlock();
-
-    if (err != cudaSuccess) {
-      throw PythonBackendException(std::string(
-                                       "failed to open ipc handle: " +
-                                       std::string(cudaGetErrorString(err)))
-                                       .c_str());
-    }
-
-    char* buffer_start = d_buffer + raw_data_shm_->offset;
-    err = cudaMemcpy(
-        (void*)buffer_start, memory_ptr_, (size_t)this->ByteSize(),
-        cudaMemcpyDeviceToDevice);
-    if (err != cudaSuccess) {
-      throw PythonBackendException(
-          std::string(
-              "failed to copy data: " + std::string(cudaGetErrorString(err)))
-              .c_str());
-    }
-
-    if (cuda_ipc_close_mutex_ != nullptr)
-      cuda_ipc_close_mutex_->lock();
-
-    err = cudaIpcCloseMemHandle(d_buffer);
-
-    if (cuda_ipc_close_mutex_ != nullptr)
-      cuda_ipc_close_mutex_->unlock();
-
-    if (err != cudaSuccess) {
-      throw PythonBackendException(std::string(
-                                       "failed to close memory handle: " +
-                                       std::string(cudaGetErrorString(err)))
-                                       .c_str());
-    }
-  } else {
-    throw PythonBackendException("LoadGPUData called on a CPU tensor.");
-  }
-}
-
-void
-PbTensor::CopyToCPU(std::unique_ptr<SharedMemory>& shm_pool)
-{
-  if (!this->IsCPU()) {
-    char* raw_data_ptr;
-    uint64_t* offset_ptr;
-    off_t raw_ptr_offset = 0;
-    off_t raw_data_offset;
-
-    // Raw Data
-    SaveRawDataToSharedMemory(
-        shm_pool, raw_data_offset, raw_data_ptr,
-        TRITONSERVER_MEMORY_CPU /* memory_type */, 0 /*memory_type_id */,
-        this->ByteSize(), &offset_ptr, raw_ptr_offset);
-    tensor_shm_->raw_data = raw_data_offset;
-    cudaError_t err = cudaMemcpy(
-        (void*)raw_data_ptr, memory_ptr_, this->ByteSize(),
-        cudaMemcpyDeviceToHost);
-
-    if (err != cudaSuccess) {
-      throw PythonBackendException(
-          std::string(
-              "failed to copy data: " + std::string(cudaGetErrorString(err)))
-              .c_str());
-    }
-  } else {
-    throw PythonBackendException("CopyToCPU can be called on a GPU tensor.");
-  }
-}
-#endif  // TRITON_ENABLE_GPU
-
-void
-PbTensor::SetDataPtr(void* ptr)
-{
-  memory_ptr_ = ptr;
-}
-
-void
-PbTensor::SetMemoryType(TRITONSERVER_MemoryType memory_type)
-{
-  memory_type_ = memory_type;
-  raw_data_shm_->memory_type = memory_type;
-}
-
-void
-PbTensor::SetMemoryTypeId(int64_t memory_type_id)
-{
-  memory_type_id_ = memory_type_id;
-  raw_data_shm_->memory_type_id = memory_type_id;
-}
-
-#ifdef TRITON_ENABLE_GPU
-#ifndef TRITON_PB_STUB
-void
-PbTensor::SetBackendMemory(
-    std::unique_ptr<BackendMemory> backend_memory,
-    std::unique_ptr<SharedMemory>& shm_pool)
-{
-  tensor_shm_->is_cuda_handle_set = false;
-  cudaSetDevice(this->MemoryTypeId());
-  cudaError_t err =
-      cudaIpcGetMemHandle(cuda_ipc_mem_handle_, backend_memory->MemoryPtr());
-  if (err != cudaSuccess) {
-    throw PythonBackendException(std::string(
-                                     "failed to get cuda ipc handle: " +
-                                     std::string(cudaGetErrorString(err)))
-                                     .c_str());
-  }
-
-  memory_ptr_ = backend_memory->MemoryPtr();
-  SetMemoryType(backend_memory->MemoryType());
-  SetMemoryTypeId(backend_memory->MemoryTypeId());
-  backend_memory_ = std::move(backend_memory);
-  raw_data_shm_->offset = this->GetGPUPointerOffset();
-  tensor_shm_->is_cuda_handle_set = true;
-}
-#endif
-#endif
-
-int
+TRITONSERVER_DataType
 PbTensor::TritonDtype() const
 {
   return dtype_;
 }
 
-void*
-PbTensor::GetDataPtr() const
+bi::managed_external_buffer::handle_t
+PbTensor::ShmOffset()
 {
-  return memory_ptr_;
+  return shm_offset_;
+}
+
+PbTensor::PbTensor(
+    AllocatedSharedMemory<TensorShm>& tensor_shm,
+    AllocatedSharedMemory<int64_t>& dims_shm,
+    std::unique_ptr<PbString>& name_shm, std::unique_ptr<PbMemory>& pb_memory)
+    : tensor_shm_(std::move(tensor_shm)), dims_shm_(std::move(dims_shm)),
+      name_shm_(std::move(name_shm)), pb_memory_(std::move(pb_memory))
+{
+  tensor_shm_ptr_ = tensor_shm_.data_.get();
+  dims_shm_ptr_ = dims_shm_.data_.get();
+
+  name_ = name_shm_->String();
+  dims_ = std::vector<int64_t>(
+      dims_shm_ptr_, dims_shm_ptr_ + tensor_shm_.data_->dims_count);
+  dtype_ = tensor_shm_.data_->dtype;
+  dl_managed_tensor_ = nullptr;
+  byte_size_ = pb_memory_->ByteSize();
+  memory_ptr_ = pb_memory_->DataPtr();
+  memory_type_ = pb_memory_->MemoryType();
+  memory_type_id_ = pb_memory_->MemoryTypeId();
+  shm_offset_ = tensor_shm_.handle_;
+
+#ifdef TRITON_PB_STUB
+  if (memory_type_ == TRITONSERVER_MEMORY_CPU ||
+      memory_type_ == TRITONSERVER_MEMORY_CPU_PINNED) {
+    if (dtype_ != TRITONSERVER_TYPE_BYTES) {
+      py::object numpy_array =
+          py::array(triton_to_pybind_dtype(dtype_), dims_, (void*)memory_ptr_);
+      numpy_array_ = numpy_array.attr("view")(triton_to_numpy_type(dtype_));
+    } else {
+      py::object numpy_array = py::array(
+          triton_to_pybind_dtype(TRITONSERVER_TYPE_UINT8), {byte_size_},
+          (void*)memory_ptr_);
+      py::module triton_pb_utils =
+          py::module::import("triton_python_backend_utils");
+      numpy_array_ =
+          triton_pb_utils.attr("deserialize_bytes_tensor")(numpy_array)
+              .attr("reshape")(dims_);
+    }
+  } else {
+    numpy_array_ = py::none();
+  }
+#endif
 }
 }}}  // namespace triton::backend::python

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -390,7 +390,7 @@ PbTensor::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
   tensor_shm_ptr_->dims_count = dims_.size();
   shm_offset_ = tensor_shm_.handle_;
 
-  dims_shm_ = shm_pool->ConstructMany<int64_t>(dims_.size());
+  dims_shm_ = shm_pool->Construct<int64_t>(dims_.size());
   dims_shm_ptr_ = dims_shm_.data_.get();
 
   // Write the dimensions data to shared memory.

--- a/src/pb_tensor.h
+++ b/src/pb_tensor.h
@@ -172,6 +172,10 @@ class PbTensor {
   /// \return Triton dtype
   TRITONSERVER_DataType TritonDtype() const;
 
+  /// Get the data ptr
+  /// \return Get the raw pointer.
+  void* DataPtr();
+
   /// This function will be automatically called by the stub when the tensor is
   /// no longer required.
   void DeleteDLPack();

--- a/src/pb_tensor.h
+++ b/src/pb_tensor.h
@@ -1,5 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights
-// reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -203,6 +202,9 @@ class PbTensor {
   /// Get the dimensions of the tensor
   /// \return A vector containing the tensor dimensions.
   const std::vector<int64_t>& Dims() const;
+
+  // Release the ownership of this tensor.
+  void Release();
 
   PbTensor();
 

--- a/src/pb_tensor.h
+++ b/src/pb_tensor.h
@@ -70,7 +70,7 @@ struct TensorShm {
 // PbTensor class is the representation of Triton tensors inside Python backend.
 // Once the `SaveToSharedMemory` function is called, class attributes and the
 // actual data that is stored in shared memory can become out of sync. Because
-// of this reason most of the class attributes cannot be changed after a Tensor
+// of this most of the class attributes cannot be changed after a Tensor
 // is created. The only exceptions are `SetName`, `SetMemoryType`, and
 // `SetMemoryTypeId`.
 class PbTensor {
@@ -229,6 +229,7 @@ class PbTensor {
   int64_t* dims_shm_ptr_;
 
   std::unique_ptr<PbString> name_shm_;
+
   // The pointer is null when the object is not stored in shared memory.
   std::unique_ptr<PbMemory> pb_memory_;
 };

--- a/src/pb_tensor.h
+++ b/src/pb_tensor.h
@@ -55,14 +55,7 @@ namespace triton { namespace backend { namespace python {
 struct TensorShm {
   // Handle for the pointer data in shared memory.
   bi::managed_external_buffer::handle_t memory;
-
-  // Handle for name field.
-  bi::managed_external_buffer::handle_t name;
-
   TRITONSERVER_DataType dtype;
-
-  // Shared memory handle for the dimensions.
-  bi::managed_external_buffer::handle_t dims;
   size_t dims_count;
 };
 
@@ -111,8 +104,7 @@ class PbTensor {
   /// \param dims_shm Tensor dimensions
   /// \param pb_string Triton dtype
   PbTensor(
-      AllocatedSharedMemory<TensorShm>& tensor_shm,
-      AllocatedSharedMemory<int64_t>& dims_shm,
+      AllocatedSharedMemory<char>& tensor_shm,
       std::unique_ptr<PbString>& name_shm,
       std::unique_ptr<PbMemory>& pb_memory);
 
@@ -198,9 +190,6 @@ class PbTensor {
   /// \return A vector containing the tensor dimensions.
   const std::vector<int64_t>& Dims() const;
 
-  // Release the ownership of this tensor.
-  void Release();
-
   PbTensor();
 
   /// Destructor
@@ -223,12 +212,9 @@ class PbTensor {
 
   bi::managed_external_buffer::handle_t shm_handle_;
 
-  AllocatedSharedMemory<TensorShm> tensor_shm_;
+  AllocatedSharedMemory<char> tensor_shm_;
   TensorShm* tensor_shm_ptr_;
-
-  AllocatedSharedMemory<int64_t> dims_shm_;
   int64_t* dims_shm_ptr_;
-
   std::unique_ptr<PbString> name_shm_;
 
   // The pointer is null when the object is not stored in shared memory.

--- a/src/pb_tensor.h
+++ b/src/pb_tensor.h
@@ -67,11 +67,6 @@ struct TensorShm {
 };
 
 // PbTensor class is the representation of Triton tensors inside Python backend.
-// Once the `SaveToSharedMemory` function is called, class attributes and the
-// actual data that is stored in shared memory can become out of sync. Because
-// of this most of the class attributes cannot be changed after a Tensor
-// is created. The only exceptions are `SetName`, `SetMemoryType`, and
-// `SetMemoryTypeId`.
 class PbTensor {
  public:
 #ifdef TRITON_PB_STUB

--- a/src/pb_tensor.h
+++ b/src/pb_tensor.h
@@ -53,15 +53,15 @@ namespace triton { namespace backend { namespace python {
 // Represents a Tensor object in shared memory.
 //
 struct TensorShm {
-  // Offset for the pointer data in shared memory.
+  // Handle for the pointer data in shared memory.
   bi::managed_external_buffer::handle_t memory;
 
-  // Offset for name field.
+  // Handle for name field.
   bi::managed_external_buffer::handle_t name;
 
   TRITONSERVER_DataType dtype;
 
-  // Shared memory offset for the dimensions.
+  // Shared memory handle for the dimensions.
   bi::managed_external_buffer::handle_t dims;
   size_t dims_count;
 };
@@ -101,14 +101,14 @@ class PbTensor {
   /// \param memory_ptr Pointer to the location of the data. Data must be
   /// contiguous and in C-order.
   /// \param byte_size Total number of bytes that the tensor uses.
-  /// \param shm_offset The shared memory offset of pointer if it is stored in
+  /// \param shm_handle The shared memory handle of pointer if it is stored in
   /// shared memory.
   PbTensor(
       const std::string& name, const std::vector<int64_t>& dims,
       TRITONSERVER_DataType dtype, TRITONSERVER_MemoryType memory_type,
       int64_t memory_type_id, void* memory_ptr, uint64_t byte_size,
       DLManagedTensor* dl_managed_tensor = nullptr,
-      bi::managed_external_buffer::handle_t shm_offset = 0);
+      bi::managed_external_buffer::handle_t shm_handle = 0);
 
   /// This constructor is used when
   /// loading the tensor from shared memory.
@@ -151,11 +151,11 @@ class PbTensor {
   /// \param name Name of the tensor.
   void SetName(const std::string& name);
 
-  bi::managed_external_buffer::handle_t ShmOffset();
+  bi::managed_external_buffer::handle_t ShmHandle();
 
   static std::shared_ptr<PbTensor> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t tensor_offset);
+      bi::managed_external_buffer::handle_t tensor_handle);
 
 #ifdef TRITON_PB_STUB
   /// Get NumPy representation of the tensor.
@@ -226,7 +226,7 @@ class PbTensor {
   uint64_t byte_size_;
   DLManagedTensor* dl_managed_tensor_;
 
-  bi::managed_external_buffer::handle_t shm_offset_;
+  bi::managed_external_buffer::handle_t shm_handle_;
 
   AllocatedSharedMemory<TensorShm> tensor_shm_;
   TensorShm* tensor_shm_ptr_;

--- a/src/pb_utils.cc
+++ b/src/pb_utils.cc
@@ -44,7 +44,6 @@
 #include <memory>
 #include <string>
 #include <unordered_map>
-#include "shm_manager.h"
 
 #ifdef TRITON_ENABLE_GPU
 #include <cuda.h>

--- a/src/pb_utils.cc
+++ b/src/pb_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -121,22 +121,6 @@ struct IPCControlShm {
   bi::managed_external_buffer::handle_t parent_message_queue;
 };
 
-
-//
-// Represents a Tensor object that will be passed to Python code.
-//
-struct Tensor {
-  // Offset for raw data field.
-  off_t raw_data;
-  // Offset for name field.
-  off_t name;
-  TRITONSERVER_DataType dtype;
-  // Shared memory offset for the dimensions.
-  off_t dims;
-  size_t dims_count;
-  bool is_cuda_handle_set;
-};
-
 struct ResponseShm {
   // Offset for Tensor output.
   off_t outputs;

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -121,16 +121,6 @@ struct IPCControlShm {
   bi::managed_external_buffer::handle_t parent_message_queue;
 };
 
-struct ResponseShm {
-  // Offset for Tensor output.
-  off_t outputs;
-  uint32_t outputs_size;
-  off_t error;
-  bool has_error;
-  // Indicates whether this error has a message or not.
-  bool is_error_set;
-};
-
 struct ResponseBatch {
   // Offset for response object.
   off_t responses;

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -76,6 +76,15 @@ namespace bi = boost::interprocess;
     }                                                                     \
   } while (false)
 
+#define THROW_IF_CUDA_ERROR(X)                          \
+  do {                                                  \
+    cudaError_t cuda_err__ = (X);                       \
+    if (cuda_err__ != cudaSuccess) {                    \
+      throw PythonBackendException(                     \
+          std::string(cudaGetErrorString(cuda_err__))); \
+    }                                                   \
+  } while (false)
+
 #define THROW_IF_ERROR(MSG, X)           \
   do {                                   \
     int return__ = (X);                  \
@@ -83,6 +92,13 @@ namespace bi = boost::interprocess;
       throw PythonBackendException(MSG); \
     }                                    \
   } while (false)
+
+
+#define DISALLOW_COPY(TypeName) TypeName(const TypeName&) = delete;
+#define DISALLOW_ASSIGN(TypeName) void operator=(const TypeName&) = delete;
+#define DISALLOW_COPY_AND_ASSIGN(TypeName) \
+  DISALLOW_COPY(TypeName)                  \
+  DISALLOW_ASSIGN(TypeName)
 
 struct InitializeResponseShm {
   // Indicates whether the response has an error or not.
@@ -105,16 +121,6 @@ struct IPCControlShm {
   bi::managed_external_buffer::handle_t parent_message_queue;
 };
 
-//
-// Represents a memory object in shared memory.
-//
-struct MemoryShm {
-  bi::managed_external_buffer::handle_t memory_ptr;
-  uint64_t offset;
-  TRITONSERVER_MemoryType memory_type;
-  int64_t memory_type_id;
-  uint64_t byte_size;
-};
 
 //
 // Represents a Tensor object that will be passed to Python code.

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -50,12 +50,12 @@ namespace bi = boost::interprocess;
       (X);                                                         \
     }                                                              \
     catch (cont PythonBackendException & pb_exception) {           \
-      off_t string_offset__;                                       \
+      bi::managed_external_buffer::handle_t string_handle__;       \
       try {                                                        \
         SaveStringToSharedMemory(                                  \
-            SHM_POOL, string_offset__, pb_exception.what());       \
+            SHM_POOL, string_handle__, pb_exception.what());       \
         RESPONSE->has_error = true;                                \
-        RESPONSE->error = string_offset__;                         \
+        RESPONSE->error = string_handle__;                         \
         if (R)                                                     \
           return;                                                  \
       }                                                            \
@@ -122,10 +122,10 @@ struct IPCControlShm {
 };
 
 struct ResponseBatch {
-  // Offset for response object.
-  off_t responses;
+  // Handle for response object.
+  bi::managed_external_buffer::handle_t responses;
   uint32_t batch_size;
-  off_t error;
+  bi::managed_external_buffer::handle_t error;
   bool has_error;
   // Indicates whether an additional call to stub is required for the clean up
   // of the resources.
@@ -135,8 +135,8 @@ struct ResponseBatch {
 };
 
 struct RequestBatch {
-  // Offset for request object.
-  off_t requests;
+  // Handle for request object.
+  bi::managed_external_buffer::handle_t requests;
   uint32_t batch_size;
 };
 

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -122,8 +122,6 @@ struct IPCControlShm {
 };
 
 struct ResponseBatch {
-  // Handle for response object.
-  bi::managed_external_buffer::handle_t responses;
   uint32_t batch_size;
   bi::managed_external_buffer::handle_t error;
   bool has_error;
@@ -135,8 +133,6 @@ struct ResponseBatch {
 };
 
 struct RequestBatch {
-  // Handle for request object.
-  bi::managed_external_buffer::handle_t requests;
   uint32_t batch_size;
 };
 

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -31,11 +31,11 @@
 #endif  // TRITON_ENABLE_GPU
 #include <pthread.h>
 #include <climits>
-#include <exception>
 #include <memory>
 #include <string>
 #include <unordered_map>
 #include <vector>
+#include "pb_exception.h"
 #include "shm_manager.h"
 #include "triton/backend/backend_common.h"
 #include "triton/core/tritonserver.h"
@@ -138,19 +138,6 @@ struct RequestBatch {
   // Offset for request object.
   off_t requests;
   uint32_t batch_size;
-};
-
-//
-// PythonBackendException
-//
-// Exception thrown if error occurs in PythonBackend.
-//
-struct PythonBackendException : std::exception {
-  PythonBackendException(std::string message) : message_(message) {}
-
-  const char* what() const throw() { return message_.c_str(); }
-
-  std::string message_;
 };
 
 #ifdef TRITON_ENABLE_GPU

--- a/src/python.cc
+++ b/src/python.cc
@@ -832,7 +832,7 @@ ModelInstanceState::GetInputTensor(
 #endif  // TRITON_ENABLE_GPU
 
   if (cpu_only_tensors || src_memory_type != TRITONSERVER_MEMORY_GPU) {
-    input_tensor = std::make_unique<PbTensor>(
+    input_tensor = std::make_shared<PbTensor>(
         std::string(input_name),
         std::vector<int64_t>(input_shape, input_shape + input_dims_count),
         input_dtype, TRITONSERVER_MEMORY_CPU /* memory_type */,
@@ -853,7 +853,7 @@ ModelInstanceState::GetInputTensor(
         input_name, nullptr, 0, alloc_perference,
         reinterpret_cast<const char**>(&buffer), &input_byte_size,
         &src_memory_type, &src_memory_type_id));
-    input_tensor = std::make_unique<PbTensor>(
+    input_tensor = std::make_shared<PbTensor>(
         std::string(input_name),
         std::vector<int64_t>(input_shape, input_shape + input_dims_count),
         input_dtype, src_memory_type, src_memory_type_id,
@@ -1046,6 +1046,7 @@ ModelInstanceState::ProcessRequests(
 
     RESPOND_ALL_AND_RETURN_IF_EXCEPTION(
         responses, request_count, infer_request->SaveToSharedMemory(shm_pool_));
+    (requests_shm.data_.get())[r] = infer_request->ShmOffset();
     pb_inference_requests.emplace_back(std::move(infer_request));
   }
 

--- a/src/python.cc
+++ b/src/python.cc
@@ -1063,6 +1063,11 @@ ModelInstanceState::ProcessRequests(
   SendMessageAndReceiveResponse(
       ipc_message->ShmOffset(), response_message, restart, responses, requests,
       request_count);
+
+  defer _(nullptr, std::bind([this, &restart] {
+            if (!restart)
+              stub_message_queue_->Push(1000);
+          }));
   if (restart) {
     return;
   }
@@ -1071,8 +1076,6 @@ ModelInstanceState::ProcessRequests(
       responses, request_count,
       ipc_message =
           IPCMessage::LoadFromSharedMemory(shm_pool_, response_message));
-
-  defer _(nullptr, std::bind([this] { stub_message_queue_->Push(1000); }));
 
   uint64_t compute_end_ns = 0;
   SET_TIMESTAMP(compute_end_ns);

--- a/src/python.cc
+++ b/src/python.cc
@@ -226,7 +226,6 @@ class ModelState : public BackendModel {
   bool force_cpu_only_input_tensors_;
 };
 
-
 class ModelInstanceState : public BackendModelInstance {
   ModelInstanceState(
       ModelState* model_state, TRITONBACKEND_ModelInstance* model_instance);
@@ -651,7 +650,7 @@ ModelInstanceState::StartStubProcess()
             PbString::LoadFromSharedMemory(
                 shm_pool_, initialize_response->response_error);
         return TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INTERNAL, error_message->String());
+            TRITONSERVER_ERROR_INTERNAL, error_message->String().c_str());
       } else {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INTERNAL,
@@ -1107,7 +1106,8 @@ ModelInstanceState::ProcessRequests(
           error_message_shm = PbString::LoadFromSharedMemory(
               shm_pool_, response_batch.data_->error));
       RespondErrorToAllRequests(
-          error_message_shm->String(), responses, requests, request_count);
+          error_message_shm->String().c_str(), responses, requests,
+          request_count);
     } else {
       const char* error_message =
           "Failed to fetch the error in response batch.";

--- a/src/python.cc
+++ b/src/python.cc
@@ -1123,7 +1123,6 @@ ModelInstanceState::ProcessRequests(
       reinterpret_cast<bi::managed_external_buffer::handle_t*>(
           response_batch.data_.get() + sizeof(ResponseBatch));
 
-
   for (uint32_t r = 0; r < request_count; ++r) {
     NVTX_RANGE(nvtx_, "LoadingResponse " + Name());
     TRITONBACKEND_Response* response = (*responses)[r];

--- a/src/python.cc
+++ b/src/python.cc
@@ -680,10 +680,13 @@ ModelInstanceState::SetupStubProcess()
       std::to_string(model_state->StateForBackend()->number_of_instance_inits);
   int64_t shm_default_size =
       model_state->StateForBackend()->shm_default_byte_size;
+  int64_t shm_growth_byte_size =
+      model_state->StateForBackend()->shm_growth_byte_size;
 
   try {
     shm_pool_ = std::make_unique<SharedMemoryManager>(
-        shm_region_name_, shm_default_size, true /* create */);
+        shm_region_name_, shm_default_size, shm_growth_byte_size,
+        true /* create */);
   }
   catch (const PythonBackendException& pb_exception) {
     return TRITONSERVER_ErrorNew(

--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -132,6 +132,7 @@ SharedMemoryManager::FreeMemory()
   return managed_buffer_->get_free_memory();
 }
 
+
 SharedMemoryManager::~SharedMemoryManager() noexcept(false)
 {
   bi::shared_memory_object::remove(shm_region_name_.c_str());

--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -132,7 +132,6 @@ SharedMemoryManager::FreeMemory()
   return managed_buffer_->get_free_memory();
 }
 
-
 SharedMemoryManager::~SharedMemoryManager() noexcept(false)
 {
   bi::shared_memory_object::remove(shm_region_name_.c_str());

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -27,7 +27,10 @@
 #include <sys/wait.h>
 #include <boost/interprocess/allocators/allocator.hpp>
 #include <boost/interprocess/managed_external_buffer.hpp>
+#include <iostream>
 #include <memory>
+#include <type_traits>
+#include <typeinfo>
 #include <vector>
 
 #pragma once

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -72,8 +72,8 @@ class SharedMemoryManager {
 
     {
       bi::scoped_lock<bi::interprocess_mutex> gaurd{*shm_mutex_};
-      GrowIfNeeded(sizeof(AllocatedShmOwnership));
       GrowIfNeeded(sizeof(T) * count);
+      GrowIfNeeded(sizeof(AllocatedShmOwnership));
       if (!aligned) {
         obj =
             reinterpret_cast<T*>(managed_buffer_->allocate(sizeof(T) * count));
@@ -96,11 +96,6 @@ class SharedMemoryManager {
     }
 
     return WrapObjectInUniquePtr(obj, shm_ownership_data, handle);
-  }
-
-  std::unique_ptr<bi::managed_external_buffer>& ManagedBuffer()
-  {
-    return managed_buffer_;
   }
 
   template <typename T>

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -132,8 +132,7 @@ class SharedMemoryManager {
     }
 
     {
-      // bi::scoped_lock<bi::interprocess_mutex>
-      // gaurd{shm_ownership_data->mutex_};
+      bi::scoped_lock<bi::interprocess_mutex> gaurd{shm_ownership_data->mutex_};
       shm_ownership_data->ref_count_ += 1;
     }
 


### PR DESCRIPTION
Performance results before and after these changes:

|  Scenario  |  Latency  (before) |  Throughput (before)  | Latency  (after) |  Throughput (after)  |
|:--- |:--- | :--- |:--- | :--- |
| 16mb_latency_grpc | 39.714 | 25.2 |  40.229 | 25.0 |
| 16mb_latency_http | 41.374 |  24.2 |  47.424 | 21.0 |
| 16mb_throughput_grpc |  145.534 |  110.2 |  145.975 | 109.6 |
| 16mb_throughput_http |  404.136 |    38.4  |   291.94 |   52.8 |
| max_throughput_grpc | 1.481 |  10772.8 |  2.299 |  6948.6 ⬇️  |
| max_throughput_http |   1.02 |  15603.6 |   1.666 |  9573.0 ⬇️  |
| min_latency_grpc |   0.386 |  2562.0 |   0.481 |  2062.6  ⬇️ |
| min_latency_http | 0.443 |   2237.8 |   0.454 |   2185.8 ⬇️ |

It looks like there is a significant slowdown for the small tensor no model benchmarks but the performance for large payload seems to be on par with before.

## Update: The numbers below are collected using the C-API
|  Scenario  |  Latency  (before) |  Throughput (before)  | Latency  (after) |  Throughput (after)  |
|:--- |:--- | :--- |:--- | :--- |
| 16mb_latency | 11624 (us) | 86 infer/sec |  11684 usec |   85.6 infer/sec  |
| 16mb_throughput | 96059  (us) |  166.4 infer/sec  |  95579 (us)  |167.2 infer/sec |
| max_throughput |  972 (us) |  **16435.4 infer/sec**  |1078 (us)  |   **14824.4 infer/sec** |
| min_latency |   136 (us) |  **7323.4 infer/sec** | 163 (us) |  **6092.2 infer/sec** | 

Still there is a gap but the results are much closer now to the previous numbers. The PA number without the C-API for `max_throughput_http` is  for 12766.8 infer/sec throughput.  This is up from 9573.0 in the previous results.