### PR TITLE
Implement the new shared memory interface

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -36,6 +36,7 @@ project(tritonpythonbackend LANGUAGES C CXX)
 #
 option(TRITON_ENABLE_GPU "Enable GPU support in backend" ON)
 option(TRITON_ENABLE_STATS "Include statistics collections in backend" ON)
+option(TRITON_ENABLE_NVTX "Include nvtx markers collection in backend." OFF)
 
 set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/backend repo")
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
@@ -115,6 +116,10 @@ elseif()
   message(WARNING "TRITON_ENABLE_GPU is OFF, GPU Tensor support will be disabled")
 endif() # TRITON_ENABLE_GPU
 
+if(${TRITON_ENABLE_NVTX})
+  add_definitions(-DTRITON_ENABLE_NVTX=1)
+endif() # TRITON_ENABLE_NVTX
+
 find_package(ZLIB REQUIRED)
 find_package(Threads REQUIRED)
 
@@ -131,14 +136,23 @@ set(
   src/message_queue.h
   src/ipc_message.cc
   src/ipc_message.h
+  src/pb_string.cc
+  src/pb_string.h
+  src/pb_map.cc
+  src/pb_map.h
+  src/scoped_defer.cc
+  src/scoped_defer.h
   src/pb_error.cc
   src/pb_error.h
+  src/pb_memory.cc
+  src/pb_memory.h
   src/pb_tensor.cc
   src/pb_tensor.h
   src/pb_utils.cc
   src/pb_utils.h
   src/shm_manager.cc
   src/shm_manager.h
+  src/pb_exception.h
 )
 
 set(
@@ -146,10 +160,10 @@ set(
   src/python.cc
   src/pb_env.cc
   src/pb_env.h
-  src/pb_main_utils.cc
-  src/pb_main_utils.h
   src/pb_metric_reporter.cc
   src/pb_metric_reporter.h
+  src/request_executor.cc
+  src/request_executor.h
 )
 
 list(APPEND
@@ -164,10 +178,10 @@ add_library(
 
 set(
   PYTHNON_BACKEND_STUB_SRCS
-  src/pb_stub_utils.cc
   src/pb_stub_utils.h
-  src/pb_stub.cc
+  src/pb_stub_utils.cc
   src/pb_stub.h
+  src/pb_stub.cc
 )
 
 list(APPEND

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,11 +25,11 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #include "infer_request.h"
-#include <boost/interprocess/sync/scoped_lock.hpp>
 
+#include <boost/interprocess/sync/scoped_lock.hpp>
 #include "pb_utils.h"
+#include "scoped_defer.h"
 #ifdef TRITON_PB_STUB
-#include "infer_response.h"
 #include "pb_stub.h"
 #endif
 
@@ -95,77 +95,187 @@ InferRequest::SetFlags(uint32_t flags)
   flags_ = flags;
 }
 
-void
-InferRequest::SaveToSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, Request* request_shm)
+bi::managed_external_buffer::handle_t
+InferRequest::ShmHandle()
 {
-  request_shm->correlation_id = this->CorrelationId();
-  off_t id_offset;
-  SaveStringToSharedMemory(shm_pool, id_offset, this->RequestId().c_str());
-  request_shm->id = id_offset;
-  request_shm->requested_output_count = this->RequestedOutputNames().size();
-  off_t requested_output_names_offset;
-  off_t* requested_output_names;
-  shm_pool->Map(
-      (char**)&requested_output_names,
-      sizeof(off_t) * request_shm->requested_output_count,
-      requested_output_names_offset);
-  request_shm->flags = Flags();
+  return shm_handle_;
+}
 
-  request_shm->requested_output_names = requested_output_names_offset;
+void
+InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
+{
+  AllocatedSharedMemory<char> infer_request_shm = shm_pool->Construct<char>(
+      sizeof(InferRequestShm) +
+      (RequestedOutputNames().size() *
+       sizeof(bi::managed_external_buffer::handle_t)) +
+      (Inputs().size() * sizeof(bi::managed_external_buffer::handle_t)) +
+      PbString::ShmStructSize(ModelName()) +
+      PbString::ShmStructSize(RequestId()));
+
+  infer_request_shm_ptr_ =
+      reinterpret_cast<InferRequestShm*>(infer_request_shm.data_.get());
+  infer_request_shm_ptr_->correlation_id = CorrelationId();
+  infer_request_shm_ptr_->input_count = Inputs().size();
+  infer_request_shm_ptr_->model_version = model_version_;
+  infer_request_shm_ptr_->requested_output_count =
+      RequestedOutputNames().size();
+  infer_request_shm_ptr_->flags = Flags();
+
+  output_names_handle_shm_ptr_ =
+      reinterpret_cast<bi::managed_external_buffer::handle_t*>(
+          reinterpret_cast<char*>(infer_request_shm_ptr_) +
+          sizeof(InferRequestShm));
+
+  // [FIXME] This could also be a part of the single allocated memory for this
+  // object.
   size_t i = 0;
+  std::vector<std::unique_ptr<PbString>> requested_output_names_shm;
   for (auto& requested_output_name : requested_output_names_) {
-    SaveStringToSharedMemory(
-        shm_pool, requested_output_names[i], requested_output_name.c_str());
+    std::unique_ptr<PbString> requested_output_name_shm =
+        PbString::Create(shm_pool, requested_output_name);
+    output_names_handle_shm_ptr_[i] = requested_output_name_shm->ShmHandle();
+    requested_output_names_shm.emplace_back(
+        std::move(requested_output_name_shm));
     i++;
   }
 
-  request_shm->requested_input_count = this->Inputs().size();
-  request_shm->model_version = this->model_version_;
-  SaveStringToSharedMemory(
-      shm_pool, request_shm->model_name, this->model_name_.c_str());
+  input_tensors_handle_ptr_ =
+      reinterpret_cast<bi::managed_external_buffer::handle_t*>(
+          reinterpret_cast<char*>(output_names_handle_shm_ptr_) +
+          sizeof(bi::managed_external_buffer::handle_t) *
+              RequestedOutputNames().size());
+  i = 0;
+  for (auto& input : Inputs()) {
+    input_tensors_handle_ptr_[i] = input->ShmHandle();
+    i++;
+  }
+
+  size_t model_name_offset =
+      sizeof(InferRequestShm) +
+      (RequestedOutputNames().size() *
+       sizeof(bi::managed_external_buffer::handle_t)) +
+      (Inputs().size() * sizeof(bi::managed_external_buffer::handle_t));
+
+  std::unique_ptr<PbString> model_name_shm = PbString::Create(
+      ModelName(),
+      reinterpret_cast<char*>(infer_request_shm_ptr_) + model_name_offset,
+      infer_request_shm.handle_ + model_name_offset);
+
+  size_t request_id_offset =
+      model_name_offset + PbString::ShmStructSize(ModelName());
+  std::unique_ptr<PbString> request_id_shm = PbString::Create(
+      RequestId(),
+      reinterpret_cast<char*>(infer_request_shm_ptr_) + request_id_offset,
+      infer_request_shm.handle_ + request_id_offset);
+
+  // Save the references to shared memory.
+  infer_request_shm_ = std::move(infer_request_shm);
+  request_id_shm_ = std::move(request_id_shm);
+  model_name_shm_ = std::move(model_name_shm);
+  shm_handle_ = infer_request_shm_.handle_;
+  requested_output_names_shm_ = std::move(requested_output_names_shm);
 }
 
 std::unique_ptr<InferRequest>
 InferRequest::LoadFromSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, off_t request_offset,
-    std::shared_ptr<std::mutex>& cuda_ipc_open_mutex,
-    std::shared_ptr<std::mutex>& cuda_ipc_close_mutex)
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t request_handle, bool open_cuda_handle)
 {
-  Request* request;
-  shm_pool->MapOffset((char**)&request, request_offset);
+  AllocatedSharedMemory<char> infer_request_shm =
+      shm_pool->Load<char>(request_handle);
+  InferRequestShm* infer_request_shm_ptr =
+      reinterpret_cast<InferRequestShm*>(infer_request_shm.data_.get());
 
-  char* id = nullptr;
-  LoadStringFromSharedMemory(shm_pool, request->id, id);
+  std::vector<std::unique_ptr<PbString>> requested_output_names_shm;
+  uint32_t requested_output_count =
+      infer_request_shm_ptr->requested_output_count;
 
-  uint32_t requested_input_count = request->requested_input_count;
-
-  std::vector<std::shared_ptr<PbTensor>> py_input_tensors;
-  for (size_t input_idx = 0; input_idx < requested_input_count; ++input_idx) {
-    std::shared_ptr<PbTensor> pb_input_tensor = PbTensor::LoadFromSharedMemory(
-        shm_pool, request->inputs + sizeof(Tensor) * input_idx,
-        cuda_ipc_open_mutex, cuda_ipc_close_mutex);
-    py_input_tensors.emplace_back(std::move(pb_input_tensor));
-  }
-
-  std::vector<std::string> requested_output_names;
-  uint32_t requested_output_count = request->requested_output_count;
-  off_t* output_names;
-  shm_pool->MapOffset((char**)&output_names, request->requested_output_names);
+  bi::managed_external_buffer::handle_t* output_names_handle_shm_ptr =
+      reinterpret_cast<bi::managed_external_buffer::handle_t*>(
+          (reinterpret_cast<char*>(infer_request_shm_ptr) +
+           sizeof(InferRequestShm)));
 
   for (size_t output_idx = 0; output_idx < requested_output_count;
        ++output_idx) {
-    char* output_name = nullptr;
-    LoadStringFromSharedMemory(shm_pool, output_names[output_idx], output_name);
-    requested_output_names.emplace_back(output_name);
+    std::unique_ptr<PbString> pb_string = PbString::LoadFromSharedMemory(
+        shm_pool, output_names_handle_shm_ptr[output_idx]);
+    requested_output_names_shm.emplace_back(std::move(pb_string));
   }
 
-  char* model_name;
-  LoadStringFromSharedMemory(shm_pool, request->model_name, model_name);
-  return std::make_unique<InferRequest>(
-      id, request->correlation_id, std::move(py_input_tensors),
-      requested_output_names, model_name, request->model_version,
-      request->flags);
+  bi::managed_external_buffer::handle_t* input_names_handle_shm_ptr =
+      reinterpret_cast<bi::managed_external_buffer::handle_t*>(
+          (reinterpret_cast<char*>(infer_request_shm_ptr) +
+           sizeof(InferRequestShm) +
+           (infer_request_shm_ptr->requested_output_count *
+            sizeof(bi::managed_external_buffer::handle_t))));
+
+  std::vector<std::shared_ptr<PbTensor>> input_tensors;
+  for (size_t input_idx = 0; input_idx < infer_request_shm_ptr->input_count;
+       ++input_idx) {
+    std::shared_ptr<PbTensor> input_tensor = PbTensor::LoadFromSharedMemory(
+        shm_pool, input_names_handle_shm_ptr[input_idx], open_cuda_handle);
+    input_tensors.emplace_back(std::move(input_tensor));
+  }
+
+  size_t model_name_offset =
+      sizeof(InferRequestShm) +
+      (requested_output_count * sizeof(bi::managed_external_buffer::handle_t)) +
+      (infer_request_shm_ptr->input_count *
+       sizeof(bi::managed_external_buffer::handle_t));
+
+  std::unique_ptr<PbString> model_name_shm = PbString::LoadFromSharedMemory(
+      request_handle + model_name_offset,
+      reinterpret_cast<char*>(infer_request_shm_ptr) + model_name_offset);
+
+  size_t request_id_offset = model_name_offset + model_name_shm->Size();
+  std::unique_ptr<PbString> request_id_shm = PbString::LoadFromSharedMemory(
+      request_handle + request_id_offset,
+      reinterpret_cast<char*>(infer_request_shm_ptr) + request_id_offset);
+
+  return std::unique_ptr<InferRequest>(new InferRequest(
+      infer_request_shm, request_id_shm, requested_output_names_shm,
+      model_name_shm, input_tensors));
+}
+
+InferRequest::InferRequest(
+    AllocatedSharedMemory<char>& infer_request_shm,
+    std::unique_ptr<PbString>& request_id_shm,
+    std::vector<std::unique_ptr<PbString>>& requested_output_names_shm,
+    std::unique_ptr<PbString>& model_name_shm,
+    std::vector<std::shared_ptr<PbTensor>>& input_tensors)
+    : infer_request_shm_(std::move(infer_request_shm)),
+      request_id_shm_(std::move(request_id_shm)),
+      requested_output_names_shm_(std::move(requested_output_names_shm)),
+      model_name_shm_(std::move(model_name_shm))
+{
+  infer_request_shm_ptr_ =
+      reinterpret_cast<InferRequestShm*>(infer_request_shm_.data_.get());
+  output_names_handle_shm_ptr_ =
+      reinterpret_cast<bi::managed_external_buffer::handle_t*>(
+          reinterpret_cast<char*>(infer_request_shm_ptr_) +
+          sizeof(InferRequestShm));
+  input_tensors_handle_ptr_ =
+      reinterpret_cast<bi::managed_external_buffer::handle_t*>(
+          reinterpret_cast<char*>(infer_request_shm_ptr_) +
+          sizeof(InferRequestShm) +
+          sizeof(bi::managed_external_buffer::handle_t) *
+              infer_request_shm_ptr_->requested_output_count);
+  inputs_ = std::move(input_tensors);
+
+  std::vector<std::string> requested_output_names;
+  for (size_t output_idx = 0;
+       output_idx < infer_request_shm_ptr_->requested_output_count;
+       ++output_idx) {
+    auto& pb_string = requested_output_names_shm_[output_idx];
+    requested_output_names.emplace_back(pb_string->String());
+  }
+
+  request_id_ = request_id_shm_->String();
+  requested_output_names_ = std::move(requested_output_names);
+  model_name_ = model_name_shm_->String();
+  flags_ = infer_request_shm_ptr_->flags;
+  model_version_ = infer_request_shm_ptr_->model_version;
+  correlation_id_ = infer_request_shm_ptr_->correlation_id;
 }
 
 #ifdef TRITON_PB_STUB
