### PR TITLE
Some examples for using decoupled API

### DIFF
--- a/examples/decoupled/repeat_client.py
+++ b/examples/decoupled/repeat_client.py
@@ -1,0 +1,116 @@
+# Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+from functools import partial
+import numpy as np
+
+from tritonclient.utils import *
+import tritonclient.grpc as grpcclient
+
+
+class UserData:
+
+    def __init__(self):
+        self._completed_requests = queue.Queue()
+
+
+def callback(user_data, result, error):
+    if error:
+        user_data._completed_requests.put(error)
+    else:
+        user_data._completed_requests.put(result)
+
+
+# This client sends a single request to the model with the
+# following tensor data. In compliance with the behavior
+# of repeat_int32 model, it will expect the 4 responses
+# with output: [4], [2], [0] and [1] respectively.
+model_name = "repeat_int32"
+in_value = [4, 2, 0, 1]
+delay_value = 2
+wait_value = 5
+
+inputs = []
+inputs.append(grpcclient.InferInput('IN', [len(in_value)], "INT32"))
+inputs.append(grpcclient.InferInput('DELAY', [1], "UINT32"))
+inputs.append(grpcclient.InferInput('WAIT', [1], "UINT32"))
+
+outputs = []
+outputs.append(grpcclient.InferRequestedOutput('OUT'))
+outputs.append(grpcclient.InferRequestedOutput('IDX'))
+
+with grpcclient.InferenceServerClient(url="localhost:8001",
+                                      verbose=True) as triton_client:
+    # Establish stream
+    triton_client.start_stream(callback=partial(callback, user_data))
+
+    in_data = np.array(in_value, dtype=np.int32)
+    inputs[0].set_data_from_numpy(in_data)
+    delay_data = np.array([delay_value], dtype=np.uint32)
+    inputs[1].set_data_from_numpy(delay_data)
+    wait_data = np.array([wait_value], dtype=np.uint32)
+    inputs[2].set_data_from_numpy(wait_data)
+
+    request_id = "0"
+    triton_client.async_stream_infer(model_name=model_name,
+                                     inputs=inputs,
+                                     request_id=request_id,
+                                     outputs=outputs)
+
+    # Retrieve results...
+    recv_count = 0
+    expected_count = len(in_value)
+    result_dict = {}
+    while recv_count < expected_count:
+        data_item = user_data._completed_requests.get()
+        if type(data_item) == InferenceServerException:
+            raise data_item
+        else:
+            this_id = data_item.get_response().id
+            if this_id not in result_dict.keys():
+                result_dict[this_id] = []
+            result_dict[this_id].append((recv_count, data_item))
+
+        recv_count += 1
+
+    # Validate results...
+    if len(result_dict[request_id]) != len(in_values):
+        print("expected {} many responses for request id {}, got {}".format(
+            len(in_values), request_id, len(result_dict[request_id])))
+        sys.exit(1)
+
+    result_list = result_dict[request_id]
+    for i in range(len(result_list)):
+        expected_data = np.array([in_values[i]], dtype=np.int32)
+        this_data = result_list[i][1].as_numpy('OUT')
+        if not np.array_equal(expected_data, this_data):
+            print("incorrect data: expected {}, got {}".format(
+                expected_data, this_data))
+            sys.exit(1)
+
+    print('PASS: repeat_int32')
+    sys.exit(0)

--- a/examples/decoupled/repeat_config.pbtxt
+++ b/examples/decoupled/repeat_config.pbtxt
@@ -1,0 +1,61 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "repeat_int32"
+backend: "python"
+max_batch_size: 0
+model_transaction_policy {
+  decoupled: True
+}
+input [
+  {
+    name: "IN"
+    data_type: TYPE_INT32
+    dims: [ -1 ]
+  },
+  {
+    name: "DELAY"
+    data_type: TYPE_UINT32
+    dims: [ -1 ]
+  },
+  {
+    name: "WAIT"
+    data_type: TYPE_UINT32
+    dims: [ 1 ]
+  }
+]
+output [
+  {
+    name: "OUT"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  },
+  {
+    name: "IDX"
+    data_type: TYPE_UINT32
+    dims: [ 1 ]
+  }
+]

--- a/examples/decoupled/repeat_config.pbtxt
+++ b/examples/decoupled/repeat_config.pbtxt
@@ -59,3 +59,4 @@ output [
     dims: [ 1 ]
   }
 ]
