### PR TITLE
Expose Tensor dims

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -911,6 +911,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
       .def("triton_dtype", &PbTensor::TritonDtype)
       .def("to_dlpack", &PbTensor::ToDLPack)
       .def("is_cpu", &PbTensor::IsCPU)
+      .def("dims", &PbTensor::Dims)
       .def("from_dlpack", &PbTensor::FromDLPack);
 
   py::class_<InferResponse, std::shared_ptr<InferResponse>>(


### PR DESCRIPTION
It's useful to get the dims of a tensor to be able to do some post processing