### PR TITLE
Fix BLS performance

### DIFF
--- a/src/pb_tensor.h
+++ b/src/pb_tensor.h
@@ -96,8 +96,7 @@ class PbTensor {
       const std::string& name, const std::vector<int64_t>& dims,
       TRITONSERVER_DataType dtype, TRITONSERVER_MemoryType memory_type,
       int64_t memory_type_id, void* memory_ptr, uint64_t byte_size,
-      DLManagedTensor* dl_managed_tensor = nullptr,
-      bi::managed_external_buffer::handle_t shm_handle = 0);
+      DLManagedTensor* dl_managed_tensor = nullptr);
 
   /// This constructor is used when
   /// loading the tensor from shared memory.

--- a/src/request_executor.h
+++ b/src/request_executor.h
@@ -32,22 +32,19 @@ namespace triton { namespace backend { namespace python {
 TRITONSERVER_Error* CreateTritonErrorFromException(
     const PythonBackendException& pb_exception);
 
-
-struct AllocationInfo {
-  bi::managed_external_buffer::handle_t handle_;
-  SharedMemoryManager* shm_manager_;
-};
-
 class RequestExecutor {
   TRITONSERVER_ResponseAllocator* response_allocator_ = nullptr;
   TRITONSERVER_Server* server_;
+  std::unique_ptr<SharedMemoryManager>& shm_pool_;
 
  public:
   std::unique_ptr<InferResponse> Infer(
       const std::shared_ptr<InferRequest>& infer_request,
-      const std::unique_ptr<SharedMemoryManager>& shm_pool,
       TRITONSERVER_InferenceResponse** response);
-  RequestExecutor(TRITONSERVER_Server* server);
+  RequestExecutor(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      TRITONSERVER_Server* server);
+
   ~RequestExecutor();
 };
 


### PR DESCRIPTION
Before:
```
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 64
  Client:
    Request count: 2741
    Throughput: 548.2 infer/sec
    Avg latency: 116732 usec (standard deviation 5196 usec)
    p50 latency: 117863 usec
    p90 latency: 120976 usec
    p95 latency: 122012 usec
    p99 latency: 124953 usec
    Avg HTTP time: 116907 usec (send/recv 730 usec + response wait 116177 usec)
  Server:
    Inference count: 3286
    Execution count: 3286
    Successful request count: 3286
    Avg request latency: 114720 usec (overhead 16 usec + queue 111089 usec + compute input 150 usec + compute infer 3233 usec + compute output 232 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 64, throughput: 548.2 infer/sec, latency 116732 usec
```
After:

```
*** Measurement Settings ***
  Batch size: 1
  Using "time_windows" mode for stabilization
  Measurement window: 5000 msec
  Using synchronous calls for inference
  Stabilizing using average latency

Request concurrency: 64
  Client:
    Request count: 2857
    Throughput: 571.4 infer/sec
    Avg latency: 112067 usec (standard deviation 4477 usec)
    p50 latency: 112748 usec
    p90 latency: 115622 usec
    p95 latency: 116763 usec
    p99 latency: 118718 usec
    Avg HTTP time: 112219 usec (send/recv 746 usec + response wait 111473 usec)
  Server:
    Inference count: 3422
    Execution count: 3422
    Successful request count: 3422
    Avg request latency: 109982 usec (overhead 15 usec + queue 106496 usec + compute input 150 usec + compute infer 3089 usec + compute output 232 usec)

Inferences/Second vs. Client Average Batch Latency
Concurrency: 64, throughput: 571.4 infer/sec, latency 112067 usec
```

Looks like the performance improves slightly after this change.