@@ -175,44 +285,57 @@ InferRequest::Exec()
   ResponseBatch* response_batch = nullptr;
   bool responses_is_set = false;
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
-  std::unique_ptr<SharedMemory>& shm_pool = stub->GetSharedMemory();
+  std::unique_ptr<SharedMemoryManager>& shm_pool = stub->SharedMemory();
+  bi::managed_external_buffer::handle_t* response_handle = nullptr;
+
+  PythonBackendException pb_exception(std::string{});
+  std::unique_ptr<IPCMessage> ipc_message;
+
+  AllocatedSharedMemory<char> request_batch;
+  ScopedDefer data_load_complete(std::bind([&ipc_message] {
+    bi::scoped_lock<bi::interprocess_mutex> lock{
+        *(ipc_message->ResponseMutex())};
+    ipc_message->ResponseCondition()->notify_all();
+  }));
 
   try {
     py::gil_scoped_release release;
-    std::unique_ptr<IPCMessage> ipc_message =
-        std::make_unique<IPCMessage>(shm_pool, true /* inline_response */);
+    ipc_message = IPCMessage::Create(shm_pool, true /* inline_response */);
     bool has_exception = false;
     PythonBackendException pb_exception(std::string{});
 
     ipc_message->Command() =
         PYTHONSTUB_CommandType::PYTHONSTUB_InferExecRequest;
 
-    RequestBatch* request_batch;
-    shm_pool->Map(
-        (char**)&request_batch, sizeof(RequestBatch), ipc_message->Args());
-    request_batch->batch_size = 1;
+    request_batch = shm_pool->Construct<char>(
+        sizeof(RequestBatch) + sizeof(bi::managed_external_buffer::handle_t));
 
-    Request* request;
-    shm_pool->Map((char**)&request, sizeof(Request), request_batch->requests);
+    RequestBatch* request_batch_shm_ptr =
+        reinterpret_cast<RequestBatch*>(request_batch.data_.get());
+    request_batch_shm_ptr->batch_size = 1;
+    ipc_message->Args() = request_batch.handle_;
 
-    request->requested_input_count = this->Inputs().size();
-    Tensor* tensors;
+    bi::managed_external_buffer::handle_t* requests_shm =
+        reinterpret_cast<bi::managed_external_buffer::handle_t*>(
+            request_batch.data_.get() + sizeof(RequestBatch));
+    request_batch_shm_ptr->batch_size = 1;
+
     bool has_gpu_tensor = false;
-    shm_pool->Map(
-        (char**)&tensors, sizeof(Tensor) * request->requested_input_count,
-        request->inputs);
-
     size_t i = 0;
     for (auto& input_tensor : inputs_) {
-      input_tensor->SaveToSharedMemory(
-          shm_pool, &tensors[i], true /* copy_cpu */, false /* copy_gpu */);
+      input_tensor->SaveToSharedMemory(shm_pool, false /* copy_gpu */);
       if (!input_tensor->IsCPU()) {
         has_gpu_tensor = true;
       }
       ++i;
     }
 
-    SaveToSharedMemory(shm_pool, request);
+    SaveToSharedMemory(shm_pool);
+
+    // Save the shared memory offset of the request.
+    *requests_shm = ShmHandle();
+
+    // Send the BLS request to the parent process and wait for the response.
     {
       bi::scoped_lock<bi::interprocess_mutex> lock{
           *(ipc_message->ResponseMutex())};
@@ -220,21 +343,31 @@ InferRequest::Exec()
       ipc_message->ResponseCondition()->wait(lock);
     }
 
+    // Additional round trip required for asking the stub process
+    // to fill in the GPU tensor buffers
     if (has_gpu_tensor) {
+      AllocatedSharedMemory<bi::managed_external_buffer::handle_t>
+          gpu_buffers_handle =
+              shm_pool->Load<bi::managed_external_buffer::handle_t>(
+                  request_batch_shm_ptr->gpu_buffers_handle);
       try {
+#ifdef TRITON_ENABLE_GPU
+        size_t i = 0;
         for (auto& input_tensor : this->Inputs()) {
           if (!input_tensor->IsCPU()) {
-#ifdef TRITON_ENABLE_GPU
-            input_tensor->SetCudaIpcMutexes(
-                stub->CudaIpcOpenMutex(), stub->CudaIpcCloseMutex());
-            input_tensor->LoadGPUData(shm_pool);
-#endif  // TRITON_ENABLE_GPU
+            std::unique_ptr<PbMemory> dst_buffer =
+                PbMemory::LoadFromSharedMemory(
+                    shm_pool, (gpu_buffers_handle.data_.get())[i],
+                    true /* open cuda handle */);
+            PbMemory::CopyBuffer(dst_buffer, input_tensor->Memory());
+            ++i;
           }
         }
+#endif  // TRITON_ENABLE_GPU
       }
       catch (const PythonBackendException& exception) {
         // We need to catch the exception here. Otherwise, we will not notify
-        // the main process and it will wait for the resposne forever.
+        // the main process and it will wait for the response forever.
         pb_exception = exception;
         has_exception = true;
       }
@@ -255,17 +388,23 @@ InferRequest::Exec()
 
     // Get the response for the current message.
     std::unique_ptr<IPCMessage> bls_response = IPCMessage::LoadFromSharedMemory(
-        shm_pool, ipc_message->RequestOffset());
-    shm_pool->MapOffset((char**)&response_batch, bls_response->Args());
-    responses_is_set = true;
+        shm_pool, ipc_message->ResponseHandle());
 
+    AllocatedSharedMemory<char> response_batch_shm =
+        shm_pool->Load<char>(bls_response->Args());
+    response_batch =
+        reinterpret_cast<ResponseBatch*>(response_batch_shm.data_.get());
+    response_handle = reinterpret_cast<bi::managed_external_buffer::handle_t*>(
+        response_batch_shm.data_.get() + sizeof(ResponseBatch));
+
+    responses_is_set = true;
     if (response_batch->has_error) {
       if (response_batch->is_error_set) {
-        char* err_string;
-        LoadStringFromSharedMemory(shm_pool, response_batch->error, err_string);
+        std::unique_ptr<PbString> pb_string =
+            PbString::LoadFromSharedMemory(shm_pool, response_batch->error);
         return std::make_unique<InferResponse>(
             std::vector<std::shared_ptr<PbTensor>>{},
-            std::make_shared<PbError>(err_string));
+            std::make_shared<PbError>(pb_string->String()));
       } else {
         return std::make_unique<InferResponse>(
             std::vector<std::shared_ptr<PbTensor>>{},
@@ -283,8 +422,7 @@ InferRequest::Exec()
   if (responses_is_set) {
     std::unique_ptr<InferResponse> infer_response =
         InferResponse::LoadFromSharedMemory(
-            shm_pool, response_batch->responses, stub->CudaIpcOpenMutex(),
-            stub->CudaIpcCloseMutex());
+            shm_pool, *response_handle, true /* open cuda handle */);
 
     return infer_response;
   } else {
@@ -296,4 +434,5 @@ InferRequest::Exec()
 }
 
 #endif
+
 }}}  // namespace triton::backend::python

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -31,15 +31,19 @@
 #include "pb_tensor.h"
 
 namespace triton { namespace backend { namespace python {
-class InferRequest {
-  std::string request_id_;
-  uint64_t correlation_id_;
-  std::vector<std::shared_ptr<PbTensor>> inputs_;
-  std::vector<std::string> requested_output_names_;
-  std::string model_name_;
-  int64_t model_version_;
-  uint32_t flags_;
 
+//
+// Inference Request
+//
+struct InferRequestShm {
+  uint64_t correlation_id;
+  uint32_t input_count;
+  uint32_t requested_output_count;
+  int64_t model_version;
+  uint32_t flags;
+};
+
+class InferRequest {
  public:
   InferRequest(
       const std::string& request_id, uint64_t correlation_id,
@@ -56,23 +60,59 @@ class InferRequest {
   uint32_t Flags();
   void SetFlags(uint32_t flags);
   const std::vector<std::string>& RequestedOutputNames();
+  bi::managed_external_buffer::handle_t ShmHandle();
 
-  /// Save an Inference Request to shared memory.
-  /// \param shm_pool Shared memory pool to save the inference request.
-  /// \param request_shm A pointer to a location in shared memory with enough
-  /// space to save the inference request.
-  void SaveToSharedMemory(
-      std::unique_ptr<SharedMemory>& shm_pool, Request* request_shm);
-
-  /// Create an Inference Request object from shared memory.
-  /// \param shm_pool Shared memory pool
-  /// \param request_offset Shared memory offset of the request.
-  static std::unique_ptr<InferRequest> LoadFromSharedMemory(
-      std::unique_ptr<SharedMemory>& shm_pool, off_t request_offset,
-      std::shared_ptr<std::mutex>& cuda_ipc_open_mutex,
-      std::shared_ptr<std::mutex>& cuda_ipc_close_mutex);
 #ifdef TRITON_PB_STUB
   std::unique_ptr<InferResponse> Exec();
 #endif
+
+  /// Save an Inference Request to shared memory.
+  /// \param shm_pool Shared memory pool to save the inference request.
+  void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
+
+  /// Create an Inference Request object from shared memory.
+  /// \param shm_pool Shared memory pool
+  /// \param request_handle Shared memory handle of the request.
+  /// \param open_cuda_handle Determines if the tensor in the infer request
+  /// object is a GPU tensor, to call the cudaIpcOpenMemHandle to obtain the
+  /// tensor or not.
+  /// \return Returns the infer request in the specified request_handle
+  /// location.
+  static std::unique_ptr<InferRequest> LoadFromSharedMemory(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      bi::managed_external_buffer::handle_t request_handle,
+      bool open_cuda_handle);
+
+  /// Disallow copying the inference request object.
+  DISALLOW_COPY_AND_ASSIGN(InferRequest);
+
+  ~InferRequest() {}
+
+ private:
+  InferRequest(
+      AllocatedSharedMemory<char>& infer_request_shm,
+      std::unique_ptr<PbString>& request_id_shm,
+      std::vector<std::unique_ptr<PbString>>& requested_output_names_shm,
+      std::unique_ptr<PbString>& model_name_shm,
+      std::vector<std::shared_ptr<PbTensor>>& input_tensors);
+
+  std::string request_id_;
+  uint64_t correlation_id_;
+  std::vector<std::shared_ptr<PbTensor>> inputs_;
+  std::vector<std::string> requested_output_names_;
+  std::string model_name_;
+  int64_t model_version_;
+  uint32_t flags_;
+
+  // Shared Memory Data Structures
+  AllocatedSharedMemory<char> infer_request_shm_;
+  InferRequestShm* infer_request_shm_ptr_;
+
+  std::unique_ptr<PbString> request_id_shm_;
+  std::vector<std::unique_ptr<PbString>> requested_output_names_shm_;
+  std::unique_ptr<PbString> model_name_shm_;
+  bi::managed_external_buffer::handle_t* output_names_handle_shm_ptr_;
+  bi::managed_external_buffer::handle_t* input_tensors_handle_ptr_;
+  bi::managed_external_buffer::handle_t shm_handle_;
 };
 }}};  // namespace triton::backend::python

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -52,87 +52,100 @@ InferResponse::HasError()
   return error_.get() != nullptr;
 }
 
-bool
-InferResponse::IsErrorMessageSet()
-{
-  return is_message_set_;
-}
-
 void
 InferResponse::SaveToSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, Response* response_shm,
-    bool copy_cpu, bool copy_gpu)
+    std::unique_ptr<SharedMemoryManager>& shm_pool, bool copy_gpu)
 {
   size_t output_tensor_length = output_tensors_.size();
-  response_shm->has_error = false;
-  response_shm->is_error_set = false;
+  if (HasError()) {
+    response_shm_ = shm_pool->Construct<char>(sizeof(ResponseShm));
+  } else {
+    response_shm_ = shm_pool->Construct<char>(
+        sizeof(ResponseShm) +
+        output_tensor_length * sizeof(bi::managed_external_buffer::handle_t));
+  }
+
+  ResponseShm* response_shm_ptr =
+      reinterpret_cast<ResponseShm*>(response_shm_.data_.get());
+  response_shm_ptr->has_error = false;
+  response_shm_ptr->is_error_set = false;
+  shm_handle_ = response_shm_.handle_;
 
   // Only save the output tensors to shared memory when the inference response
   // doesn't have error.
-  if (this->HasError()) {
-    response_shm->has_error = true;
-    off_t error_offset;
-    SaveStringToSharedMemory(
-        shm_pool, error_offset, this->Error()->Message().c_str());
-    response_shm->is_error_set = true;
-    response_shm->error = error_offset;
-    response_shm->outputs_size = 0;
+  if (HasError()) {
+    response_shm_ptr->has_error = true;
+    Error()->SaveToSharedMemory(shm_pool);
+
+    response_shm_ptr->is_error_set = true;
+    response_shm_ptr->error = Error()->ShmHandle();
+    response_shm_ptr->outputs_size = 0;
   } else {
-    Tensor* output_tensors_shm;
-    off_t output_tensors_offset;
-    shm_pool->Map(
-        (char**)&output_tensors_shm, sizeof(Tensor) * output_tensor_length,
-        output_tensors_offset);
-    response_shm->outputs = output_tensors_offset;
-    response_shm->outputs_size = output_tensor_length;
+    bi::managed_external_buffer::handle_t* tensor_handle_shm_ptr =
+        reinterpret_cast<bi::managed_external_buffer::handle_t*>(
+            response_shm_.data_.get() + sizeof(ResponseShm));
+    response_shm_ptr->outputs_size = output_tensor_length;
 
     size_t j = 0;
     for (auto& output_tensor : output_tensors_) {
-      Tensor* output_tensor_shm = &output_tensors_shm[j];
-      output_tensor->SaveToSharedMemory(
-          shm_pool, output_tensor_shm, copy_cpu, copy_gpu);
+      output_tensor->SaveToSharedMemory(shm_pool, copy_gpu);
+      tensor_handle_shm_ptr[j] = output_tensor->ShmHandle();
       j++;
     }
   }
 }
 
+bi::managed_external_buffer::handle_t
+InferResponse::ShmHandle()
+{
+  return shm_handle_;
+}
+
 std::unique_ptr<InferResponse>
 InferResponse::LoadFromSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, off_t response_offset,
-    std::shared_ptr<std::mutex>& cuda_ipc_open_mutex,
-    std::shared_ptr<std::mutex>& cuda_ipc_close_mutex)
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t response_handle,
+    bool open_cuda_handle)
 {
-  Response* response;
-  shm_pool->MapOffset((char**)&response, response_offset);
-  uint32_t requested_output_count = response->outputs_size;
+  AllocatedSharedMemory<char> response_shm =
+      shm_pool->Load<char>(response_handle);
+  ResponseShm* response_shm_ptr =
+      reinterpret_cast<ResponseShm*>(response_shm.data_.get());
+  uint32_t requested_output_count = response_shm_ptr->outputs_size;
 
   std::shared_ptr<PbError> pb_error;
-  std::vector<std::shared_ptr<PbTensor>> py_output_tensors;
+  std::vector<std::shared_ptr<PbTensor>> output_tensors;
 
   // If the error field is set, do not load output tensors from shared memory.
-  if (response->has_error) {
-    pb_error = std::make_shared<PbError>("");
-
-    char* error_string;
-    if (response->is_error_set) {
-      LoadStringFromSharedMemory(shm_pool, response->error, error_string);
-      pb_error = std::make_shared<PbError>(error_string);
-    }
+  if (response_shm_ptr->has_error && response_shm_ptr->is_error_set) {
+    pb_error = PbError::LoadFromSharedMemory(shm_pool, response_shm_ptr->error);
+  } else if (response_shm_ptr->has_error && !response_shm_ptr->is_error_set) {
+    pb_error =
+        std::make_shared<PbError>("Failed to retrieve the response error.");
   } else {
+    bi::managed_external_buffer::handle_t* tensor_handle_shm =
+        reinterpret_cast<bi::managed_external_buffer::handle_t*>(
+            response_shm.data_.get() + sizeof(ResponseShm));
     for (size_t idx = 0; idx < requested_output_count; ++idx) {
       std::shared_ptr<PbTensor> pb_tensor = PbTensor::LoadFromSharedMemory(
-          shm_pool, response->outputs + sizeof(Tensor) * idx,
-          cuda_ipc_open_mutex, cuda_ipc_close_mutex);
-      py_output_tensors.emplace_back(std::move(pb_tensor));
+          shm_pool, tensor_handle_shm[idx], open_cuda_handle);
+      output_tensors.emplace_back(std::move(pb_tensor));
     }
   }
 
-  std::unique_ptr<InferResponse> infer_response =
-      std::make_unique<InferResponse>(py_output_tensors, pb_error);
-  if (response->is_error_set)
-    infer_response->is_message_set_ = true;
+  return std::unique_ptr<InferResponse>(
+      new InferResponse(response_shm, output_tensors, pb_error));
+}
 
