### PR TITLE
Add support for flags in response send

### DIFF
--- a/examples/decoupled/repeat_config.pbtxt
+++ b/examples/decoupled/repeat_config.pbtxt
@@ -60,11 +60,3 @@ output [
   }
 ]
 instance_group [{ kind: KIND_CPU }]
-<<<<<<< HEAD
-<<<<<<< HEAD
-
-=======
->>>>>>> Some examples for using decoupled API (#137)
-=======
-
->>>>>>> Initial decoupled implementation

--- a/examples/decoupled/repeat_config.pbtxt
+++ b/examples/decoupled/repeat_config.pbtxt
@@ -61,6 +61,10 @@ output [
 ]
 instance_group [{ kind: KIND_CPU }]
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 =======
 >>>>>>> Some examples for using decoupled API (#137)
+=======
+
+>>>>>>> Initial decoupled implementation

--- a/examples/decoupled/repeat_config.pbtxt
+++ b/examples/decoupled/repeat_config.pbtxt
@@ -60,4 +60,7 @@ output [
   }
 ]
 instance_group [{ kind: KIND_CPU }]
+<<<<<<< HEAD
 
+=======
+>>>>>>> Some examples for using decoupled API (#137)

--- a/examples/decoupled/repeat_model.py
+++ b/examples/decoupled/repeat_model.py
@@ -137,6 +137,7 @@ class TritonPythonModel:
             raise pb_utils.TritonModelException("unsupported batch size " +
                                                 len(requests))
 
+<<<<<<< HEAD
         in_input = pb_utils.get_input_tensor_by_name(requests[0],
                                                      'IN').as_numpy()
         delay_input = pb_utils.get_input_tensor_by_name(requests[0],
@@ -151,6 +152,17 @@ class TritonPythonModel:
         thread = threading.Thread(target=self.response_thread,
                                   args=(requests[0].get_response_sender(),
                                         in_input, delay_input))
+=======
+        # Start a separate thread to send the responses for the request. The
+        # sending back the responses is delegated to this thread.
+        thread = threading.Thread(
+            target=self.response_thread,
+            args=(self, requests[0].get_response_sender(),
+                  pb_utils.get_input_tensor_by_name(requests[0],
+                                                    'IN').as_numpy(),
+                  pb_utils.get_input_tensor_by_name(requests[0],
+                                                    'DELAY').as_numpy()))
+>>>>>>> Some examples for using decoupled API (#137)
 
         # A model using decoupled transaction policy is not required to send all
         # responses for the current request before returning from the execute.

--- a/examples/decoupled/repeat_model.py
+++ b/examples/decoupled/repeat_model.py
@@ -138,6 +138,9 @@ class TritonPythonModel:
                                                 len(requests))
 
 <<<<<<< HEAD
+<<<<<<< HEAD
+=======
+>>>>>>> Initial decoupled implementation
         in_input = pb_utils.get_input_tensor_by_name(requests[0],
                                                      'IN').as_numpy()
         delay_input = pb_utils.get_input_tensor_by_name(requests[0],
@@ -147,6 +150,7 @@ class TritonPythonModel:
                 f"expected IN and DELAY shape to match, got {list(in_input.shape)} and {list(delay_input.shape)}."
             )
 
+<<<<<<< HEAD
         # Start a separate thread to send the responses for the request. The
         # sending back the responses is delegated to this thread.
         thread = threading.Thread(target=self.response_thread,
@@ -163,6 +167,13 @@ class TritonPythonModel:
                   pb_utils.get_input_tensor_by_name(requests[0],
                                                     'DELAY').as_numpy()))
 >>>>>>> Some examples for using decoupled API (#137)
+=======
+        # Start a separate thread to send the responses for the request. The
+        # sending back the responses is delegated to this thread.
+        thread = threading.Thread(target=self.response_thread,
+                                  args=(requests[0].get_response_sender(),
+                                        in_input, delay_input))
+>>>>>>> Initial decoupled implementation
 
         # A model using decoupled transaction policy is not required to send all
         # responses for the current request before returning from the execute.

--- a/examples/decoupled/repeat_model.py
+++ b/examples/decoupled/repeat_model.py
@@ -207,10 +207,11 @@ class TritonPythonModel:
                 output_tensors=[idx_output, out_output])
             response_sender.send(response)
 
-        # We must close the response sender to indicate to Triton that we are
-        # done sending responses for the corresponding request. We can't use the
-        # response sender after closing it.
-        response_sender.close()
+        # We must close the response sender to indicate to Triton that we are done sending
+        # responses for the corresponding request. We can't use the response sender after
+        # closing it.
+        response_sender.send(
+            flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL)
 
         with self.inflight_thread_count_lck:
             self.inflight_thread_count -= 1

--- a/examples/decoupled/repeat_model.py
+++ b/examples/decoupled/repeat_model.py
@@ -43,26 +43,30 @@ class TritonPythonModel:
     This model demonstrates how to write a decoupled model where each
     request can generate 0 to many responses.
 
-    This model has three inputs and two outputs. The model does not support batching.
-    
-      - Input 'IN' can have any vector shape (e.g. [4] or [12]), datatype must be INT32.
+    This model has three inputs and two outputs. The model does not support
+    batching.
+
+      - Input 'IN' can have any vector shape (e.g. [4] or [12]), datatype must
+      be INT32.
       - Input 'DELAY' must have the same shape as IN, datatype must be UINT32.
       - Input 'WAIT' must have shape [1] and datatype UINT32.
       - For each response, output 'OUT' must have shape [1] and datatype INT32.
       - For each response, output 'IDX' must have shape [1] and datatype UINT32.
-         
-    For a request, the model will send 'n' responses where 'n' is the number of elements in IN. 
-    For the i'th response, OUT will equal the i'th element of IN and IDX will equal the zero-based
-    count of this response for the request. For example, the first response for a request will
-    have IDX = 0 and OUT = IN[0], the second will have IDX = 1 and OUT = IN[1], etc. The model
-    will wait the i'th DELAY, in milliseconds, before sending the i'th response. If IN shape is [0]
-    then no responses will be sent.
-    
-    After WAIT milliseconds the model will return from the execute function so that Triton can call
-    execute again with another request. WAIT can be less than the sum of DELAY so that execute
-    returns before all responses are sent. Thus, even if there is only one instance of the model,
-    multiple requests can be processed at the same time, and the responses for multiple requests
-    can be intermixed, depending on the values of DELAY and WAIT.
+
+    For a request, the model will send 'n' responses where 'n' is the number of
+    elements in IN.  For the i'th response, OUT will equal the i'th element of
+    IN and IDX will equal the zero-based count of this response for the request.
+    For example, the first response for a request will have IDX = 0 and OUT =
+    IN[0], the second will have IDX = 1 and OUT = IN[1], etc. The model will
+    wait the i'th DELAY, in milliseconds, before sending the i'th response. If
+    IN shape is [0] then no responses will be sent.
+
+    After WAIT milliseconds the model will return from the execute function so
+    that Triton can call execute again with another request. WAIT can be less
+    than the sum of DELAY so that execute returns before all responses are sent.
+    Thus, even if there is only one instance of the model, multiple requests can
+    be processed at the same time, and the responses for multiple requests can
+    be intermixed, depending on the values of DELAY and WAIT.
     """
 
     def initialize(self, args):
@@ -90,7 +94,7 @@ class TritonPythonModel:
         if not using_decoupled:
             raise pb_utils.TritonModelException(
                 """the model `{}` can generate any number of responses per request,
-                enable decoupled transaction policy in model configuration to 
+                enable decoupled transaction policy in model configuration to
                 serve this model""".format(args['model_name']))
 
         # Get OUT configuration
@@ -117,10 +121,11 @@ class TritonPythonModel:
         argument. This function is called when an inference request is made
         for this model. The request.get_response_sender() must be used to
         get an InferenceResponseSender object associated with the request.
-        Use the InferenceResponseSender.send() and InferenceResponseSender.close()
-        calls to send responses and indicate no responses will be sent for
-        the corresponding request respectively. If there is an error, you can
-        set the error argument when creating a pb_utils.InferenceResponse.
+        Use the InferenceResponseSender.send() and
+        InferenceResponseSender.close() calls to send responses and indicate no
+        responses will be sent for the corresponding request respectively. If
+        there is an error, you can set the error argument when creating a
+        pb_utils.InferenceResponse.
 
         Parameters
         ----------
@@ -132,15 +137,12 @@ class TritonPythonModel:
         None
         """
 
-        # This model does not support batching, so 'request_count' should always be 1.
+        # This model does not support batching, so 'request_count' should always
+        # be 1.
         if len(requests) != 1:
             raise pb_utils.TritonModelException("unsupported batch size " +
                                                 len(requests))
 
-<<<<<<< HEAD
-<<<<<<< HEAD
-=======
->>>>>>> Initial decoupled implementation
         in_input = pb_utils.get_input_tensor_by_name(requests[0],
                                                      'IN').as_numpy()
         delay_input = pb_utils.get_input_tensor_by_name(requests[0],
@@ -150,30 +152,11 @@ class TritonPythonModel:
                 f"expected IN and DELAY shape to match, got {list(in_input.shape)} and {list(delay_input.shape)}."
             )
 
-<<<<<<< HEAD
         # Start a separate thread to send the responses for the request. The
         # sending back the responses is delegated to this thread.
         thread = threading.Thread(target=self.response_thread,
                                   args=(requests[0].get_response_sender(),
                                         in_input, delay_input))
-=======
-        # Start a separate thread to send the responses for the request. The
-        # sending back the responses is delegated to this thread.
-        thread = threading.Thread(
-            target=self.response_thread,
-            args=(self, requests[0].get_response_sender(),
-                  pb_utils.get_input_tensor_by_name(requests[0],
-                                                    'IN').as_numpy(),
-                  pb_utils.get_input_tensor_by_name(requests[0],
-                                                    'DELAY').as_numpy()))
->>>>>>> Some examples for using decoupled API (#137)
-=======
-        # Start a separate thread to send the responses for the request. The
-        # sending back the responses is delegated to this thread.
-        thread = threading.Thread(target=self.response_thread,
-                                  args=(requests[0].get_response_sender(),
-                                        in_input, delay_input))
->>>>>>> Initial decoupled implementation
 
         # A model using decoupled transaction policy is not required to send all
         # responses for the current request before returning from the execute.
@@ -186,26 +169,27 @@ class TritonPythonModel:
 
         thread.start()
 
-        # Read WAIT input for wait time, then return so that Triton can call execute again with
-        # another request.
+        # Read WAIT input for wait time, then return so that Triton can call
+        # execute again with another request.
         wait_input = pb_utils.get_input_tensor_by_name(requests[0],
                                                        'WAIT').as_numpy()
         time.sleep(wait_input[0] / 1000)
 
-        # Unlike in non-decoupled model transaction policy, execute function here returns no
-        # response. A return from this function only notifies Triton that the model instance
-        # is ready to receive another request. As we are not waiting for the response thread
-        # to complete here, it is possible that at any give time the model may be processing
-        # multiple requests. Depending upon the request workload, this may lead to a lot of
-        # requests being processed by a single model instance at a time. In real-world models,
-        # the developer should be mindful of when to return from execute and be willing to
-        # accept next request.
+        # Unlike in non-decoupled model transaction policy, execute function
+        # here returns no response. A return from this function only notifies
+        # Triton that the model instance is ready to receive another request. As
+        # we are not waiting for the response thread to complete here, it is
+        # possible that at any give time the model may be processing multiple
+        # requests. Depending upon the request workload, this may lead to a lot
+        # of requests being processed by a single model instance at a time. In
+        # real-world models, the developer should be mindful of when to return
+        # from execute and be willing to accept next request.
         return None
 
     def response_thread(self, response_sender, in_input, delay_input):
-        # The response_sender is used to send response(s) associated with the corresponding request.
-        # Iterate over input/delay pairs. Wait for DELAY milliseconds and then create and
-        # send a response.
+        # The response_sender is used to send response(s) associated with the
+        # corresponding request.  Iterate over input/delay pairs. Wait for DELAY
+        # milliseconds and then create and send a response.
 
         idx_dtype = self.idx_dtype
         out_dtype = self.out_dtype
@@ -223,9 +207,9 @@ class TritonPythonModel:
                 output_tensors=[idx_output, out_output])
             response_sender.send(response)
 
-        # We must close the response sender to indicate to Triton that we are done sending
-        # responses for the corresponding request. We can't use the response sender after
-        # closing it.
+        # We must close the response sender to indicate to Triton that we are
+        # done sending responses for the corresponding request. We can't use the
+        # response sender after closing it.
         response_sender.close()
 
         with self.inflight_thread_count_lck:
@@ -241,7 +225,6 @@ class TritonPythonModel:
         print('Finalize invoked')
 
         inflight_threads = True
-        print_status = False
         cycles = 0
         logging_time_sec = 5
         sleep_time_sec = 0.1

--- a/examples/decoupled/repeat_model.py
+++ b/examples/decoupled/repeat_model.py
@@ -121,11 +121,17 @@ class TritonPythonModel:
         argument. This function is called when an inference request is made
         for this model. The request.get_response_sender() must be used to
         get an InferenceResponseSender object associated with the request.
-        Use the InferenceResponseSender.send() and
-        InferenceResponseSender.close() calls to send responses and indicate no
-        responses will be sent for the corresponding request respectively. If
+        Use the InferenceResponseSender.send(response=<infer response object>,
+        flags=<flags>) to send responses.
+
+        In the final response sent using the response sender object, you must
+        set the flags argument to TRITONSERVER_RESPONSE_COMPLETE_FINAL to
+        indicate no responses will be sent for the corresponding request. If
         there is an error, you can set the error argument when creating a
-        pb_utils.InferenceResponse.
+        pb_utils.InferenceResponse. Setting the flags argument is optional and
+        defaults to zero. When the flags argument is set to
+        TRITONSERVER_RESPONSE_COMPLETE_FINAL providing the response argument is
+        optional.
 
         Parameters
         ----------
@@ -207,9 +213,10 @@ class TritonPythonModel:
                 output_tensors=[idx_output, out_output])
             response_sender.send(response)
 
-        # We must close the response sender to indicate to Triton that we are done sending
-        # responses for the corresponding request. We can't use the response sender after
-        # closing it.
+        # We must close the response sender to indicate to Triton that we are
+        # done sending responses for the corresponding request. We can't use the
+        # response sender after closing it. The response sender is closed by
+        # setting the TRITONSERVER_RESPONSE_COMPLETE_FINAL.
         response_sender.send(
             flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL)
 

--- a/examples/decoupled/square_config.pbtxt
+++ b/examples/decoupled/square_config.pbtxt
@@ -45,4 +45,7 @@ output [
   }
 ]
 instance_group [{ kind: KIND_CPU }]
