### PR TITLE
Fix message queue on ARM

### DIFF
--- a/src/message_queue.h
+++ b/src/message_queue.h
@@ -42,13 +42,13 @@ namespace bi = boost::interprocess;
 /// \param sem_empty Semaphore object counting the number of empty buffer slots.
 /// \param sem_full Semaphore object counting the number of used buffer slots.
 struct MessageQueueShm {
-  std::size_t size;
-  bi::managed_external_buffer::handle_t buffer;
-  bi::interprocess_mutex mutex;
-  int head;
-  int tail;
   bi::interprocess_semaphore sem_empty{0};
   bi::interprocess_semaphore sem_full{0};
+  bi::interprocess_mutex mutex;
+  std::size_t size;
+  bi::managed_external_buffer::handle_t buffer;
+  int head;
+  int tail;
 };
 
 class MessageQueue {

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -54,6 +54,13 @@ struct AllocatedSharedMemory {
   bi::managed_external_buffer::handle_t handle_;
 };
 
+// The alignment here is used to extend the size of the shared memory allocation
+// struct to 16 bytes. The reason for this change is that when an aligned shared
+// memory location is requested using the `Construct` method, the memory
+// alignment of the object will be incorrect since the shared memory ownership
+// info is placed in the beginning and the actual object is placed after that
+// (i.e. 4 plus the aligned address is not 16-bytes aligned). The aligned memory
+// is required by semaphore otherwise it may lead to SIGBUS error on ARM.
 struct AllocatedShmOwnership {
   uint32_t ref_count_;
 } __attribute__((aligned(16)));

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -56,7 +56,7 @@ struct AllocatedSharedMemory {
 
 struct AllocatedShmOwnership {
   uint32_t ref_count_;
-};
+} __attribute__((aligned(16)));
 
 class SharedMemoryManager {
  public:


### PR DESCRIPTION
Looks like the address alignment is important for semaphores to function properly.