-  return infer_response;
+InferResponse::InferResponse(
+    AllocatedSharedMemory<char>& response_shm,
+    std::vector<std::shared_ptr<PbTensor>>& output_tensors,
+    std::shared_ptr<PbError>& pb_error)
+{
+  response_shm_ = std::move(response_shm);
+  output_tensors_ = std::move(output_tensors);
+  error_ = std::move(pb_error);
+  shm_handle_ = response_shm_.handle_;
 }
 
 std::shared_ptr<PbError>&

--- a/src/ipc_message.cc
+++ b/src/ipc_message.cc
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -29,61 +29,124 @@
 #include <memory>
 
 namespace triton { namespace backend { namespace python {
+std::unique_ptr<IPCMessage>
+IPCMessage::Create(
+    const std::unique_ptr<SharedMemoryManager>& shm_pool, bool inline_response)
+{
+  AllocatedSharedMemory<IPCMessageShm> ipc_message_shm =
+      shm_pool->Construct<IPCMessageShm>();
+
+  ipc_message_shm.data_->inline_response = inline_response;
+  AllocatedSharedMemory<bi::interprocess_mutex> response_mutex_shm;
+  AllocatedSharedMemory<bi::interprocess_condition> response_cond_shm;
+  if (inline_response) {
+    response_mutex_shm = std::move(shm_pool->Construct<bi::interprocess_mutex>(
+        1 /* count */, true /* aligned */));
+    response_cond_shm =
+        std::move(shm_pool->Construct<bi::interprocess_condition>(
+            1 /* count */, true /* aligned */));
+
+    ipc_message_shm.data_->response_mutex = response_mutex_shm.handle_;
+    ipc_message_shm.data_->response_cond = response_cond_shm.handle_;
+    new (response_mutex_shm.data_.get()) bi::interprocess_mutex{};
+    new (response_cond_shm.data_.get()) bi::interprocess_condition{};
+  }
+
+  return std::unique_ptr<IPCMessage>(
+      new IPCMessage(ipc_message_shm, response_mutex_shm, response_cond_shm));
+}
 
 std::unique_ptr<IPCMessage>
 IPCMessage::LoadFromSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, off_t message_offset)
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t message_handle)
 {
-  std::unique_ptr<IPCMessage> ipc_message = std::make_unique<IPCMessage>();
-  ipc_message->shm_offset_ = message_offset;
-  shm_pool->MapOffset((char**)&ipc_message->ipc_message_shm_, message_offset);
+  AllocatedSharedMemory<IPCMessageShm> ipc_message_shm =
+      shm_pool->Load<IPCMessageShm>(message_handle);
 
-  if (ipc_message->ipc_message_shm_->inline_response) {
-    shm_pool->MapOffset(
-        (char**)&ipc_message->response_mutex_,
-        ipc_message->ipc_message_shm_->response_mutex);
-    shm_pool->MapOffset(
-        (char**)&ipc_message->response_cond_,
-        ipc_message->ipc_message_shm_->response_cond);
+  AllocatedSharedMemory<bi::interprocess_mutex> response_mutex_shm;
+  AllocatedSharedMemory<bi::interprocess_condition> response_cond_shm;
+  if (ipc_message_shm.data_->inline_response) {
+    response_mutex_shm = shm_pool->Load<bi::interprocess_mutex>(
+        ipc_message_shm.data_->response_mutex);
+    response_cond_shm = shm_pool->Load<bi::interprocess_condition>(
+        ipc_message_shm.data_->response_cond);
   }
 
-  return ipc_message;
+  return std::unique_ptr<IPCMessage>(
+      new IPCMessage(ipc_message_shm, response_mutex_shm, response_cond_shm));
 }
 
 PYTHONSTUB_CommandType&
 IPCMessage::Command()
 {
-  return ipc_message_shm_->command;
+  return ipc_message_shm_ptr_->command;
 }
 
-off_t&
+bi::managed_external_buffer::handle_t&
 IPCMessage::Args()
 {
-  return ipc_message_shm_->args;
+  return ipc_message_shm_ptr_->args;
 }
 
 bool&
 IPCMessage::InlineResponse()
 {
-  return ipc_message_shm_->inline_response;
+  return ipc_message_shm_ptr_->inline_response;
 }
 
 bi::interprocess_condition*
 IPCMessage::ResponseCondition()
 {
-  return response_cond_;
+  return response_cond_shm_ptr_;
 }
 
 bi::interprocess_mutex*
 IPCMessage::ResponseMutex()
 {
-  return response_mutex_;
+  return response_mutex_shm_ptr_;
 }
 
-off_t&
-IPCMessage::RequestOffset()
+bi::managed_external_buffer::handle_t&
+IPCMessage::ResponseHandle()
 {
-  return this->ipc_message_shm_->request_offset;
+  return ipc_message_shm_ptr_->response_handle;
+}
+
+bi::managed_external_buffer::handle_t
+IPCMessage::ShmHandle()
+{
+  return ipc_message_handle_;
+}
+
+IPCMessage::IPCMessage(
+    AllocatedSharedMemory<IPCMessageShm>& ipc_message_shm,
+    AllocatedSharedMemory<bi::interprocess_mutex>& response_mutex_shm,
+    AllocatedSharedMemory<bi::interprocess_condition>& response_cond_shm)
+    : ipc_message_shm_(std::move(ipc_message_shm)),
+      response_mutex_shm_(std::move(response_mutex_shm)),
+      response_cond_shm_(std::move(response_cond_shm))
+{
+  ipc_message_shm_ptr_ = ipc_message_shm_.data_.get();
+  response_mutex_shm_ptr_ = response_mutex_shm_.data_.get();
+  response_cond_shm_ptr_ = response_cond_shm_.data_.get();
+  ipc_message_handle_ = ipc_message_shm_.handle_;
+}
+
+void
+IPCMessage::Release()
+{
+  if (ipc_message_shm_.data_ != nullptr) {
+    ipc_message_shm_.data_.release();
+  }
+
+  if (response_mutex_shm_.data_ != nullptr) {
+    response_mutex_shm_.data_.release();
+  }
+
+  if (response_cond_shm_.data_ != nullptr) {
+    response_cond_shm_.data_.release();
+  }
 }
 
 }}};  // namespace triton::backend::python

--- a/src/message_queue.cc
+++ b/src/message_queue.cc
@@ -1,4 +1,4 @@
-// Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -29,52 +29,53 @@
 #include <boost/interprocess/sync/scoped_lock.hpp>
 #include <boost/thread/thread_time.hpp>
 #include <iostream>
