### PR TITLE
Improve the GPU memory manager

### DIFF
--- a/src/memory_manager.h
+++ b/src/memory_manager.h
@@ -65,16 +65,15 @@ class GPUMemoryRecord : public MemoryRecord {
 /// message queue asking the memory manager to deallocate the GPU tensor.
 class MemoryManager {
  public:
-  MemoryManager(std::unique_ptr<MessageQueue<uint64_t>>&& memory_message_queue);
-  uint64_t AddRecord(std::unique_ptr<MemoryRecord>&& memory_record);
+  MemoryManager(std::unique_ptr<MessageQueue<intptr_t>>&& memory_message_queue);
+  intptr_t AddRecord(std::unique_ptr<MemoryRecord>&& memory_record);
   TRITONSERVER_Error* ResetCounter();
   ~MemoryManager();
 
  private:
   std::thread thread_;
-  std::unordered_map<uint64_t, std::unique_ptr<MemoryRecord>> records_;
-  uint64_t record_count_;
-  std::unique_ptr<MessageQueue<uint64_t>> message_queue_;
+  std::unordered_map<intptr_t, std::unique_ptr<MemoryRecord>> records_;
+  std::unique_ptr<MessageQueue<intptr_t>> message_queue_;
   void QueueMonitorThread();
   std::mutex mu_;
 };

--- a/src/python.cc
+++ b/src/python.cc
@@ -688,10 +688,10 @@ ModelInstanceState::StartStubProcess()
           MessageQueue<bi::managed_external_buffer::handle_t>::Create(
               shm_pool_, message_queue_size));
 
-  std::unique_ptr<MessageQueue<uint64_t>> memory_manager_message_queue;
+  std::unique_ptr<MessageQueue<intptr_t>> memory_manager_message_queue;
   RETURN_IF_EXCEPTION(
       memory_manager_message_queue =
-          MessageQueue<uint64_t>::Create(shm_pool_, message_queue_size));
+          MessageQueue<intptr_t>::Create(shm_pool_, message_queue_size));
 
   memory_manager_message_queue->ResetSemaphores();
   ipc_control_->memory_manager_message_queue =


### PR DESCRIPTION
Use address instead of the record count to make sure that we will not face overflow if the server is running for a very long period.