+<<<<<<< HEAD
 
+=======
+>>>>>>> Some examples for using decoupled API (#137)

--- a/examples/decoupled/square_config.pbtxt
+++ b/examples/decoupled/square_config.pbtxt
@@ -46,6 +46,10 @@ output [
 ]
 instance_group [{ kind: KIND_CPU }]
 <<<<<<< HEAD
+<<<<<<< HEAD
 
 =======
 >>>>>>> Some examples for using decoupled API (#137)
+=======
+
+>>>>>>> Initial decoupled implementation

--- a/examples/decoupled/square_config.pbtxt
+++ b/examples/decoupled/square_config.pbtxt
@@ -45,11 +45,4 @@ output [
   }
 ]
 instance_group [{ kind: KIND_CPU }]
-<<<<<<< HEAD
-<<<<<<< HEAD
 
-=======
->>>>>>> Some examples for using decoupled API (#137)
-=======
-
->>>>>>> Initial decoupled implementation

--- a/examples/decoupled/square_model.py
+++ b/examples/decoupled/square_model.py
@@ -183,10 +183,11 @@ class TritonPythonModel:
             response = pb_utils.InferenceResponse(output_tensors=[out_output])
             response_sender.send(response)
 
-        # We must close the response sender to indicate to Triton that we are
-        # done sending responses for the corresponding request. We can't use the
-        # response sender after closing it.
-        response_sender.close()
+        # We must close the response sender to indicate to Triton that we are done sending
+        # responses for the corresponding request. We can't use the response sender after
+        # closing it.
+        response_sender.send(
+            flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL)
 
         with self.inflight_thread_count_lck:
             self.inflight_thread_count -= 1

--- a/examples/decoupled/square_model.py
+++ b/examples/decoupled/square_model.py
@@ -46,10 +46,10 @@ class TritonPythonModel:
     This model has one input and one output. The model can support batching,
     with constraint that each request must be batch-1 request, but the shapes
     described here refer to the non-batch portion of the shape.
-    
+
       - Input 'IN' must have shape [1] and datatype INT32.
       - Output 'OUT' must have shape [1] and datatype INT32.
-         
+
     For a request, the backend will sent 'n' responses where 'n' is the
     element in IN. For each response, OUT will equal the element of IN.
     """
@@ -79,7 +79,7 @@ class TritonPythonModel:
         if not using_decoupled:
             raise pb_utils.TritonModelException(
                 """the model `{}` can generate any number of responses per request,
-                enable decoupled transaction policy in model configuration to 
+                enable decoupled transaction policy in model configuration to
                 serve this model""".format(args['model_name']))
 
         # Get IN configuration
@@ -122,9 +122,9 @@ class TritonPythonModel:
         for this model. The request.get_response_sender() must be used to
         get an InferenceResponseSender object associated with the request.
         Use the InferenceResponseSender.send() and InferenceResponseSender.end()
-        calls to send responses and indicate no responses will be sent for
-        the corresponding request respectively. If there is an error, you can
-        set the error argument when creating a pb_utils.InferenceResponse.
+        calls to send responses and indicate no responses will be sent for the
+        corresponding request respectively. If there is an error, you can set
+        the error argument when creating a pb_utils.InferenceResponse.
 
         Parameters
         ----------
@@ -136,20 +136,22 @@ class TritonPythonModel:
         None
         """
 
-        # Visit individual request to start processing them. Note that execute function is
-        # not required to wait for all the requests of the current batch to be processed
-        # before returning.
+        # Visit individual request to start processing them. Note that execute
+        # function is not required to wait for all the requests of the current
+        # batch to be processed before returning.
         for request in requests:
             self.process_request(request)
 
-        # Unlike in non-decoupled model transaction policy, execute function here returns no
-        # response. A return from this function only notifies Triton that the model instance
-        # is ready to receive another batch of requests. As we are not waiting for the
-        # response thread to complete here, it is possible that at any give time the model
-        # may be processing multiple batches of requests. Depending upon the request workload,
-        # this may lead to a lot of requests being processed by a single model instance at a
-        # time. In real-world models, the developer should be mindful of when to return from
-        # execute and be willing to accept next request batch.
+        # Unlike in non-decoupled model transaction policy, execute function
+        # here returns no response. A return from this function only notifies
+        # Triton that the model instance is ready to receive another batch of
+        # requests. As we are not waiting for the response thread to complete
+        # here, it is possible that at any give time the model may be processing
+        # multiple batches of requests. Depending upon the request workload,
+        # this may lead to a lot of requests being processed by a single model
+        # instance at a time. In real-world models, the developer should be
+        # mindful of when to return from execute and be willing to accept next
+        # request batch.
         return None
 
     def process_request(self, request):
@@ -172,27 +174,18 @@ class TritonPythonModel:
         thread.start()
 
     def response_thread(self, response_sender, in_input):
-        # The response_sender is used to send response(s) associated with the corresponding request.
+        # The response_sender is used to send response(s) associated with the
+        # corresponding request.
 
         for idx in range(in_input[0]):
-<<<<<<< HEAD
-<<<<<<< HEAD
             out_output = pb_utils.Tensor("OUT", np.array([in_input[0]],
                                                          np.int32))
-=======
-            out_output = pb_utils.Tensor("OUT",
-                                         numpy.array([in_input[0]], np.int32))
->>>>>>> Some examples for using decoupled API (#137)
-=======
-            out_output = pb_utils.Tensor("OUT", np.array([in_input[0]],
-                                                         np.int32))
->>>>>>> Initial decoupled implementation
             response = pb_utils.InferenceResponse(output_tensors=[out_output])
             response_sender.send(response)
 
-        # We must close the response sender to indicate to Triton that we are done sending
-        # responses for the corresponding request. We can't use the response sender after
-        # closing it.
+        # We must close the response sender to indicate to Triton that we are
+        # done sending responses for the corresponding request. We can't use the
+        # response sender after closing it.
         response_sender.close()
 
         with self.inflight_thread_count_lck:
@@ -209,7 +202,6 @@ class TritonPythonModel:
         print('Finalize invoked')
 
         inflight_threads = True
-        print_status = False
         cycles = 0
         logging_time_sec = 5
         sleep_time_sec = 0.1

--- a/examples/decoupled/square_model.py
+++ b/examples/decoupled/square_model.py
@@ -121,10 +121,17 @@ class TritonPythonModel:
         argument. This function is called when an inference request is made
         for this model. The request.get_response_sender() must be used to
         get an InferenceResponseSender object associated with the request.
-        Use the InferenceResponseSender.send() and InferenceResponseSender.end()
-        calls to send responses and indicate no responses will be sent for the
-        corresponding request respectively. If there is an error, you can set
-        the error argument when creating a pb_utils.InferenceResponse.
+        Use the InferenceResponseSender.send(response=<infer response object>,
+        flags=<flags>) to send responses.
+
+        In the final response sent using the response sender object, you must
+        set the flags argument to TRITONSERVER_RESPONSE_COMPLETE_FINAL to
+        indicate no responses will be sent for the corresponding request. If
+        there is an error, you can set the error argument when creating a
+        pb_utils.InferenceResponse. Setting the flags argument is optional and
+        defaults to zero. When the flags argument is set to
+        TRITONSERVER_RESPONSE_COMPLETE_FINAL providing the response argument is
+        optional.
 
         Parameters
         ----------
@@ -183,9 +190,10 @@ class TritonPythonModel:
             response = pb_utils.InferenceResponse(output_tensors=[out_output])
             response_sender.send(response)
 
-        # We must close the response sender to indicate to Triton that we are done sending
-        # responses for the corresponding request. We can't use the response sender after
-        # closing it.
+        # We must close the response sender to indicate to Triton that we are
+        # done sending responses for the corresponding request. We can't use the
+        # response sender after closing it. The response sender is closed by
+        # setting the TRITONSERVER_RESPONSE_COMPLETE_FINAL.
         response_sender.send(
             flags=pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL)
 

--- a/examples/decoupled/square_model.py
+++ b/examples/decoupled/square_model.py
@@ -176,12 +176,17 @@ class TritonPythonModel:
 
         for idx in range(in_input[0]):
 <<<<<<< HEAD
+<<<<<<< HEAD
             out_output = pb_utils.Tensor("OUT", np.array([in_input[0]],
                                                          np.int32))
 =======
             out_output = pb_utils.Tensor("OUT",
                                          numpy.array([in_input[0]], np.int32))
 >>>>>>> Some examples for using decoupled API (#137)
+=======
+            out_output = pb_utils.Tensor("OUT", np.array([in_input[0]],
+                                                         np.int32))
+>>>>>>> Initial decoupled implementation
             response = pb_utils.InferenceResponse(output_tensors=[out_output])
             response_sender.send(response)
 

--- a/examples/decoupled/square_model.py
+++ b/examples/decoupled/square_model.py
@@ -175,8 +175,13 @@ class TritonPythonModel:
         # The response_sender is used to send response(s) associated with the corresponding request.
 
         for idx in range(in_input[0]):
+<<<<<<< HEAD
             out_output = pb_utils.Tensor("OUT", np.array([in_input[0]],
                                                          np.int32))
+=======
+            out_output = pb_utils.Tensor("OUT",
+                                         numpy.array([in_input[0]], np.int32))
+>>>>>>> Some examples for using decoupled API (#137)
             response = pb_utils.InferenceResponse(output_tensors=[out_output])
             response_sender.send(response)
 

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -355,11 +355,6 @@ InferRequest::Exec()
   ResponseBatch* response_batch = nullptr;
   bool responses_is_set = false;
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
-  if (stub->IsDecoupled()) {
-    throw PythonBackendException(
-        "Running BLS requests is not supported in the decoupled transaction "
-        "policy.");
-  }
   std::unique_ptr<SharedMemoryManager>& shm_pool = stub->SharedMemory();
   bi::managed_external_buffer::handle_t* response_handle = nullptr;
 

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -68,7 +68,8 @@ class InferResponse {
 #ifndef TRITON_PB_STUB
   /// Send an inference response
   TRITONSERVER_Error* Send(
-      TRITONBACKEND_ResponseFactory* response_factory, void* cuda_stream);
+      TRITONBACKEND_ResponseFactory* response_factory, void* cuda_stream,
+      const uint32_t flags);
 #endif
 
   // Disallow copying the inference response object.

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -880,8 +880,9 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
 
   py::class_<ResponseSender, std::shared_ptr<ResponseSender>>(
       module, "InferenceResponseSender")
-      .def("send", &ResponseSender::Send)
-      .def("close", &ResponseSender::Close);
+      .def(
+          "send", &ResponseSender::Send, py::arg("response") = nullptr,
+          py::arg("flags") = 0);
 
   // This class is not part of the public API for Python backend. This is only
   // used for internal testing purposes.

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -153,9 +153,8 @@ struct ResponseSenderBase {
 
 struct ResponseSendMessage : ResponseSenderBase {
   bi::managed_external_buffer::handle_t response;
+  uint32_t flags;
 };
-
-using ResponseCloseMessage = ResponseSenderBase;
 
 struct RequestBatch {
   uint32_t batch_size;

--- a/src/python.cc
+++ b/src/python.cc
@@ -2003,6 +2003,7 @@ ModelInstanceState::~ModelInstanceState()
 
       ModelState* model_state = reinterpret_cast<ModelState*>(Model());
       if (model_state->IsDecoupled()) {
+        futures_.clear();
         parent_message_queue_->Push(DUMMY_MESSAGE);
         decoupled_monitor_.join();
       }

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -212,6 +212,7 @@ def get_output_config_by_name(model_config, name):
 
     return None
 
+
 def using_decoupled_model_transaction_policy(model_config):
     """Whether or not the model is configured with decoupled
     transaction policy.
@@ -296,3 +297,4 @@ def triton_string_to_numpy(triton_type_string):
 
 TRITONSERVER_REQUEST_FLAG_SEQUENCE_START = 1
 TRITONSERVER_REQUEST_FLAG_SEQUENCE_END = 2
+TRITONSERVER_RESPONSE_COMPLETE_FINAL = 1

--- a/src/response_sender.cc
+++ b/src/response_sender.cc
@@ -61,6 +61,12 @@ ResponseSender::Send(
         "Unable to send response. Unsupported flag provided.");
   }
 
+  if (flags == 0 && infer_response == nullptr) {
+    throw PythonBackendException(
+        "Inference Response object must be provided when the response flags is "
+        "set to zero.");
+  }
+
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
 
   AllocatedSharedMemory<ResponseSendMessage> response_send_message =

--- a/src/response_sender.cc
+++ b/src/response_sender.cc
@@ -43,11 +43,22 @@ ResponseSender::ResponseSender(
 
 
 void
-ResponseSender::Send(std::shared_ptr<InferResponse>& infer_response)
+ResponseSender::Send(
+    std::shared_ptr<InferResponse> infer_response, const uint32_t flags)
 {
   if (closed_) {
     throw PythonBackendException(
-        "Unable to send responses. Response sender has been closed.");
+        "Unable to send response. Response sender has been closed.");
+  }
+
+  if (flags == TRITONSERVER_RESPONSE_COMPLETE_FINAL) {
+    closed_ = true;
+  }
+
+  // Check the correctness of the provided flags.
+  if (flags != TRITONSERVER_RESPONSE_COMPLETE_FINAL && flags != 0) {
+    throw PythonBackendException(
+        "Unable to send response. Unsupported flag provided.");
   }
 
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
@@ -56,7 +67,9 @@ ResponseSender::Send(std::shared_ptr<InferResponse>& infer_response)
       shm_pool_->Construct<ResponseSendMessage>(
           1 /* count */, true /* aligned */);
 
-  infer_response->SaveToSharedMemory(shm_pool_, false /* copy_gpu */);
+  if (infer_response) {
+    infer_response->SaveToSharedMemory(shm_pool_, false /* copy_gpu */);
+  }
 
   ResponseSendMessage* send_message_payload = response_send_message.data_.get();
   new (&(send_message_payload->mu)) bi::interprocess_mutex;
@@ -65,9 +78,16 @@ ResponseSender::Send(std::shared_ptr<InferResponse>& infer_response)
   send_message_payload->is_stub_turn = false;
   send_message_payload->request_address = request_address_;
   send_message_payload->response_factory_address = response_factory_address_;
-  send_message_payload->response = infer_response->ShmHandle();
+
+  if (infer_response) {
+    send_message_payload->response = infer_response->ShmHandle();
+  } else {
+    send_message_payload->response = 0;
+  }
+
   send_message_payload->has_error = false;
   send_message_payload->is_error_set = false;
+  send_message_payload->flags = flags;
 
   std::unique_ptr<IPCMessage> ipc_message =
       IPCMessage::Create(shm_pool_, false /* inline_response */);
@@ -103,56 +123,5 @@ ResponseSender::Send(std::shared_ptr<InferResponse>& infer_response)
     }
   }
 }
-
-void
-ResponseSender::Close()
-{
-  if (closed_) {
-    throw PythonBackendException(
-        "Unable to close the response sender. Response sender has already been "
-        "closed.");
-  }
-  closed_ = true;
-  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
-  AllocatedSharedMemory<ResponseCloseMessage> response_close_message =
-      shm_pool_->Construct<ResponseCloseMessage>(
-          1 /* count */, true /* aligned */);
-
-  ResponseCloseMessage* close_message_payload =
-      reinterpret_cast<ResponseCloseMessage*>(
-          response_close_message.data_.get());
-
-  new (&(close_message_payload->mu)) bi::interprocess_mutex;
-  new (&(close_message_payload->cv)) bi::interprocess_condition;
-  close_message_payload->is_stub_turn = false;
-  close_message_payload->request_address = request_address_;
-  close_message_payload->response_factory_address = response_factory_address_;
-  close_message_payload->has_error = false;
-  close_message_payload->is_error_set = false;
-
-  std::unique_ptr<IPCMessage> ipc_message =
-      IPCMessage::Create(shm_pool_, false /* inline_response */);
-
-  ipc_message->Command() = PYTHONSTUB_ResponseClose;
-  ipc_message->Args() = response_close_message.handle_;
-
-  ScopedDefer _([&close_message_payload] {
-    {
-      bi::scoped_lock<bi::interprocess_mutex> guard{close_message_payload->mu};
-
-      close_message_payload->is_stub_turn = false;
-      close_message_payload->cv.notify_all();
-    }
-  });
-
-  {
-    bi::scoped_lock<bi::interprocess_mutex> guard{close_message_payload->mu};
-    stub->SendIPCMessage(ipc_message);
-    while (!close_message_payload->is_stub_turn) {
-      close_message_payload->cv.wait(guard);
-    }
-  }
-}
-
 
 }}}  // namespace triton::backend::python

--- a/src/response_sender.h
+++ b/src/response_sender.h
@@ -36,8 +36,7 @@ class ResponseSender {
   ResponseSender(
       intptr_t request_address, intptr_t response_factory_address,
       std::unique_ptr<SharedMemoryManager>& shm_pool);
-  void Send(std::shared_ptr<InferResponse>& infer_response);
-  void Close();
+  void Send(std::shared_ptr<InferResponse> response, const uint32_t flags);
 
  private:
   intptr_t request_address_;


### PR DESCRIPTION
Previously, we couldn't simultaneously send and close a response sender. With the new API, it is possible to close and send a response simultaneously.

The response_sender.close API has been removed to avoid confusion.

Only the last two commits needs to be reviewed. The rest of the commits will be rebased when BLS PR is merged.