-#include "ipc_message.h"
-#include "pb_utils.h"
 
 namespace triton { namespace backend { namespace python {
-MessageQueue::MessageQueue(
-    std::unique_ptr<SharedMemory>& shm_pool, std::size_t number_of_messages)
+
+std::unique_ptr<MessageQueue>
+MessageQueue::Create(
+    std::unique_ptr<SharedMemoryManager>& shm_pool, uint32_t message_queue_size)
 {
-  MessageQueueShm* message_queue_shm;
-  shm_pool->Map(
-      (char**)&message_queue_shm, sizeof(MessageQueueShm), shm_struct_);
+  AllocatedSharedMemory<MessageQueueShm> mq_shm =
+      shm_pool->Construct<MessageQueueShm>();
+  mq_shm.data_->size = message_queue_size;
 
-  message_queue_shm->size = number_of_messages;
-  size_ = &(message_queue_shm->size);
+  AllocatedSharedMemory<bi::managed_external_buffer::handle_t> mq_buffer_shm =
+      shm_pool->Construct<bi::managed_external_buffer::handle_t>(
+          message_queue_size);
+  mq_shm.data_->buffer = mq_buffer_shm.handle_;
+  mq_shm.data_->head = 0;
+  mq_shm.data_->tail = 0;
 
-  message_queue_shm->index = 0;
-  index_ = &(message_queue_shm->index);
+  new (&(mq_shm.data_->mutex)) bi::interprocess_mutex{};
+  new (&(mq_shm.data_->sem_empty))
+      bi::interprocess_semaphore{message_queue_size};
+  new (&(mq_shm.data_->sem_full)) bi::interprocess_semaphore{0};
 
-  shm_pool->Map(
-      (char**)&sem_full_, sizeof(bi::interprocess_semaphore),
-      message_queue_shm->sem_full);
-  shm_pool->Map(
-      (char**)&sem_empty_, sizeof(bi::interprocess_semaphore),
-      message_queue_shm->sem_empty);
+  return std::unique_ptr<MessageQueue>(new MessageQueue(mq_shm, mq_buffer_shm));
+}
 
-  new (sem_full_) bi::interprocess_semaphore(0);
-  new (sem_empty_) bi::interprocess_semaphore(number_of_messages);
-
-  shm_pool->Map(
-      (char**)&mutex_, sizeof(bi::interprocess_mutex),
-      message_queue_shm->mutex);
-  new (mutex_) bi::interprocess_mutex;
-
-  shm_pool->Map(
-      (char**)&buffer_, sizeof(off_t) * number_of_messages,
-      message_queue_shm->buffer);
+MessageQueue::MessageQueue(
+    AllocatedSharedMemory<MessageQueueShm>& mq_shm,
+    AllocatedSharedMemory<bi::managed_external_buffer::handle_t>& mq_buffer_shm)
+    : mq_shm_(std::move(mq_shm)), mq_buffer_shm_(std::move(mq_buffer_shm))
+{
+  mq_buffer_shm_ptr_ = mq_buffer_shm_.data_.get();
+  mq_shm_ptr_ = mq_shm_.data_.get();
+  mq_handle_ = mq_shm_.handle_;
 }
 
 void
-MessageQueue::Push(off_t message, int const& duration, bool& success)
+MessageQueue::Push(
+    bi::managed_external_buffer::handle_t message, int const& duration,
+    bool& success)
 {
   boost::system_time timeout =
       boost::get_system_time() + boost::posix_time::milliseconds(duration);
 
   while (true) {
     try {
-      if (!sem_empty_->timed_wait(timeout)) {
+      if (!SemEmptyMutable()->timed_wait(timeout)) {
         success = false;
         return;
       } else {
@@ -88,26 +89,26 @@ MessageQueue::Push(off_t message, int const& duration, bool& success)
   {
     timeout =
         boost::get_system_time() + boost::posix_time::milliseconds(duration);
-    bi::scoped_lock<bi::interprocess_mutex> lock{*mutex_, timeout};
+    bi::scoped_lock<bi::interprocess_mutex> lock{*MutexMutable(), timeout};
     if (!lock) {
-      sem_empty_->post();
+      SemEmptyMutable()->post();
       success = false;
       return;
     }
     success = true;
 
-    buffer_[*index_] = message;
-    (*index_)++;
+    Buffer()[Head()] = message;
+    HeadIncrement();
   }
-  sem_full_->post();
+  SemFullMutable()->post();
 }
 
 void
-MessageQueue::Push(off_t message)
+MessageQueue::Push(bi::managed_external_buffer::handle_t message)
 {
   while (true) {
     try {
-      sem_empty_->wait();
+      SemEmptyMutable()->wait();
       break;
     }
     catch (bi::interprocess_exception& ex) {
@@ -115,27 +116,21 @@ MessageQueue::Push(off_t message)
   }
 
   {
-    bi::scoped_lock<bi::interprocess_mutex> lock{*mutex_};
-    buffer_[*index_] = message;
-    (*index_)++;
+    bi::scoped_lock<bi::interprocess_mutex> lock{*MutexMutable()};
+    Buffer()[Head()] = message;
+    HeadIncrement();
   }
-  sem_full_->post();
+  SemFullMutable()->post();
 }
 
-off_t
-MessageQueue::ShmOffset()
-{
-  return shm_struct_;
-}
-
-off_t
+bi::managed_external_buffer::handle_t
 MessageQueue::Pop()
 {
-  off_t message;
+  bi::managed_external_buffer::handle_t message;
 
   while (true) {
     try {
-      sem_full_->wait();
+      SemFullMutable()->wait();
       break;
     }
     catch (bi::interprocess_exception& ex) {
@@ -143,25 +138,38 @@ MessageQueue::Pop()
   }
 
   {
-    bi::scoped_lock<bi::interprocess_mutex> lock{*mutex_};
-    message = buffer_[*index_ - 1];
-    (*index_)--;
+    bi::scoped_lock<bi::interprocess_mutex> lock{*MutexMutable()};
+
+    message = Buffer()[Tail()];
+    TailIncrement();
   }
-  sem_empty_->post();
+  SemEmptyMutable()->post();
 
   return message;
 }
 
-off_t
+void
+MessageQueue::HeadIncrement()
+{
+  mq_shm_ptr_->head = (mq_shm_ptr_->head + 1) % Size();
+}
+
+void
+MessageQueue::TailIncrement()
+{
+  mq_shm_ptr_->tail = (mq_shm_ptr_->tail + 1) % Size();
+}
+
+bi::managed_external_buffer::handle_t
 MessageQueue::Pop(int const& duration, bool& success)
 {
-  off_t message = 0;
+  bi::managed_external_buffer::handle_t message = 0;
   boost::system_time timeout =
       boost::get_system_time() + boost::posix_time::milliseconds(duration);
 
   while (true) {
     try {
-      if (!sem_full_->timed_wait(timeout)) {
+      if (!SemFullMutable()->timed_wait(timeout)) {
         success = false;
         return message;
       } else {
@@ -175,18 +183,18 @@ MessageQueue::Pop(int const& duration, bool& success)
   {
     timeout =
         boost::get_system_time() + boost::posix_time::milliseconds(duration);
-    bi::scoped_lock<bi::interprocess_mutex> lock{*mutex_, timeout};
+    bi::scoped_lock<bi::interprocess_mutex> lock{*MutexMutable(), timeout};
     if (!lock) {
-      sem_full_->post();
+      SemFullMutable()->post();
       success = false;
       return message;
     }
     success = true;
 
-    message = buffer_[*index_ - 1];
-    (*index_)--;
+    message = Buffer()[Tail()];
+    TailIncrement();
   }
-  sem_empty_->post();
+  SemEmptyMutable()->post();
 
   return message;
 }
@@ -194,31 +202,42 @@ MessageQueue::Pop(int const& duration, bool& success)
 void
 MessageQueue::ResetSemaphores()
 {
-  new (sem_full_) bi::interprocess_semaphore(0);
-  new (sem_empty_) bi::interprocess_semaphore(*size_);
-  new (mutex_) bi::interprocess_mutex;
+  new (SemFullMutable()) bi::interprocess_semaphore(0);
+  new (SemEmptyMutable()) bi::interprocess_semaphore(Size());
+  new (MutexMutable()) bi::interprocess_mutex;
+  mq_shm_ptr_->tail = 0;
+  mq_shm_ptr_->head = 0;
 }
 
 std::unique_ptr<MessageQueue>
 MessageQueue::LoadFromSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, off_t message_queue_offset)
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t message_queue_handle)
 {
-  std::unique_ptr<MessageQueue> message_queue =
-      std::make_unique<MessageQueue>();
-  MessageQueueShm* message_queue_shm;
-  shm_pool->MapOffset((char**)&message_queue_shm, message_queue_offset);
-  message_queue->size_ = &(message_queue_shm->size);
-  message_queue->index_ = &(message_queue_shm->index);
+  AllocatedSharedMemory<MessageQueueShm> mq_shm =
+      shm_pool->Load<MessageQueueShm>(message_queue_handle);
+  AllocatedSharedMemory<bi::managed_external_buffer::handle_t> mq_shm_buffer =
+      shm_pool->Load<bi::managed_external_buffer::handle_t>(
+          mq_shm.data_->buffer);
 
-  shm_pool->MapOffset((char**)&message_queue->mutex_, message_queue_shm->mutex);
-  shm_pool->MapOffset(
-      (char**)&message_queue->sem_full_, message_queue_shm->sem_full);
-  shm_pool->MapOffset(
-      (char**)&message_queue->sem_empty_, message_queue_shm->sem_empty);
-  shm_pool->MapOffset(
-      (char**)&message_queue->buffer_, message_queue_shm->buffer);
-  message_queue->shm_struct_ = message_queue_offset;
-  return message_queue;
+  return std::unique_ptr<MessageQueue>(new MessageQueue(mq_shm, mq_shm_buffer));
 }
 
+bi::managed_external_buffer::handle_t
+MessageQueue::ShmHandle()
+{
+  return mq_handle_;
+}
+
+void
+MessageQueue::Release()
+{
+  if (mq_shm_.data_ != nullptr) {
+    mq_shm_.data_.release();
+  }
+
+  if (mq_buffer_shm_.data_ != nullptr) {
+    mq_buffer_shm_.data_.release();
+  }
+}
 }}}  // namespace triton::backend::python

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -36,6 +36,127 @@
 
 
 namespace triton { namespace backend { namespace python {
+
+void
+CopySingleArchiveEntry(archive* input_archive, archive* output_archive)
+{
+  const void* buff;
+  size_t size;
+#if ARCHIVE_VERSION_NUMBER >= 3000000
+  int64_t offset;
+#else
+  off_t offset;
+#endif
+
+  for (;;) {
+    int return_status;
+    return_status =
+        archive_read_data_block(input_archive, &buff, &size, &offset);
+    if (return_status == ARCHIVE_EOF)
+      break;
+    if (return_status != ARCHIVE_OK)
+      throw PythonBackendException(
+          "archive_read_data_block() failed with error code = " +
+          std::to_string(return_status));
+
+    return_status =
+        archive_write_data_block(output_archive, buff, size, offset);
+    if (return_status != ARCHIVE_OK) {
+      throw PythonBackendException(
+          "archive_write_data_block() failed with error code = " +
+          std::to_string(return_status) + ", error message is " +
+          archive_error_string(output_archive));
+    }
+  }
+}
+
+
+void
+ExtractTarFile(std::string& archive_path, std::string& dst_path)
+{
+  char current_directory[PATH_MAX];
+  if (getcwd(current_directory, PATH_MAX) == nullptr) {
+    throw PythonBackendException(
+        (std::string("Failed to get the current working directory. Error: ") +
+         std::strerror(errno)));
+  }
+  if (chdir(dst_path.c_str()) == -1) {
+    throw PythonBackendException(
+        (std::string("Failed to change the directory to ") + dst_path +
+         " Error: " + std::strerror(errno))
+            .c_str());
+  }
+
+  struct archive_entry* entry;
+  int flags = ARCHIVE_EXTRACT_TIME;
+
+  struct archive* input_archive = archive_read_new();
+  struct archive* output_archive = archive_write_disk_new();
+  archive_write_disk_set_options(output_archive, flags);
+
+  archive_read_support_filter_gzip(input_archive);
+  archive_read_support_format_tar(input_archive);
+
+  if (archive_path.size() == 0) {
+    throw PythonBackendException("The archive path is empty.");
+  }
+
+  THROW_IF_ERROR(
+      "archive_read_open_filename() failed.",
+      archive_read_open_filename(
+          input_archive, archive_path.c_str(), 10240 /* block_size */));
+
+  while (true) {
+    int read_status = archive_read_next_header(input_archive, &entry);
+    if (read_status == ARCHIVE_EOF)
+      break;
+    if (read_status != ARCHIVE_OK) {
+      throw PythonBackendException(
+          std::string("archive_read_next_header() failed with error code = ") +
+          std::to_string(read_status) + std::string(" error message is ") +
+          archive_error_string(input_archive));
+    }
+
+    read_status = archive_write_header(output_archive, entry);
+    if (read_status != ARCHIVE_OK) {
+      throw PythonBackendException(std::string(
+          "archive_write_header() failed with error code = " +
+          std::to_string(read_status) + std::string(" error message is ") +
+          archive_error_string(output_archive)));
+    }
+
+    CopySingleArchiveEntry(input_archive, output_archive);
+
+    read_status = archive_write_finish_entry(output_archive);
+    if (read_status != ARCHIVE_OK) {
+      throw PythonBackendException(std::string(
+          "archive_write_finish_entry() failed with error code = " +
+          std::to_string(read_status) + std::string(" error message is ") +
+          archive_error_string(output_archive)));
+    }
+  }
+
+  archive_read_close(input_archive);
+  archive_read_free(input_archive);
+
+  archive_write_close(output_archive);
+  archive_write_free(output_archive);
+
+  // Revert the directory change.
+  if (chdir(current_directory) == -1) {
+    throw PythonBackendException(
+        (std::string("Failed to change the directory to ") + current_directory)
+            .c_str());
+  }
+}
+
+bool
+FileExists(std::string& path)
+{
+  struct stat buffer;
+  return stat(path.c_str(), &buffer) == 0;
+}
+
 
 void
 RecursiveDirectoryDelete(const char* dir)

--- a/src/pb_env.h
+++ b/src/pb_env.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION. All rights reserved.
+// Copyright (c) 2021-2022, NVIDIA CORPORATION. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -31,6 +31,10 @@
 #include <string>
 
 namespace triton { namespace backend { namespace python {
+
+void ExtractTarFile(std::string& archive_path, std::string& dst_path);
+
+bool FileExists(std::string& path);
 
 //
 // A class that manages Python environments

--- a/src/pb_error.h
+++ b/src/pb_error.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -27,13 +27,25 @@
 #pragma once
 
 #include <string>
+#include "pb_string.h"
+#include "pb_utils.h"
 
 namespace triton { namespace backend { namespace python {
 class PbError {
-  std::string message_;
-
  public:
   PbError(const std::string& message) : message_(message) {}
   const std::string& Message();
+  void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
+  bi::managed_external_buffer::handle_t ShmHandle();
+  static std::shared_ptr<PbError> LoadFromSharedMemory(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      bi::managed_external_buffer::handle_t handle);
+  DISALLOW_COPY_AND_ASSIGN(PbError);
+
+ private:
+  PbError(std::unique_ptr<PbString>& pb_error);
+  std::string message_;
+  std::shared_ptr<PbString> message_shm_;
+  bi::managed_external_buffer::handle_t shm_handle_;
 };
 }}};  // namespace triton::backend::python

--- a/src/pb_exception.h
+++ b/src/pb_exception.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,47 +26,21 @@
 
 #pragma once
 
-#include "pb_error.h"
-#include "pb_tensor.h"
-#include "pb_utils.h"
+#include <exception>
 
 namespace triton { namespace backend { namespace python {
 
-struct ResponseShm {
-  uint32_t outputs_size;
-  bi::managed_external_buffer::handle_t error;
-  bool has_error;
-  // Indicates whether this error has a message or not.
-  bool is_error_set;
+//
+// PythonBackendException
+//
+// Exception thrown if error occurs in PythonBackend.
+//
+struct PythonBackendException : std::exception {
+  PythonBackendException(const std::string& message) : message_(message) {}
+
+  const char* what() const throw() { return message_.c_str(); }
+
+  std::string message_;
 };
 
-class InferResponse {
- public:
-  InferResponse(
-      const std::vector<std::shared_ptr<PbTensor>>& output_tensors,
-      std::shared_ptr<PbError> error = nullptr);
-  std::vector<std::shared_ptr<PbTensor>>& OutputTensors();
-  void SaveToSharedMemory(
-      std::unique_ptr<SharedMemoryManager>& shm_pool, bool copy_gpu = true);
-  static std::unique_ptr<InferResponse> LoadFromSharedMemory(
-      std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t response_handle,
-      bool open_cuda_handle);
-  bool HasError();
-  std::shared_ptr<PbError>& Error();
-  bi::managed_external_buffer::handle_t ShmHandle();
-
-  // Disallow copying the inference response object.
-  DISALLOW_COPY_AND_ASSIGN(InferResponse);
-
- private:
-  InferResponse(
-      AllocatedSharedMemory<char>& response_shm,
-      std::vector<std::shared_ptr<PbTensor>>& output_tensors,
-      std::shared_ptr<PbError>& pb_error);
-  std::vector<std::shared_ptr<PbTensor>> output_tensors_;
-  std::shared_ptr<PbError> error_;
-  bi::managed_external_buffer::handle_t shm_handle_;
-  AllocatedSharedMemory<char> response_shm_;
-};
 }}}  // namespace triton::backend::python

--- a/src/pb_map.cc
+++ b/src/pb_map.cc
@@ -1,0 +1,110 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pb_map.h"
+
+namespace triton { namespace backend { namespace python {
+
+std::unique_ptr<PbMap>
+PbMap::Create(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    std::unordered_map<std::string, std::string>& map)
+{
+  std::vector<std::unique_ptr<PbString>> strings;
+  AllocatedSharedMemory<DictShm> dict_shm = shm_pool->Construct<DictShm>();
+  dict_shm.data_->length = map.size();
+
+  AllocatedSharedMemory<PairShm> pair_shms =
+      shm_pool->Construct<PairShm>(map.size());
+  dict_shm.data_->values = pair_shms.handle_;
+
+  size_t i = 0;
+  for (auto& pair : map) {
+    auto key = PbString::Create(shm_pool, pair.first);
+    auto value = PbString::Create(shm_pool, pair.second);
+
+    (pair_shms.data_.get())[i].key = key->ShmHandle();
+    (pair_shms.data_.get())[i].value = value->ShmHandle();
+
+    strings.emplace_back(std::move(key));
+    strings.emplace_back(std::move(value));
+    i++;
+  }
+
+  return std::unique_ptr<PbMap>(new PbMap(strings, dict_shm, pair_shms, map));
+}
+
+const std::unordered_map<std::string, std::string>&
+PbMap::UnorderedMap()
+{
+  return map_;
+}
+
+bi::managed_external_buffer::handle_t
+PbMap::ShmHandle()
+{
+  return dict_handle_;
+}
+
+std::unique_ptr<PbMap>
+PbMap::LoadFromSharedMemory(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t handle)
+{
+  AllocatedSharedMemory<DictShm> dict_shm = shm_pool->Load<DictShm>(handle);
+  AllocatedSharedMemory<PairShm> pair_shms =
+      shm_pool->Load<PairShm>(dict_shm.data_->values);
+
+  std::vector<std::unique_ptr<PbString>> pb_strings;
+  std::unordered_map<std::string, std::string> map;
+  for (size_t i = 0; i < dict_shm.data_->length; i++) {
+    std::unique_ptr<PbString> key = PbString::LoadFromSharedMemory(
+        shm_pool, (pair_shms.data_.get())[i].key);
+
+    std::unique_ptr<PbString> value = PbString::LoadFromSharedMemory(
+        shm_pool, (pair_shms.data_.get())[i].value);
+
+    map.insert({key->String(), value->String()});
+    pb_strings.emplace_back(std::move(key));
+    pb_strings.emplace_back(std::move(value));
+  }
+
+  return std::unique_ptr<PbMap>(
+      new PbMap(pb_strings, dict_shm, pair_shms, map));
+}
+
+PbMap::PbMap(
+    std::vector<std::unique_ptr<PbString>>& strings,
+    AllocatedSharedMemory<DictShm>& dict_shm,
+    AllocatedSharedMemory<PairShm>& pair_shms,
+    std::unordered_map<std::string, std::string>& map)
+    : strings_(std::move(strings)), dict_shm_(std::move(dict_shm)),
+      pair_shms_(std::move(pair_shms)), map_(std::move(map))
+{
+  dict_handle_ = dict_shm.handle_;
+}
+
+}}}  // namespace triton::backend::python

--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -1,0 +1,388 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pb_memory.h"
+
+namespace triton { namespace backend { namespace python {
+
+std::unique_ptr<PbMemory>
+PbMemory::Create(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+    uint64_t byte_size, char* data, bool copy_gpu)
+{
+  size_t requested_byte_size = sizeof(MemoryShm);
+
+  if (memory_type == TRITONSERVER_MEMORY_GPU) {
+#ifdef TRITON_ENABLE_GPU
+    requested_byte_size += sizeof(cudaIpcMemHandle_t);
+#endif
+  } else {
+    requested_byte_size += byte_size;
+  }
+
+  AllocatedSharedMemory<char> memory_shm =
+      shm_pool->Construct<char>(requested_byte_size);
+  PbMemory::FillShmData(
+      memory_type, memory_type_id, byte_size, data, memory_shm.data_.get(),
+      memory_shm.handle_, copy_gpu);
+
+  if (memory_type == TRITONSERVER_MEMORY_CPU) {
+    data = memory_shm.data_.get() + sizeof(MemoryShm);
+  }
+
+  std::unique_ptr<PbMemory> pb_memory(
+      new PbMemory(memory_shm, data, false /* opened_cuda_ipc_handle */));
+
+#ifdef TRITON_ENABLE_GPU
+  if (memory_type == TRITONSERVER_MEMORY_GPU) {
+    pb_memory->memory_shm_ptr_->gpu_pointer_offset =
+        pb_memory->GetGPUPointerOffset();
+  }
+#endif
+  return pb_memory;
+}
+
+#ifndef TRITON_PB_STUB
+std::unique_ptr<PbMemory>
+PbMemory::Create(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    std::unique_ptr<BackendMemory>&& backend_memory, bool copy_gpu)
+{
+  std::unique_ptr<PbMemory> pb_memory = PbMemory::Create(
+      shm_pool, backend_memory->MemoryType(), backend_memory->MemoryTypeId(),
+      backend_memory->ByteSize(), backend_memory->MemoryPtr(), copy_gpu);
+  pb_memory->backend_memory_ = std::move(backend_memory);
+
+  return pb_memory;
+}
+#endif
+
+std::unique_ptr<PbMemory>
+PbMemory::Create(
+    TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+    uint64_t byte_size, char* data, char* data_shm,
+    bi::managed_external_buffer::handle_t handle, bool copy_gpu)
+{
+  PbMemory::FillShmData(
+      memory_type, memory_type_id, byte_size, data, data_shm, handle, copy_gpu);
+
+  if (memory_type == TRITONSERVER_MEMORY_CPU) {
+    data = data_shm + sizeof(MemoryShm);
+  }
+
+  std::unique_ptr<PbMemory> pb_memory(
+      new PbMemory(data_shm, data, handle, false /* opened_cuda_ipc_handle */));
+
+#ifdef TRITON_ENABLE_GPU
+  if (memory_type == TRITONSERVER_MEMORY_GPU) {
+    pb_memory->memory_shm_ptr_->gpu_pointer_offset =
+        pb_memory->GetGPUPointerOffset();
+  }
+#endif
+
+  return pb_memory;
+}
+
+void
+PbMemory::CopyBuffer(
+    std::unique_ptr<PbMemory>& dst, std::unique_ptr<PbMemory>& src)
+{
+  if (src->ByteSize() != dst->ByteSize()) {
+    throw PythonBackendException(
+        "Failed to copy memory buffers. Source and destination byte size do "
+        "not match: " +
+        std::to_string(dst->ByteSize()) +
+        " != " + std::to_string(src->ByteSize()));
+  }
+
+  if (src->MemoryType() == TRITONSERVER_MEMORY_CPU &&
+      dst->MemoryType() == TRITONSERVER_MEMORY_CPU) {
+    std::memcpy(dst->DataPtr(), src->DataPtr(), dst->ByteSize());
+    return;
+  }
+
+#ifdef TRITON_ENABLE_GPU
+  cudaMemcpyKind kind = cudaMemcpyHostToDevice;
+
+  if (src->MemoryType() == TRITONSERVER_MEMORY_CPU &&
+      dst->MemoryType() == TRITONSERVER_MEMORY_GPU) {
+    kind = cudaMemcpyHostToDevice;
+  } else if (
+      src->MemoryType() == TRITONSERVER_MEMORY_GPU &&
+      dst->MemoryType() == TRITONSERVER_MEMORY_CPU) {
+    kind = cudaMemcpyDeviceToHost;
+  } else if (
+      src->MemoryType() == TRITONSERVER_MEMORY_GPU &&
+      dst->MemoryType() == TRITONSERVER_MEMORY_GPU) {
+    kind = cudaMemcpyDeviceToDevice;
+  }
+
+  cudaError_t err =
+      cudaMemcpy(dst->DataPtr(), src->DataPtr(), src->ByteSize(), kind);
+
+  if (err != cudaSuccess) {
+    throw PythonBackendException(
+        std::string(
+            "failed to copy data: " + std::string(cudaGetErrorString(err)))
+            .c_str());
+  }
+#endif
+}
+
+void
+PbMemory::FillShmData(
+    TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+    uint64_t byte_size, char* data, char* data_shm,
+    bi::managed_external_buffer::handle_t handle, bool copy_gpu)
+{
+  char* memory_data_shm = data_shm + sizeof(MemoryShm);
+  MemoryShm* memory_shm_ptr = reinterpret_cast<MemoryShm*>(data_shm);
+  memory_shm_ptr->is_cuda_handle_set = copy_gpu;
+
+  if (memory_type == TRITONSERVER_MEMORY_GPU) {
+#ifdef TRITON_ENABLE_GPU
+    if (data != nullptr) {
+      if (copy_gpu) {
+        // [FIXME] Restore the previous device
+        THROW_IF_CUDA_ERROR(cudaSetDevice(memory_type_id));
+        THROW_IF_CUDA_ERROR(cudaIpcGetMemHandle(
+            reinterpret_cast<cudaIpcMemHandle_t*>(memory_data_shm), data));
+      }
+    }
+#endif
+  } else {
+    if (data != nullptr) {
+      std::copy(data, data + byte_size, memory_data_shm);
+    }
+  }
+
+  memory_shm_ptr->byte_size = byte_size;
+  memory_shm_ptr->memory_type_id = memory_type_id;
+  memory_shm_ptr->memory_type = memory_type;
+}
+
+std::unique_ptr<PbMemory>
+PbMemory::LoadFromSharedMemory(
+    bi::managed_external_buffer::handle_t handle, char* data_shm,
+    bool open_cuda_handle)
+{
+  MemoryShm* memory_shm_ptr = reinterpret_cast<MemoryShm*>(data_shm);
+  char* memory_data_shm = data_shm + sizeof(MemoryShm);
+
+  char* data_ptr = nullptr;
+  bool opened_cuda_ipc_handle = false;
+  if (memory_shm_ptr->memory_type == TRITONSERVER_MEMORY_GPU &&
+      open_cuda_handle) {
+#ifdef TRITON_ENABLE_GPU
+    cudaIpcMemHandle_t* cuda_handle =
+        reinterpret_cast<cudaIpcMemHandle_t*>(memory_data_shm);
+
+    // The pointer opened by the cudaIpcOpenMemHandle will refer to the base
+    // address. We need to manually correct the offset.
+    void* data_ptr_base;
+    CUDAHandler& cuda_handler = CUDAHandler::getInstance();
+    cuda_handler.OpenCudaHandle(
+        memory_shm_ptr->memory_type_id, cuda_handle, &data_ptr_base);
+
+    data_ptr =
+        (reinterpret_cast<char*>(data_ptr_base) +
+         memory_shm_ptr->gpu_pointer_offset);
+    opened_cuda_ipc_handle = true;
+#endif
+  } else {
+    data_ptr = memory_data_shm;
+  }
+  return std::unique_ptr<PbMemory>(new PbMemory(
+      data_shm, data_ptr, handle,
+      opened_cuda_ipc_handle /* opened_cuda_ipc_handle */));
+}
+
+
+std::unique_ptr<PbMemory>
+PbMemory::LoadFromSharedMemory(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t handle, bool open_cuda_handle)
+{
+  AllocatedSharedMemory<char> memory_shm = shm_pool->Load<char>(handle);
+  MemoryShm* memory_shm_ptr =
+      reinterpret_cast<MemoryShm*>(memory_shm.data_.get());
+  char* memory_data_shm = memory_shm.data_.get() + sizeof(MemoryShm);
+
+  char* data_ptr = nullptr;
+  bool opened_cuda_ipc_handle = false;
+  if (memory_shm_ptr->memory_type == TRITONSERVER_MEMORY_GPU) {
+    if (memory_shm_ptr->byte_size > 0 && open_cuda_handle) {
+#ifdef TRITON_ENABLE_GPU
+      cudaIpcMemHandle_t* cuda_handle =
+          reinterpret_cast<cudaIpcMemHandle_t*>(memory_data_shm);
+
+      // The pointer opened by the cudaIpcOpenMemHandle will refer to the base
+      // address. We need to manually correct the offset.
+
+      void* data_ptr_base;
+      CUDAHandler& cuda_handler = CUDAHandler::getInstance();
+      cuda_handler.OpenCudaHandle(
+          memory_shm_ptr->memory_type_id, cuda_handle, &data_ptr_base);
+
+      data_ptr =
+          (reinterpret_cast<char*>(data_ptr_base) +
+           memory_shm_ptr->gpu_pointer_offset);
+      opened_cuda_ipc_handle = true;
+#endif
+    }
+  } else {
+    data_ptr = memory_data_shm;
+  }
+  return std::unique_ptr<PbMemory>(new PbMemory(
+      memory_shm, data_ptr,
+      opened_cuda_ipc_handle /* opened_cuda_ipc_handle */));
+}
+
+PbMemory::PbMemory(
+    AllocatedSharedMemory<char>& memory_shm, char* data,
+    bool opened_cuda_ipc_handle)
+    : memory_shm_(std::move(memory_shm)), data_ptr_(data),
+      opened_cuda_ipc_handle_(opened_cuda_ipc_handle)
+{
+  memory_shm_ptr_ = reinterpret_cast<MemoryShm*>(memory_shm_.data_.get());
+  memory_shm_handle_ = memory_shm_.handle_;
+}
+
+PbMemory::PbMemory(
+    char* memory_shm, char* data, bi::managed_external_buffer::handle_t handle,
+    bool opened_cuda_ipc_handle)
+{
+  memory_shm_ptr_ = reinterpret_cast<MemoryShm*>(memory_shm);
+  data_ptr_ = data;
+  opened_cuda_ipc_handle_ = opened_cuda_ipc_handle;
+  memory_shm_handle_ = handle;
+}
+
+bi::managed_external_buffer::handle_t
+PbMemory::ShmHandle()
+{
+  return memory_shm_handle_;
+}
+
+#ifdef TRITON_ENABLE_GPU
+void*
+PbMemory::GetGPUStartAddress()
+{
+  if (memory_shm_ptr_->memory_type == TRITONSERVER_MEMORY_GPU) {
+    CUDAHandler& cuda_api = CUDAHandler::getInstance();
+    CUdeviceptr start_address;
+
+    cuda_api.PointerGetAttribute(
+        &start_address, CU_POINTER_ATTRIBUTE_RANGE_START_ADDR,
+        reinterpret_cast<CUdeviceptr>(data_ptr_));
+
+    return reinterpret_cast<void*>(start_address);
+  }
+
+  throw PythonBackendException(
+      "Calling GetGPUStartAddress function on CPU memory.");
+}
+
+uint64_t
+PbMemory::GetGPUPointerOffset()
+{
+  uint64_t offset;
+  if (memory_shm_ptr_->memory_type == TRITONSERVER_MEMORY_GPU) {
+    offset = data_ptr_ - reinterpret_cast<char*>(GetGPUStartAddress());
+  } else {
+    throw PythonBackendException(
+        "Calling GetGPUPointerOffset function on CPU tensor.");
+  }
+  return offset;
+}
+#endif
+
+TRITONSERVER_MemoryType
+PbMemory::MemoryType() const
+{
+  return memory_shm_ptr_->memory_type;
+}
+
+int64_t
+PbMemory::MemoryTypeId() const
+{
+  return memory_shm_ptr_->memory_type_id;
+}
+
+uint64_t
+PbMemory::ByteSize() const
+{
+  return memory_shm_ptr_->byte_size;
+}
+
+char*
+PbMemory::ShmData() const
+{
+  return reinterpret_cast<char*>(memory_shm_ptr_) + sizeof(MemoryShm);
+}
+
+char*
+PbMemory::DataPtr() const
+{
+  return data_ptr_;
+}
+
+uint64_t
+PbMemory::ShmStructSize(TRITONSERVER_MemoryType memory_type, uint64_t byte_size)
+{
+  uint64_t total_memory_size = sizeof(MemoryShm);
+  if (memory_type == TRITONSERVER_MEMORY_GPU) {
+#ifdef TRITON_ENABLE_GPU
+    total_memory_size += sizeof(cudaIpcMemHandle_t);
+#endif
+  } else {
+    total_memory_size += byte_size;
+  }
+
+  return total_memory_size;
+}
+
+#ifdef TRITON_ENABLE_GPU
+void
+PbMemory::SetCudaIpcHandle(cudaIpcMemHandle_t* cuda_ipc_handle)
+{
+  *(reinterpret_cast<cudaIpcMemHandle_t*>(ShmData())) = *(cuda_ipc_handle);
+}
+#endif
+
+PbMemory::~PbMemory()
+{
+  if (opened_cuda_ipc_handle_) {
+#ifdef TRITON_ENABLE_GPU
+    CUDAHandler& cuda_handler = CUDAHandler::getInstance();
+    cuda_handler.CloseCudaHandle(
+        memory_shm_ptr_->memory_type_id, GetGPUStartAddress());
+#endif
+  }
+}
+
+}}}  // namespace triton::backend::python

--- a/src/pb_memory.h
+++ b/src/pb_memory.h
@@ -1,0 +1,155 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "pb_utils.h"
+#include "shm_manager.h"
+#include "triton/backend/backend_common.h"
+#include "triton/backend/backend_memory.h"
+
+#ifdef TRITON_ENABLE_GPU
+#include <cuda_runtime_api.h>
+#endif  // TRITON_ENABLE_GPU
+
+namespace triton { namespace backend { namespace python {
+
+//
+// Represents a memory object in shared memory.
+//
+struct MemoryShm {
+  // If the memory type is a GPU pointer, the offset of the GPU pointer from the
+  // base address. For CPU memory type this field contains garbage data.
+  uint64_t gpu_pointer_offset;
+
+  TRITONSERVER_MemoryType memory_type;
+  int64_t memory_type_id;
+  uint64_t byte_size;
+  bool is_cuda_handle_set;
+};
+
+class PbMemory {
+ public:
+  static std::unique_ptr<PbMemory> Create(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+      uint64_t byte_size, char* data, bool copy_gpu = true);
+
+  static std::unique_ptr<PbMemory> Create(
+      TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+      uint64_t byte_size, char* data, char* data_shm,
+      bi::managed_external_buffer::handle_t handle, bool copy_gpu = true);
+
+#ifndef TRITON_PB_STUB
+  static std::unique_ptr<PbMemory> Create(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      std::unique_ptr<BackendMemory>&& backend_memory, bool copy_gpu = true);
+#endif
+
+#ifdef TRITON_ENABLE_GPU
+  void SetCudaIpcHandle(cudaIpcMemHandle_t* cuda_ipc_handle);
+#endif
+
+  // Copy the destination buffer to the source buffer.
+  static void CopyBuffer(
+      std::unique_ptr<PbMemory>& dst, std::unique_ptr<PbMemory>& src);
+
+  static std::unique_ptr<PbMemory> LoadFromSharedMemory(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      bi::managed_external_buffer::handle_t memory_handle,
+      bool open_cuda_handle);
+  static std::unique_ptr<PbMemory> LoadFromSharedMemory(
+      bi::managed_external_buffer::handle_t handle, char* data_shm,
+      bool open_cuda_handle);
+  static uint64_t ShmStructSize(
+      TRITONSERVER_MemoryType memory_type, uint64_t byte_size);
+
+  bi::managed_external_buffer::handle_t ShmHandle();
+
+  /// Get the total byte size of the tensor.
+  uint64_t ByteSize() const;
+
+  /// Get the triton memory type.
+  /// \return the memory type of the tensor.
+  TRITONSERVER_MemoryType MemoryType() const;
+
+  /// Get the pointer.
+  /// \return The location to the memory where the data is stored.
+  char* DataPtr() const;
+
+  /// Get the memory type id.
+  /// \return The memory type id of the tensor.
+  int64_t MemoryTypeId() const;
+
+  /// Get the shm data
+  /// \return The memory type id of the tensor.
+  char* ShmData() const;
+
+  ~PbMemory();
+
+ private:
+  AllocatedSharedMemory<char> memory_shm_;
+  MemoryShm* memory_shm_ptr_;
+
+#ifndef TRITON_PB_STUB
+  std::unique_ptr<BackendMemory> backend_memory_;
+#endif
+
+  // Refers to the pointer that can hold the data. For CPU pointers this will be
+  // the same as memory_data_shm_ptr_.
+  char* data_ptr_;
+
+  bi::managed_external_buffer::handle_t memory_shm_handle_;
+  bool opened_cuda_ipc_handle_;
+
+#ifdef TRITON_ENABLE_GPU
+  /// Calculate the pointer offest from the base address.
+  /// \return The offset of a device pointer.
+  /// \throws PythonBackendException if the tensor is stored in CPU.
+  uint64_t GetGPUPointerOffset();
+
+  /// Get the GPU start address.
+  /// \return The start address of a device pointer.
+  /// \throws PythonBackendException if the tensor is stored in CPU.
+  void* GetGPUStartAddress();
+
+#endif
+
+  static void FillShmData(
+      TRITONSERVER_MemoryType memory_type, int64_t memory_type_id,
+      uint64_t byte_size, char* data, char* data_shm,
+      bi::managed_external_buffer::handle_t handle, bool copy_gpu = true);
+
+  PbMemory(
+      AllocatedSharedMemory<char>& memory_shm, char* data,
+      bool opened_cuda_ipc_handle);
+
+  PbMemory(
+      char* memory_shm, char* data,
+      bi::managed_external_buffer::handle_t handle,
+      bool opened_cuda_ipc_handle);
+};
+}}}  // namespace triton::backend::python

--- a/src/pb_string.cc
+++ b/src/pb_string.cc
@@ -1,0 +1,126 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pb_string.h"
+
+namespace triton { namespace backend { namespace python {
+
+std::unique_ptr<PbString>
+PbString::Create(
+    std::unique_ptr<SharedMemoryManager>& shm_pool, const std::string& string)
+{
+  AllocatedSharedMemory<StringShm> string_container_shm =
+      shm_pool->Construct<StringShm>();
+  string_container_shm.data_->length = string.size();
+
+  AllocatedSharedMemory<char> string_shm =
+      shm_pool->Construct<char>(string.size());
+  std::memcpy(string_shm.data_.get(), string.data(), string.size());
+  string_container_shm.data_->data = string_shm.handle_;
+
+  return std::unique_ptr<PbString>(
+      new PbString(string_container_shm, string_shm));
+}
+
+std::unique_ptr<PbString>
+PbString::Create(
+    const std::string& string, char* data_shm,
+    bi::managed_external_buffer::handle_t handle)
+{
+  StringShm* string_container_shm = reinterpret_cast<StringShm*>(data_shm);
+  string_container_shm->length = string.size();
+
+  char* string_shm = data_shm + sizeof(StringShm);
+  std::memcpy(string_shm, string.data(), string.size());
+
+  return std::unique_ptr<PbString>(
+      new PbString(string_container_shm, string_shm, handle));
+}
+
+std::unique_ptr<PbString>
+PbString::LoadFromSharedMemory(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t handle)
+{
+  AllocatedSharedMemory<StringShm> string_container_shm =
+      shm_pool->Load<StringShm>(handle);
+  AllocatedSharedMemory<char> string_shm =
+      shm_pool->Load<char>(string_container_shm.data_->data);
+
+  return std::unique_ptr<PbString>(
+      new PbString(string_container_shm, string_shm));
+}
+
+std::unique_ptr<PbString>
+PbString::LoadFromSharedMemory(
+    bi::managed_external_buffer::handle_t handle, char* data_shm)
+{
+  StringShm* string_container_shm = reinterpret_cast<StringShm*>(data_shm);
+  char* string_shm = data_shm + sizeof(StringShm);
+
+  return std::unique_ptr<PbString>(
+      new PbString(string_container_shm, string_shm, handle));
+}
+
+PbString::PbString(
+    AllocatedSharedMemory<StringShm>& string_container_shm,
+    AllocatedSharedMemory<char>& string_shm)
+    : string_container_shm_(std::move(string_container_shm)),
+      string_shm_(std::move(string_shm))
+{
+  string_shm_ptr_ = string_shm_.data_.get();
+  string_container_shm_ptr_ = string_container_shm_.data_.get();
+  string_handle_ = string_container_shm_.handle_;
+}
+
+PbString::PbString(
+    StringShm* string_container_shm, char* string_shm,
+    bi::managed_external_buffer::handle_t handle)
+{
+  string_shm_ptr_ = string_shm;
+  string_container_shm_ptr_ = string_container_shm;
+  string_handle_ = handle;
+}
+
+bi::managed_external_buffer::handle_t
+PbString::ShmHandle()
+{
+  return string_handle_;
+}
+
+std::size_t
+PbString::ShmStructSize(const std::string& string)
+{
+  return string.size() + sizeof(StringShm);
+}
+
+std::size_t
+PbString::Size()
+{
+  return string_container_shm_ptr_->length + sizeof(StringShm);
+}
+
+}}}  // namespace triton::backend::python

--- a/src/pb_string.h
+++ b/src/pb_string.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,47 +26,55 @@
 
 #pragma once
 
-#include "pb_error.h"
-#include "pb_tensor.h"
-#include "pb_utils.h"
+#include "shm_manager.h"
 
 namespace triton { namespace backend { namespace python {
 
-struct ResponseShm {
-  uint32_t outputs_size;
-  bi::managed_external_buffer::handle_t error;
-  bool has_error;
-  // Indicates whether this error has a message or not.
-  bool is_error_set;
+struct StringShm {
+  bi::managed_external_buffer::handle_t data;
+  size_t length;
 };
 
-class InferResponse {
+class PbString {
  public:
-  InferResponse(
-      const std::vector<std::shared_ptr<PbTensor>>& output_tensors,
-      std::shared_ptr<PbError> error = nullptr);
-  std::vector<std::shared_ptr<PbTensor>>& OutputTensors();
-  void SaveToSharedMemory(
-      std::unique_ptr<SharedMemoryManager>& shm_pool, bool copy_gpu = true);
-  static std::unique_ptr<InferResponse> LoadFromSharedMemory(
+  static std::unique_ptr<PbString> Create(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t response_handle,
-      bool open_cuda_handle);
-  bool HasError();
-  std::shared_ptr<PbError>& Error();
-  bi::managed_external_buffer::handle_t ShmHandle();
+      const std::string& string);
+  static std::unique_ptr<PbString> Create(
+      const std::string& string, char* data_shm,
+      bi::managed_external_buffer::handle_t handle);
+  static std::unique_ptr<PbString> LoadFromSharedMemory(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      bi::managed_external_buffer::handle_t handle);
+  static std::unique_ptr<PbString> LoadFromSharedMemory(
+      bi::managed_external_buffer::handle_t handle, char* data_shm);
+  static std::size_t ShmStructSize(const std::string& string);
 
-  // Disallow copying the inference response object.
-  DISALLOW_COPY_AND_ASSIGN(InferResponse);
+  char* MutableString() { return string_shm_ptr_; }
+  std::string String()
+  {
+    return std::string(
+        string_shm_ptr_, string_shm_ptr_ + string_container_shm_ptr_->length);
+  }
+  bi::managed_external_buffer::handle_t ShmHandle();
+  std::size_t Size();
 
  private:
-  InferResponse(
-      AllocatedSharedMemory<char>& response_shm,
-      std::vector<std::shared_ptr<PbTensor>>& output_tensors,
-      std::shared_ptr<PbError>& pb_error);
-  std::vector<std::shared_ptr<PbTensor>> output_tensors_;
-  std::shared_ptr<PbError> error_;
-  bi::managed_external_buffer::handle_t shm_handle_;
-  AllocatedSharedMemory<char> response_shm_;
+  AllocatedSharedMemory<StringShm> string_container_shm_;
+  StringShm* string_container_shm_ptr_;
+
+  AllocatedSharedMemory<char> string_shm_;
+  char* string_shm_ptr_;
+
+  bi::managed_external_buffer::handle_t string_handle_;
+
+  PbString(
+      AllocatedSharedMemory<StringShm>& string_container_shm,
+      AllocatedSharedMemory<char>& string_shm);
+
+  PbString(
+      StringShm* string_container_shm, char* string_shm,
+      bi::managed_external_buffer::handle_t handle);
 };
+
 }}}  // namespace triton::backend::python

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -33,7 +33,6 @@
 namespace py = pybind11;
 #endif
 #include "pb_tensor.h"
-#include "pb_utils.h"
 
 
 namespace triton { namespace backend { namespace python {
@@ -43,7 +42,6 @@ PbTensor::PbTensor(const std::string& name, py::object numpy_array)
     : name_(name)
 {
   dtype_ = numpy_to_triton_type(numpy_array.attr("dtype"));
-  tensor_type_ = PYTHONBACKEND_NUMPY;
   memory_type_ = TRITONSERVER_MEMORY_CPU;
   memory_type_id_ = 0;
   dl_managed_tensor_ = nullptr;
@@ -105,7 +103,6 @@ PbTensor::PbTensor(
     memory_ptr_ = numpy_array_.request().ptr;
     byte_size_ = numpy_array_.nbytes();
   }
-  tensor_type_ = PYTHONBACKEND_NUMPY;
   memory_type_ = TRITONSERVER_MEMORY_CPU;
   dtype_ = dtype;
 
@@ -125,7 +122,8 @@ PbTensor::PbTensor(
     const std::string& name, const std::vector<int64_t>& dims,
     TRITONSERVER_DataType dtype, TRITONSERVER_MemoryType memory_type,
     int64_t memory_type_id, void* memory_ptr, uint64_t byte_size,
-    DLManagedTensor* dl_managed_tensor, off_t shm_offset)
+    DLManagedTensor* dl_managed_tensor,
+    bi::managed_external_buffer::handle_t shm_handle)
 {
   name_ = name;
   memory_ptr_ = memory_ptr;
@@ -133,7 +131,7 @@ PbTensor::PbTensor(
   memory_type_id_ = memory_type_id;
   dtype_ = dtype;
   dims_ = dims;
-  raw_shm_offset_ = shm_offset;
+  // [FIXME] fix shm_handle
 
 #ifdef TRITON_PB_STUB
   if (memory_type_ == TRITONSERVER_MEMORY_CPU ||
@@ -159,22 +157,13 @@ PbTensor::PbTensor(
 
   byte_size_ = byte_size;
   dl_managed_tensor_ = dl_managed_tensor;
-
-  if (dl_managed_tensor != nullptr) {
-    tensor_type_ = PYTHONBACKEND_DLPACK;
-  } else {
-    tensor_type_ = PYTHONBACKEND_RAW;
-  }
 }
 
 bool
 PbTensor::IsCPU() const
 {
-  if (tensor_type_ == PYTHONBACKEND_NUMPY ||
-      ((tensor_type_ == PYTHONBACKEND_RAW ||
-        tensor_type_ == PYTHONBACKEND_DLPACK) &&
-       (memory_type_ == TRITONSERVER_MEMORY_CPU ||
-        memory_type_ == TRITONSERVER_MEMORY_CPU_PINNED))) {
+  if (memory_type_ == TRITONSERVER_MEMORY_CPU ||
+      memory_type_ == TRITONSERVER_MEMORY_CPU_PINNED) {
     return true;
   } else {
     return false;
@@ -193,12 +182,6 @@ PbTensor::MemoryTypeId() const
   return memory_type_id_;
 }
 
-off_t
-PbTensor::RawShmOffset()
-{
-  return raw_shm_offset_;
-}
-
 uint64_t
 PbTensor::ByteSize() const
 {
@@ -211,10 +194,14 @@ PbTensor::Dims() const
   return dims_;
 }
 
-PYTHONBACKEND_TensorType
-PbTensor::TensorType() const
+void
+PbTensor::SetMemory(std::unique_ptr<PbMemory>&& memory)
 {
-  return tensor_type_;
+  pb_memory_ = std::move(memory);
+  memory_type_ = pb_memory_->MemoryType();
+  memory_type_id_ = pb_memory_->MemoryTypeId();
+  byte_size_ = pb_memory_->ByteSize();
+  memory_ptr_ = pb_memory_->DataPtr();
 }
 
 #ifdef TRITON_PB_STUB
@@ -297,86 +284,10 @@ PbTensor::DeleteDLPack()
   }
 }
 
-std::shared_ptr<PbTensor>
-PbTensor::LoadFromSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, off_t tensor_offset,
-    std::shared_ptr<std::mutex>& cuda_ipc_open_mutex,
-    std::shared_ptr<std::mutex>& cuda_ipc_close_mutex)
+std::unique_ptr<PbMemory>&
+PbTensor::Memory()
 {
-  Tensor* tensor_shm;
-  shm_pool->MapOffset((char**)&tensor_shm, tensor_offset);
-
-  char* name;
-  LoadStringFromSharedMemory(shm_pool, tensor_shm->name, name);
-  std::string name_str = name;
-
-  size_t dims_count = tensor_shm->dims_count;
-  RawData* raw_data;
-  shm_pool->MapOffset((char**)&raw_data, tensor_shm->raw_data);
-
-  int64_t* dims;
-  shm_pool->MapOffset((char**)&dims, tensor_shm->dims);
-
-  std::string reused_gpu_tensor_name;
-  std::shared_ptr<PbTensor> pb_tensor;
-
-  char* data = nullptr;
-  if (raw_data->memory_type == TRITONSERVER_MEMORY_CPU) {
-    shm_pool->MapOffset((char**)&data, raw_data->memory_ptr);
-    pb_tensor = std::make_shared<PbTensor>(
-        name, std::vector<int64_t>(dims, dims + dims_count), tensor_shm->dtype,
-        raw_data->memory_type, raw_data->memory_type_id, data,
-        raw_data->byte_size, nullptr /* DLManaged Tensor */);
-  } else if (raw_data->memory_type == TRITONSERVER_MEMORY_GPU) {
-#ifdef TRITON_ENABLE_GPU
-    cudaIpcMemHandle_t* cuda_ipc_mem_handle;
-    shm_pool->MapOffset((char**)&cuda_ipc_mem_handle, raw_data->memory_ptr);
-    if (tensor_shm->is_cuda_handle_set) {
-      cudaSetDevice(raw_data->memory_type_id);
-
-      if (cuda_ipc_open_mutex != nullptr)
-        cuda_ipc_open_mutex->lock();
-
-      cudaError_t err = cudaIpcOpenMemHandle(
-          (void**)&data, *cuda_ipc_mem_handle, cudaIpcMemLazyEnablePeerAccess);
-
-      if (cuda_ipc_open_mutex != nullptr)
-        cuda_ipc_open_mutex->unlock();
-
-      if (err != cudaSuccess) {
-        throw PythonBackendException(std::string(
-                                         "failed to open cuda ipc handle: " +
-                                         std::string(cudaGetErrorString(err)))
-                                         .c_str());
-      }
-      // Adjust the offset. cudaIpcOpenMemHandle will map the base address of a
-      // GPU pointer and the offset is not preserved when transferring the
-      // pointer using cudaIpcMemHandle.
-      data = data + raw_data->offset;
-      pb_tensor = std::make_shared<PbTensor>(
-          name, std::vector<int64_t>(dims, dims + dims_count),
-          tensor_shm->dtype, raw_data->memory_type, raw_data->memory_type_id,
-          data, raw_data->byte_size, nullptr /* DLManaged Tensor */);
-      pb_tensor->destruct_cuda_ipc_mem_handle_ = true;
-    } else {
-      pb_tensor = std::make_shared<PbTensor>(
-          name, std::vector<int64_t>(dims, dims + dims_count),
-          tensor_shm->dtype, raw_data->memory_type, raw_data->memory_type_id,
-          data, raw_data->byte_size, nullptr /* DLManaged Tensor */);
-      pb_tensor->destruct_cuda_ipc_mem_handle_ = false;
-      pb_tensor->is_cuda_handle_set_ = false;
-    }
-    pb_tensor->cuda_ipc_mem_handle_ = cuda_ipc_mem_handle;
-    pb_tensor->SetCudaIpcMutexes(cuda_ipc_open_mutex, cuda_ipc_close_mutex);
-#else
-    throw PythonBackendException("GPU Tensor is not supported.");
-#endif  // TRITON_ENABLE_GPU
-  }
-  pb_tensor->tensor_shm_ = tensor_shm;
-  pb_tensor->raw_data_shm_ = raw_data;
-  pb_tensor->shm_offset_ = tensor_offset;
-
-  return pb_tensor;
+  return pb_memory_;
 }
 
 #ifdef TRITON_PB_STUB
@@ -430,7 +341,7 @@ PbTensor::FromDLPack(const std::string& name, const py::capsule& dlpack_tensor)
       memory_type_id = 0;
       break;
     case DLDeviceType::kDLCUDAHost:
-      memory_type = TRITONSERVER_MEMORY_CPU_PINNED;
+      memory_type = TRITONSERVER_MEMORY_CPU;
       memory_type_id = 0;
       break;
     default:
@@ -460,28 +371,6 @@ PbTensor::FromDLPack(const std::string& name, const py::capsule& dlpack_tensor)
 
 PbTensor::~PbTensor() noexcept(false)
 {
-#ifdef TRITON_ENABLE_GPU
-  if (!IsCPU() && cuda_ipc_mem_handle_ != nullptr &&
-      destruct_cuda_ipc_mem_handle_) {
-    // Mutex needs to be used since calls to cudaIpcCloseMemHandle are not
-    // thread safe.
-    if (cuda_ipc_close_mutex_ != nullptr)
-      cuda_ipc_close_mutex_->lock();
-
-    cudaError_t err = cudaIpcCloseMemHandle(GetGPUStartAddress());
-
-    if (cuda_ipc_close_mutex_ != nullptr)
-      cuda_ipc_close_mutex_->unlock();
-
-    cuda_ipc_mem_handle_ = nullptr;
-    if (err != cudaSuccess) {
-      throw PythonBackendException(std::string(
-                                       "failed to close cuda ipc handle: " +
-                                       std::string(cudaGetErrorString(err)))
-                                       .c_str());
-    }
-  }
-#endif  // TRITON_ENABLE_GPU
   DeleteDLPack();
 }
 
@@ -495,7 +384,7 @@ PbTensor::Name() const
 const py::array&
 PbTensor::AsNumpy() const
 {
-  if (this->IsCPU()) {
+  if (IsCPU()) {
     return numpy_array_;
   } else {
     throw PythonBackendException(
@@ -506,282 +395,127 @@ PbTensor::AsNumpy() const
 }
 #endif  // TRITON_PB_STUB
 
-#ifdef TRITON_ENABLE_GPU
-void*
-PbTensor::GetGPUStartAddress()
-{
-  if (!this->IsCPU()) {
-    CUDADriverAPI& driver_api = CUDADriverAPI::getInstance();
-    CUdeviceptr start_address;
-
-    driver_api.PointerGetAttribute(
-        &start_address, CU_POINTER_ATTRIBUTE_RANGE_START_ADDR,
-        (CUdeviceptr)this->GetDataPtr());
-
-    return reinterpret_cast<void*>(start_address);
-  }
-
-  throw PythonBackendException(
-      "Calling GetGPUStartAddress function on a CPU tensor.");
-}
-
-void
-PbTensor::SetCudaIpcMutexes(
-    std::shared_ptr<std::mutex>& cuda_ipc_open_mutex,
-    std::shared_ptr<std::mutex>& cuda_ipc_close_mutex)
-{
-  cuda_ipc_open_mutex_ = cuda_ipc_open_mutex;
-  cuda_ipc_close_mutex_ = cuda_ipc_close_mutex;
-}
-
-uint64_t
-PbTensor::GetGPUPointerOffset()
-{
-  if (!this->IsCPU()) {
-    uint64_t offset = reinterpret_cast<char*>(this->GetDataPtr()) -
-                      reinterpret_cast<char*>(this->GetGPUStartAddress());
-    return offset;
-  }
-
-  throw PythonBackendException(
-      "Calling GetGPUPointerOffset function on a CPU tensor.");
-}
-
-const cudaIpcMemHandle_t*
-PbTensor::CudaIpcMemHandle()
-{
-  return cuda_ipc_mem_handle_;
-}
-
-#endif  // TRITON_ENABLE_GPU
-
 void
 PbTensor::SaveToSharedMemory(
-    std::unique_ptr<SharedMemory>& shm_pool, Tensor* tensor_shm, bool copy_cpu,
-    bool copy_gpu)
+    std::unique_ptr<SharedMemoryManager>& shm_pool, bool copy_gpu)
 {
-  const std::string& tensor_name = this->Name();
-  TRITONSERVER_DataType dtype_triton =
-      static_cast<TRITONSERVER_DataType>(this->TritonDtype());
-  tensor_shm->is_cuda_handle_set = false;
-  TRITONSERVER_MemoryType memory_type = TRITONSERVER_MEMORY_CPU;
-  int64_t memory_type_id = 0;
-  tensor_shm_ = tensor_shm;
+  if (!tensor_shm_.data_) {
+    uint64_t byte_size = sizeof(TensorShm) + sizeof(int64_t) * dims_.size() +
+                         PbString::ShmStructSize(name_) +
+                         PbMemory::ShmStructSize(memory_type_, byte_size_);
+    tensor_shm_ = shm_pool->Construct<char>(byte_size);
 
-  if (IsCPU()) {
-    size_t dims_count = dims_.size();
-    memory_type = TRITONSERVER_MEMORY_CPU;
-    memory_type_id = 0;
+    tensor_shm_ptr_ = reinterpret_cast<TensorShm*>(tensor_shm_.data_.get());
+    tensor_shm_ptr_->dtype = dtype_;
+    tensor_shm_ptr_->dims_count = dims_.size();
+    shm_handle_ = tensor_shm_.handle_;
 
-    char* data_in_shm;
-    char* data_ptr;
+    dims_shm_ptr_ = reinterpret_cast<int64_t*>(
+        reinterpret_cast<char*>(tensor_shm_ptr_) + sizeof(TensorShm));
 
-    data_ptr = static_cast<char*>(memory_ptr_);
-
-    uint64_t* ptr_offset;
-    SaveTensorToSharedMemory(
-        shm_pool, tensor_shm, data_in_shm, memory_type, memory_type_id,
-        byte_size_, tensor_name.c_str(), dims_.data(), dims_count, dtype_triton,
-        &ptr_offset, raw_shm_offset_);
-    *ptr_offset = 0;
-
-    if (copy_cpu) {
-      std::copy(data_ptr, data_ptr + byte_size_, data_in_shm);
-    } else {
-      memory_ptr_ = reinterpret_cast<void*>(data_in_shm);
-    }
-  } else {
-#ifdef TRITON_ENABLE_GPU
-    char* cuda_handle;
-    uint64_t* ptr_offset;
-    SaveTensorToSharedMemory(
-        shm_pool, tensor_shm, cuda_handle, this->MemoryType(),
-        this->MemoryTypeId(), this->ByteSize(), tensor_name.c_str(),
-        this->Dims().data(), this->Dims().size(), dtype_triton, &ptr_offset,
-        raw_shm_offset_);
-    cuda_ipc_mem_handle_ = reinterpret_cast<cudaIpcMemHandle_t*>(cuda_handle);
-
-    if (copy_gpu) {
-      tensor_shm->is_cuda_handle_set = true;
-      *ptr_offset = this->GetGPUPointerOffset();
-      cudaSetDevice(this->MemoryTypeId());
-      cudaError_t err = cudaIpcGetMemHandle(
-          reinterpret_cast<cudaIpcMemHandle_t*>(cuda_handle),
-          this->GetDataPtr());
-      if (err != cudaSuccess) {
-        throw PythonBackendException(std::string(
-                                         "failed to get cuda ipc handle: " +
-                                         std::string(cudaGetErrorString(err)))
-                                         .c_str());
-      }
-    }
-#else
-    throw PythonBackendException("GPU tensors are not supported.");
-#endif  // TRITON_ENABLE_GPU
-  }
-
-  shm_pool->MapOffset((char**)&raw_data_shm_, tensor_shm_->raw_data);
-}
-
-#ifdef TRITON_ENABLE_GPU
-void
-PbTensor::LoadGPUData(std::unique_ptr<SharedMemory>& shm_pool)
-{
-  if (!this->IsCPU()) {
-    if (!tensor_shm_->is_cuda_handle_set) {
-      throw PythonBackendException(
-          std::string("Failed to get cudaIpcMemHandle for tensor '") + name_ +
-          "'.");
-    }
-    char* d_buffer;
-
-    // Sync the memory type id. Since it will be updated by the main process
-    // after providing the GPU buffers.
-    memory_type_id_ = raw_data_shm_->memory_type_id;
-
-    cudaSetDevice(this->MemoryTypeId());
-    shm_pool->MapOffset(
-        (char**)&cuda_ipc_mem_handle_, raw_data_shm_->memory_ptr);
-
-    // Lock the mutex when using cudaIpcOpenMemHandle. This code is only
-    // required in the stub process. In the Triton process, we never use
-    // cudaIpcOpenMemHandle. The mutex is required because cudaIpcOpenMemHandle
-    // is not thread safe.
-    if (cuda_ipc_open_mutex_ != nullptr)
-      cuda_ipc_open_mutex_->lock();
-
-    cudaError_t err = cudaIpcOpenMemHandle(
-        (void**)&d_buffer, *cuda_ipc_mem_handle_,
-        cudaIpcMemLazyEnablePeerAccess);
-
-    if (cuda_ipc_open_mutex_ != nullptr)
-      cuda_ipc_open_mutex_->unlock();
-
-    if (err != cudaSuccess) {
-      throw PythonBackendException(std::string(
-                                       "failed to open ipc handle: " +
-                                       std::string(cudaGetErrorString(err)))
-                                       .c_str());
+    // Write the dimensions data to shared memory.
+    for (size_t i = 0; i < dims_.size(); i++) {
+      dims_shm_ptr_[i] = dims_[i];
     }
 
-    char* buffer_start = d_buffer + raw_data_shm_->offset;
-    err = cudaMemcpy(
-        (void*)buffer_start, memory_ptr_, (size_t)this->ByteSize(),
-        cudaMemcpyDeviceToDevice);
-    if (err != cudaSuccess) {
-      throw PythonBackendException(
-          std::string(
-              "failed to copy data: " + std::string(cudaGetErrorString(err)))
-              .c_str());
-    }
+    std::size_t name_offset =
+        sizeof(TensorShm) + sizeof(int64_t) * dims_.size();
+    name_shm_ = PbString::Create(
+        name_, reinterpret_cast<char*>(tensor_shm_ptr_) + name_offset,
+        shm_handle_ + name_offset);
+    std::size_t pb_memory_offset = name_offset + PbString::ShmStructSize(name_);
 
-    if (cuda_ipc_close_mutex_ != nullptr)
-      cuda_ipc_close_mutex_->lock();
+    pb_memory_ = PbMemory::Create(
+        memory_type_, memory_type_id_, byte_size_,
+        reinterpret_cast<char*>(memory_ptr_),
+        reinterpret_cast<char*>(tensor_shm_ptr_) + pb_memory_offset,
+        shm_handle_ + pb_memory_offset, copy_gpu);
 
-    err = cudaIpcCloseMemHandle(d_buffer);
-
-    if (cuda_ipc_close_mutex_ != nullptr)
-      cuda_ipc_close_mutex_->unlock();
-
-    if (err != cudaSuccess) {
-      throw PythonBackendException(std::string(
-                                       "failed to close memory handle: " +
-                                       std::string(cudaGetErrorString(err)))
-                                       .c_str());
-    }
-  } else {
-    throw PythonBackendException("LoadGPUData called on a CPU tensor.");
+    tensor_shm_ptr_->memory = pb_memory_->ShmHandle();
+    memory_ptr_ = pb_memory_->DataPtr();
   }
 }
 
-void
-PbTensor::CopyToCPU(std::unique_ptr<SharedMemory>& shm_pool)
+std::unique_ptr<PbTensor>
+PbTensor::LoadFromSharedMemory(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t tensor_handle, bool open_cuda_handle)
 {
-  if (!this->IsCPU()) {
-    char* raw_data_ptr;
-    uint64_t* offset_ptr;
-    off_t raw_ptr_offset = 0;
-    off_t raw_data_offset;
+  AllocatedSharedMemory<char> tensor_shm = shm_pool->Load<char>(tensor_handle);
+  TensorShm* tensor_shm_ptr =
+      reinterpret_cast<TensorShm*>(tensor_shm.data_.get());
+  size_t name_offset =
+      sizeof(TensorShm) + sizeof(int64_t) * tensor_shm_ptr->dims_count;
+  std::unique_ptr<PbString> name_shm = PbString::LoadFromSharedMemory(
+      tensor_handle + name_offset, tensor_shm.data_.get() + name_offset);
 
-    // Raw Data
-    SaveRawDataToSharedMemory(
-        shm_pool, raw_data_offset, raw_data_ptr,
-        TRITONSERVER_MEMORY_CPU /* memory_type */, 0 /*memory_type_id */,
-        this->ByteSize(), &offset_ptr, raw_ptr_offset);
-    tensor_shm_->raw_data = raw_data_offset;
-    cudaError_t err = cudaMemcpy(
-        (void*)raw_data_ptr, memory_ptr_, this->ByteSize(),
-        cudaMemcpyDeviceToHost);
-
-    if (err != cudaSuccess) {
-      throw PythonBackendException(
-          std::string(
-              "failed to copy data: " + std::string(cudaGetErrorString(err)))
-              .c_str());
-    }
-  } else {
-    throw PythonBackendException("CopyToCPU can be called on a GPU tensor.");
-  }
-}
-#endif  // TRITON_ENABLE_GPU
-
-void
-PbTensor::SetDataPtr(void* ptr)
-{
-  memory_ptr_ = ptr;
+  std::size_t pb_memory_offset = name_offset + name_shm->Size();
+  std::unique_ptr<PbMemory> pb_memory = PbMemory::LoadFromSharedMemory(
+      pb_memory_offset, tensor_shm.data_.get() + pb_memory_offset,
+      open_cuda_handle);
+  return std::unique_ptr<PbTensor>(
+      new PbTensor(tensor_shm, name_shm, pb_memory));
 }
 
-void
-PbTensor::SetMemoryType(TRITONSERVER_MemoryType memory_type)
-{
-  memory_type_ = memory_type;
-  raw_data_shm_->memory_type = memory_type;
-}
-
-void
-PbTensor::SetMemoryTypeId(int64_t memory_type_id)
-{
-  memory_type_id_ = memory_type_id;
-  raw_data_shm_->memory_type_id = memory_type_id;
-}
-
-#ifdef TRITON_ENABLE_GPU
-#ifndef TRITON_PB_STUB
-void
-PbTensor::SetBackendMemory(
-    std::unique_ptr<BackendMemory> backend_memory,
-    std::unique_ptr<SharedMemory>& shm_pool)
-{
-  tensor_shm_->is_cuda_handle_set = false;
-  cudaSetDevice(this->MemoryTypeId());
-  cudaError_t err =
-      cudaIpcGetMemHandle(cuda_ipc_mem_handle_, backend_memory->MemoryPtr());
-  if (err != cudaSuccess) {
-    throw PythonBackendException(std::string(
-                                     "failed to get cuda ipc handle: " +
-                                     std::string(cudaGetErrorString(err)))
-                                     .c_str());
-  }
-
-  memory_ptr_ = backend_memory->MemoryPtr();
-  SetMemoryType(backend_memory->MemoryType());
-  SetMemoryTypeId(backend_memory->MemoryTypeId());
-  backend_memory_ = std::move(backend_memory);
-  raw_data_shm_->offset = this->GetGPUPointerOffset();
-  tensor_shm_->is_cuda_handle_set = true;
-}
-#endif
-#endif
-
-int
+TRITONSERVER_DataType
 PbTensor::TritonDtype() const
 {
   return dtype_;
 }
 
 void*
-PbTensor::GetDataPtr() const
+PbTensor::DataPtr()
 {
   return memory_ptr_;
+}
+
+bi::managed_external_buffer::handle_t
+PbTensor::ShmHandle()
+{
+  return shm_handle_;
+}
+
+PbTensor::PbTensor(
+    AllocatedSharedMemory<char>& tensor_shm,
+    std::unique_ptr<PbString>& name_shm, std::unique_ptr<PbMemory>& pb_memory)
+    : tensor_shm_(std::move(tensor_shm)), name_shm_(std::move(name_shm)),
+      pb_memory_(std::move(pb_memory))
+{
+  tensor_shm_ptr_ = reinterpret_cast<TensorShm*>(tensor_shm_.data_.get());
+  dims_shm_ptr_ = reinterpret_cast<int64_t*>(
+      reinterpret_cast<char*>(tensor_shm_ptr_) + sizeof(TensorShm));
+
+  name_ = name_shm_->String();
+  dims_ = std::vector<int64_t>(
+      dims_shm_ptr_, dims_shm_ptr_ + tensor_shm_ptr_->dims_count);
+  dtype_ = tensor_shm_ptr_->dtype;
+  dl_managed_tensor_ = nullptr;
+  byte_size_ = pb_memory_->ByteSize();
+  memory_ptr_ = pb_memory_->DataPtr();
+  memory_type_ = pb_memory_->MemoryType();
+  memory_type_id_ = pb_memory_->MemoryTypeId();
+  shm_handle_ = tensor_shm_.handle_;
+
+#ifdef TRITON_PB_STUB
+  if (memory_type_ == TRITONSERVER_MEMORY_CPU ||
+      memory_type_ == TRITONSERVER_MEMORY_CPU_PINNED) {
+    if (dtype_ != TRITONSERVER_TYPE_BYTES) {
+      py::object numpy_array =
+          py::array(triton_to_pybind_dtype(dtype_), dims_, (void*)memory_ptr_);
+      numpy_array_ = numpy_array.attr("view")(triton_to_numpy_type(dtype_));
+    } else {
+      py::object numpy_array = py::array(
+          triton_to_pybind_dtype(TRITONSERVER_TYPE_UINT8), {byte_size_},
+          (void*)memory_ptr_);
+      py::module triton_pb_utils =
+          py::module::import("triton_python_backend_utils");
+      numpy_array_ =
+          triton_pb_utils.attr("deserialize_bytes_tensor")(numpy_array)
+              .attr("reshape")(dims_);
+    }
+  } else {
+    numpy_array_ = py::none();
+  }
+#endif
 }
 }}}  // namespace triton::backend::python

--- a/src/request_executor.h
+++ b/src/request_executor.h
@@ -24,49 +24,31 @@
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-#pragma once
-
-#include "pb_error.h"
-#include "pb_tensor.h"
-#include "pb_utils.h"
+#include <memory>
+#include "infer_request.h"
+#include "infer_response.h"
 
 namespace triton { namespace backend { namespace python {
+TRITONSERVER_Error* CreateTritonErrorFromException(
+    const PythonBackendException& pb_exception);
 
-struct ResponseShm {
-  uint32_t outputs_size;
-  bi::managed_external_buffer::handle_t error;
-  bool has_error;
-  // Indicates whether this error has a message or not.
-  bool is_error_set;
+
+struct AllocationInfo {
+  bi::managed_external_buffer::handle_t handle_;
+  SharedMemoryManager* shm_manager_;
 };
 
-class InferResponse {
+class RequestExecutor {
+  TRITONSERVER_ResponseAllocator* response_allocator_ = nullptr;
+  TRITONSERVER_Server* server_;
+
  public:
-  InferResponse(
-      const std::vector<std::shared_ptr<PbTensor>>& output_tensors,
-      std::shared_ptr<PbError> error = nullptr);
-  std::vector<std::shared_ptr<PbTensor>>& OutputTensors();
-  void SaveToSharedMemory(
-      std::unique_ptr<SharedMemoryManager>& shm_pool, bool copy_gpu = true);
-  static std::unique_ptr<InferResponse> LoadFromSharedMemory(
-      std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t response_handle,
-      bool open_cuda_handle);
-  bool HasError();
-  std::shared_ptr<PbError>& Error();
-  bi::managed_external_buffer::handle_t ShmHandle();
-
-  // Disallow copying the inference response object.
-  DISALLOW_COPY_AND_ASSIGN(InferResponse);
-
- private:
-  InferResponse(
-      AllocatedSharedMemory<char>& response_shm,
-      std::vector<std::shared_ptr<PbTensor>>& output_tensors,
-      std::shared_ptr<PbError>& pb_error);
-  std::vector<std::shared_ptr<PbTensor>> output_tensors_;
-  std::shared_ptr<PbError> error_;
-  bi::managed_external_buffer::handle_t shm_handle_;
-  AllocatedSharedMemory<char> response_shm_;
+  std::unique_ptr<InferResponse> Infer(
+      const std::shared_ptr<InferRequest>& infer_request,
+      const std::unique_ptr<SharedMemoryManager>& shm_pool,
+      TRITONSERVER_InferenceResponse** response);
+  RequestExecutor(TRITONSERVER_Server* server);
+  ~RequestExecutor();
 };
+
 }}}  // namespace triton::backend::python

--- a/src/scoped_defer.h
+++ b/src/scoped_defer.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -25,48 +25,18 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 #pragma once
-
-#include "pb_error.h"
-#include "pb_tensor.h"
-#include "pb_utils.h"
+#include <functional>
 
 namespace triton { namespace backend { namespace python {
-
-struct ResponseShm {
-  uint32_t outputs_size;
-  bi::managed_external_buffer::handle_t error;
-  bool has_error;
-  // Indicates whether this error has a message or not.
-  bool is_error_set;
-};
-
-class InferResponse {
+class ScopedDefer {
  public:
-  InferResponse(
-      const std::vector<std::shared_ptr<PbTensor>>& output_tensors,
-      std::shared_ptr<PbError> error = nullptr);
-  std::vector<std::shared_ptr<PbTensor>>& OutputTensors();
-  void SaveToSharedMemory(
-      std::unique_ptr<SharedMemoryManager>& shm_pool, bool copy_gpu = true);
-  static std::unique_ptr<InferResponse> LoadFromSharedMemory(
-      std::unique_ptr<SharedMemoryManager>& shm_pool,
-      bi::managed_external_buffer::handle_t response_handle,
-      bool open_cuda_handle);
-  bool HasError();
-  std::shared_ptr<PbError>& Error();
-  bi::managed_external_buffer::handle_t ShmHandle();
-
-  // Disallow copying the inference response object.
-  DISALLOW_COPY_AND_ASSIGN(InferResponse);
+  ScopedDefer(std::function<void()> task);
+  ~ScopedDefer();
+  void Complete();
 
  private:
-  InferResponse(
-      AllocatedSharedMemory<char>& response_shm,
-      std::vector<std::shared_ptr<PbTensor>>& output_tensors,
-      std::shared_ptr<PbError>& pb_error);
-  std::vector<std::shared_ptr<PbTensor>> output_tensors_;
-  std::shared_ptr<PbError> error_;
-  bi::managed_external_buffer::handle_t shm_handle_;
-  AllocatedSharedMemory<char> response_shm_;
+  std::function<void()> task_;
+  bool done_;
 };
+
 }}}  // namespace triton::backend::python


### PR DESCRIPTION
Performance results before and after these changes for BLS:

|  Scenario  |  Latency  (before) |  Latency (after)  | Throughput (before) |  Throughput (after)  |
|:--- |:--- | :--- |:--- | :--- |
| 4mb_payload_latency | 11997 | 10617 |  83.4 | 94.2 |
| 1kb_payload_latency | 520 |  533 |  1918.6 | 1871.6 |
| 4b_payload_latency |  503 |  506 |  1981.6 | 1969.6  |
| 4mb_payload_throughput | 471614 | 460934 |  136.4 | 138.8 |
| 1kb_payload_throughput | 18078 | 18098 |  3539 |  3535.2 |
| 4b_payload_throughput |  17348 |  17399 |  3689 | 3677.2 |

The *_latency scenarios use a single instance count with the concurrency of 1. The *_throughput scenarios use 2 instance counts with concurrency of 64. The numbers were collected using the Perf Analyzer C-API. The results are almost the same before and after these changes. The only curious result is the 4mb_payload_latency. I applied one performance improvement as a part of this change which was to not rewrite the tensor to shared memory if it is already saved to shared memory. I think this is why we are seeing slight improvement in the results.

This PR is just the combination of all the previous changes and contains no new commit. 