### PR TITLE
Add TYPE_BF16 scaffolding

### DIFF
--- a/src/pb_stub_utils.cc
+++ b/src/pb_stub_utils.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/pb_stub_utils.cc
+++ b/src/pb_stub_utils.cc
@@ -166,9 +166,12 @@ triton_to_pybind_dtype(TRITONSERVER_DataType data_type)
       // Will be reinterpreted in the python code.
       dtype_numpy = py::dtype(py::format_descriptor<uint8_t>::format());
       break;
+    case TRITONSERVER_TYPE_BF16:
+      throw PythonBackendException("TYPE_BF16 not currently supported.");
     case TRITONSERVER_TYPE_INVALID:
       throw PythonBackendException("Dtype is invalid.");
-      break;
+    default:
+      throw PythonBackendException("Unsupported triton dtype.");
   }
 
   return dtype_numpy;
@@ -242,7 +245,6 @@ triton_to_dlpack_type(TRITONSERVER_DataType triton_dtype)
           std::string("DType code \"") +
           std::to_string(static_cast<int>(triton_dtype)) +
           "\" is not supported.");
-      break;
   }
 
   dl_dtype.code = dl_code;

--- a/src/pb_stub_utils.cc
+++ b/src/pb_stub_utils.cc
@@ -166,6 +166,8 @@ triton_to_pybind_dtype(TRITONSERVER_DataType data_type)
       // Will be reinterpreted in the python code.
       dtype_numpy = py::dtype(py::format_descriptor<uint8_t>::format());
       break;
+    case TRITONSERVER_TYPE_BF16:
+      throw PythonBackendException("TYPE_BF16 not currently supported.");
     case TRITONSERVER_TYPE_INVALID:
       throw PythonBackendException("Dtype is invalid.");
     default:

--- a/src/pb_stub_utils.cc
+++ b/src/pb_stub_utils.cc
@@ -166,8 +166,6 @@ triton_to_pybind_dtype(TRITONSERVER_DataType data_type)
       // Will be reinterpreted in the python code.
       dtype_numpy = py::dtype(py::format_descriptor<uint8_t>::format());
       break;
-    case TRITONSERVER_TYPE_BF16:
-      throw PythonBackendException("TYPE_BF16 not currently supported.");
     case TRITONSERVER_TYPE_INVALID:
       throw PythonBackendException("Dtype is invalid.");
     default:


### PR DESCRIPTION
Most backends handle TYPE_BF16 in their `default / else` cases. Simply added a `default` to one of the type conversion helpers, as well as a `TYPE_BF16` case just to have a clear error message since the specific type isn't included in the default case error.

Also removed unnecessary `break`s after `throw`s