+instance_group [{ kind: KIND_CPU }]

--- a/examples/decoupled/repeat_model.py
+++ b/examples/decoupled/repeat_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/examples/decoupled/repeat_model.py
+++ b/examples/decoupled/repeat_model.py
@@ -25,7 +25,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
+import numpy
 import threading
+import time
 
 # triton_python_backend_utils is available in every Triton Python model. You
 # need to use this module to create inference requests and responses. It also
@@ -138,7 +140,7 @@ class TritonPythonModel:
         # Start a separate thread to send the responses for the request. The
         # sending back the responses is delegated to this thread.
         thread = threading.Thread(
-            target=response_thread,
+            target=self.response_thread,
             args=(self, requests[0].get_response_sender(),
                   pb_utils.get_input_tensor_by_name(requests[0],
                                                     'IN').as_numpy(),

--- a/examples/decoupled/repeat_model.py
+++ b/examples/decoupled/repeat_model.py
@@ -1,0 +1,170 @@
+# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import json
+
+# triton_python_backend_utils is available in every Triton Python model. You
+# need to use this module to create inference requests and responses. It also
+# contains some utility functions for extracting information from model_config
+# and converting Triton input/output types to numpy types.
+import triton_python_backend_utils as pb_utils
+
+
+class TritonPythonModel:
+    """Your Python model must use the same class name. Every Python model
+    that is created must have "TritonPythonModel" as the class name.
+
+    This model has three inputs and two outputs. The model does not support batching.
+    
+      - Input 'IN' can have any vector shape (e.g. [4] or [12]), datatype must be INT32.
+      - Input 'DELAY' must have the same shape as IN, datatype must be UINT32.
+      - Input 'WAIT' must have shape [1] and datatype UINT32.
+      - For each response, output 'OUT' must have shape [1] and datatype INT32.
+      - For each response, output 'IDX' must have shape [1] and datatype UINT32.
+         
+    For a request, the model will send 'n' responses where 'n' is the number of elements in IN. 
+    For the i'th response, OUT will equal the i'th element of IN and IDX will equal the zero-based
+    count of this response for the request. For example, the first response for a request will
+    have IDX = 0 and OUT = IN[0], the second will have IDX = 1 and OUT = IN[1], etc. The model
+    will wait the i'th DELAY, in milliseconds, before sending the i'th response. If IN shape is [0]
+    then no responses will be sent.
+    
+    After WAIT milliseconds the model will return from the execute function so that Triton can call
+    execute again with another request. WAIT can be less than the sum of DELAY so that execute
+    returns before all responses are sent. Thus, even if there is only one instance of the model,
+    multiple requests can be processed at the same time, and the responses for multiple requests
+    can be intermixed, depending on the values of DELAY and WAIT.
+    """
+
+    def initialize(self, args):
+        """`initialize` is called only once when the model is being loaded.
+        Implementing `initialize` function is optional. This function allows
+        the model to intialize any state associated with this model.
+
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
+
+        # You must parse model_config. JSON string is not parsed here
+        self.model_config = model_config = json.loads(args['model_config'])
+
+        # Get OUT configuration
+        out_config = pb_utils.get_output_config_by_name(
+            model_config, "OUT")
+
+        # Get IDX configuration
+        idx_config = pb_utils.get_output_config_by_name(
+            model_config, "IDX")
+
+        # Convert Triton types to numpy types
+        self.out_dtype = pb_utils.triton_string_to_numpy(
+            out_config['data_type'])
+        self.idx_dtype = pb_utils.triton_string_to_numpy(
+            idx_config['data_type'])
+
+    
+
+    def execute(self, requests):
+        """`execute` MUST be implemented in every Python model. `execute`
+        function receives a list of pb_utils.InferenceRequest as the only
+        argument. This function is called when an inference request is made
+        for this model. Depending on the batching configuration (e.g. Dynamic
+        Batching) used, `requests` may contain multiple requests. Every
+        Python model, must create one pb_utils.InferenceResponse for every
+        pb_utils.InferenceRequest in `requests`. If there is an error, you can
+        set the error argument when creating a pb_utils.InferenceResponse
+
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+
+        Returns
+        -------
+        None
+        """
+        
+        # This model does not support batching, so 'request_count' should always be 1.
+        if len(requests) != 1:
+            raise pb_utils.TritonModelException("unsupported batch size " + len(requests))
+
+        # Start a separate thread to send the responses for the request. In a full implementation we
+        # would need to keep track of any running threads so that we could delay finalizing the
+        # model until all response_thread threads have completed.
+        thread = threading.Thread(target=response_thread,
+                                  args=(self,
+                                  requests[0].get_response_sender(),
+                                  pb_utils.get_input_tensor_by_name(requests[0], 'IN').as_numpy(),
+                                  pb_utils.get_input_tensor_by_name(requests[0], 'DELAY').as_numpy()))
+        thread.daemon = True
+        thread.start()
+                 
+        # Read WAIT input for wait time, then return so that Triton can call execute again with
+        # another request.
+        wait_input = pb_utils.get_input_tensor_by_name(requests[0], 'WAIT').as_numpy()
+        time.sleep(wait_input[0] / 1000)
+
+        return None
+
+    def response_thread(self, response_sender, in_input, delay_input):
+        # The response_sender is used to send response(s) associated with the corresponding request.
+        # Iterate over input/delay pairs. Wait for DELAY milliseconds and then create and
+        # send a response.
+
+        idx_dtype = self.idx_dtype
+        out_dtype = self.out_dtype
+
+        for idx in range(in_input.size):
+            in_value = in_input[idx]
+            delay_value = delay_input[idx]
+    
+            time.sleep(delay_value / 1000)
+
+            idx_output = pb_utils.Tensor("IDX", numpy.array([idx], idx_dtype))
+            out_output = pb_utils.Tensor("OUT", numpy.array([in_value], out_dtype))
+            response = pb_utils.InferenceResponse(output_tensors=[idx_output, out_output])
+            response_sender.send(response)
+
+        # We must close the response sender to indicate to Triton that we are done sending
+        # responses for the corresponding request. We can't use the response sender after
+        # closing it.
+        response_sender.close() 
+
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is OPTIONAL. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print('Cleaning up...')

--- a/examples/decoupled/square_client.py
+++ b/examples/decoupled/square_client.py
@@ -1,0 +1,117 @@
+# Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+import sys
+from functools import partial
+import numpy as np
+
+from tritonclient.utils import *
+import tritonclient.grpc as grpcclient
+
+
+class UserData:
+
+    def __init__(self):
+        self._completed_requests = queue.Queue()
+
+
+def callback(user_data, result, error):
+    if error:
+        user_data._completed_requests.put(error)
+    else:
+        user_data._completed_requests.put(result)
+
+
+# This client sends a 4 requests to the model with the
+# input as: [4], [2], [0] and [1] respectively. In
+# compliance with the behavior of square_int32 model,
+# it will expect the 4 responses for the 1st request
+# each with output [4], 2 responses for 2nd request
+# each with output [2], no response for the 3rd request
+# and finally 1 response for the 4th request with output
+# [1]
+model_name = "square_int32"
+in_values = [4, 2, 0, 1]
+inputs = [grpcclient.InferInput("IN", [1], np_to_triton_dtype(np.int32))]
+outputs = [grpcclient.InferRequestedOutput("OUT")]
+
+with grpcclient.InferenceServerClient(url="localhost:8001",
+                                      verbose=True) as triton_client:
+    # Establish stream
+    triton_client.start_stream(callback=partial(callback, user_data))
+
+    # Send specified many requests in parallel
+    for i in range(in_values.size):
+        in_data = np.array([in_values[i]], dtype=np.int32)
+        inputs[0].set_data_from_numpy(in_data)
+
+        triton_client.async_stream_infer(model_name=model_name,
+                                         inputs=inputs,
+                                         request_id=str(i),
+                                         outputs=outputs)
+
+    # Retrieve results...
+    recv_count = 0
+    expected_count = sum(in_values)
+    result_dict = {}
+    while recv_count < expected_count:
+        data_item = user_data._completed_requests.get()
+        if type(data_item) == InferenceServerException:
+            raise data_item
+        else:
+            this_id = data_item.get_response().id
+            if this_id not in result_dict.keys():
+                result_dict[this_id] = []
+            result_dict[this_id].append((recv_count, data_item))
+
+        recv_count += 1
+
+    # Validate results...
+    for i in range(in_values.size):
+        this_id = str(i)
+        if in_values[i] != 0 and this_id not in result_dict.keys():
+            print("response for request id {} not received".format(this_id))
+            sys.exit(1)
+        elif in_values[i] == 0 and this_id in result_dict.keys():
+            print("received unexpected response for request id {}".format(
+                this_id))
+            sys.exit(1)
+        if in_values[i] != 0:
+            if len(result_dict[this_id]) != in_values[i]:
+                print("expected {} many responses for request id {}, got {}".
+                      format(in_values[i], this_id, result_dict[this_id]))
+                sys.exit(1)
+        result_list = result_dict[this_id]
+        expected_data = np.array([in_values[i]], dtype=np.int32)
+        for j in range(len(result_list)):
+            this_data = result_list[j][1].as_numpy('OUT')
+            if not np.array_equal(expected_data, this_data):
+                print("incorrect data: expected {}, got {}".format(
+                    expected_data, this_data))
+                sys.exit(1)
+
+    print('PASS: square_int32')
+    sys.exit(0)

--- a/examples/decoupled/square_config.pbtxt
+++ b/examples/decoupled/square_config.pbtxt
@@ -1,0 +1,46 @@
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "square_int32"
+backend: "python"
+max_batch_size: 0
+model_transaction_policy {
+  decoupled: True
+}
+input [
+  {
+    name: "IN"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+output [
+  {
+    name: "OUT"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]

--- a/examples/decoupled/square_config.pbtxt
+++ b/examples/decoupled/square_config.pbtxt
@@ -44,3 +44,4 @@ output [
     dims: [ 1 ]
   }
 ]
+instance_group [{ kind: KIND_CPU }]

--- a/examples/decoupled/square_model.py
+++ b/examples/decoupled/square_model.py
@@ -173,6 +173,8 @@ class TritonPythonModel:
         """`finalize` is called only once when the model is being unloaded.
         Implementing `finalize` function is OPTIONAL. This function allows
         the model to perform any necessary clean ups before exit.
+        Here we will wait for all response threads to complete sending
+        responses.
         """
 
         print('Finalize invoked')

--- a/examples/decoupled/square_model.py
+++ b/examples/decoupled/square_model.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2022, NVIDIA CORPORATION. All rights reserved.
+# Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions

--- a/examples/decoupled/square_model.py
+++ b/examples/decoupled/square_model.py
@@ -25,8 +25,9 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import json
-import threading
 import numpy as np
+import threading
+import time
 
 # triton_python_backend_utils is available in every Triton Python model. You
 # need to use this module to create inference requests and responses. It also
@@ -154,8 +155,8 @@ class TritonPythonModel:
     def process_request(self, request):
         # Start a separate thread to send the responses for the request. The
         # sending back the responses is delegated to this thread.
-        thread = threading.Thread(target=response_thread,
-                                  args=(self, request.get_response_sender(),
+        thread = threading.Thread(target=self.response_thread,
+                                  args=(request.get_response_sender(),
                                         pb_utils.get_input_tensor_by_name(
                                             request, 'IN').as_numpy()))
 

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -213,7 +213,7 @@ def get_output_config_by_name(model_config, name):
     return None
 
 def using_decoupled_model_transaction_policy(model_config):
-    """Whether or not the model is using decoupled model
+    """Whether or not the model is configured with decoupled
     transaction policy.
     Parameters
     ----------
@@ -222,9 +222,9 @@ def using_decoupled_model_transaction_policy(model_config):
 
     Returns
     -------
-    dict
-        A dictionary containing all the properties for a given output
-        name, or None if no output with this name exists
+    bool
+        True if the model is configured with decoupled transaction
+        policy.
     """
     if 'model_transaction_policy' in model_config:
         return model_config['model_transaction_policy']['decoupled']

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -212,6 +212,25 @@ def get_output_config_by_name(model_config, name):
 
     return None
 
+def using_decoupled_model_transaction_policy(model_config):
+    """Whether or not the model is using decoupled model
+    transaction policy.
+    Parameters
+    ----------
+    model_config : dict
+        dictionary object containing the model configuration
+
+    Returns
+    -------
+    dict
+        A dictionary containing all the properties for a given output
+        name, or None if no output with this name exists
+    """
+    if 'model_transaction_policy' in model_config:
+        return model_config['model_transaction_policy']['decoupled']
+
+    return False
+
 
 def triton_to_numpy_type(data_type):
     if data_type == 1:


### PR DESCRIPTION
These example model.py can be easily swapped with repeat_int32 and square_int32 in L0_decoupled_test for a decent test coverage. Other special cases will be covered in L0_backend_python tests. 
The detailed explanation of the examples will be added with another PR.