### PR TITLE
Extend Logging to the python backend

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ set(
   src/scoped_defer.h
   src/pb_error.cc
   src/pb_error.h
+  src/pb_log.h
   src/pb_memory.cc
   src/pb_memory.h
   src/pb_tensor.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -143,6 +143,7 @@ set(
   src/scoped_defer.h
   src/pb_error.cc
   src/pb_error.h
+  src/pb_log.cc
   src/pb_log.h
   src/pb_memory.cc
   src/pb_memory.h

--- a/README.md
+++ b/README.md
@@ -72,6 +72,7 @@ any C++ code.
   - [Preprocessing](#preprocessing)
   - [Decoupled Models](#decoupled-models)
 - [Running with Inferentia](#running-with-inferentia)
+- [Logging to Triton](#logging-to-triton)
 - [Reporting problems, asking questions](#reporting-problems-asking-questions)
 
 ## Quick Start
@@ -1052,6 +1053,25 @@ You can find the complete example instructions in [examples/decoupled](examples/
 # Running with Inferentia
 
 Please see the [README.md](https://github.com/triton-inference-server/python_backend/tree/main/inferentia/README.md) located in the python_backend/inferentia sub folder.
+
+# Logging to Triton
+
+Model files that have imported ```triton_python_backend_utils``` can send log messages to the Triton server using any of the following access functions:
+```python
+import triton_python_backend_utils as pb_utils
+logger = pb_utils.Logger
+logger.log_info("Info Msg!")
+logger.log_warn("Warning Msg!")
+logger.log_error("Error Msg!")
+logger.log_verbose("Verbose Msg!")
+```
+Log messages can also be sent with their log-level type explcitiy specified:
+```python
+# log-level options: INFO, WARNING, ERROR, VERBOSE
+logger.log("Specific Msg!", logger.INFO)
+```
+
+Note that the Triton server's settings determine which log messages appear within the server log. For example, if a model attempts to log a verbose-level message, but Triton is not set to log verbose-level messages, it will not appear in the server log. For more information on Triton's log settings and how to adjust them dynamically, please see Triton's [logging extension](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_logging.md) document.
 
 # Reporting problems, asking questions
 

--- a/README.md
+++ b/README.md
@@ -72,7 +72,7 @@ any C++ code.
   - [Preprocessing](#preprocessing)
   - [Decoupled Models](#decoupled-models)
 - [Running with Inferentia](#running-with-inferentia)
-- [Logging to Triton](#logging-to-triton)
+- [Logging](#logging)
 - [Reporting problems, asking questions](#reporting-problems-asking-questions)
 
 ## Quick Start
@@ -1054,24 +1054,33 @@ You can find the complete example instructions in [examples/decoupled](examples/
 
 Please see the [README.md](https://github.com/triton-inference-server/python_backend/tree/main/inferentia/README.md) located in the python_backend/inferentia sub folder.
 
-# Logging to Triton
+# Logging
 
-Model files that have imported ```triton_python_backend_utils``` can send log messages to the Triton server using any of the following access functions:
+Your Python model can log information using the following methods:
+
 ```python
 import triton_python_backend_utils as pb_utils
+...
 logger = pb_utils.Logger
 logger.log_info("Info Msg!")
 logger.log_warn("Warning Msg!")
 logger.log_error("Error Msg!")
 logger.log_verbose("Verbose Msg!")
 ```
-Log messages can also be sent with their log-level type explcitiy specified:
+Log messages can also be sent with their log-level explcitiy specified:
 ```python
 # log-level options: INFO, WARNING, ERROR, VERBOSE
 logger.log("Specific Msg!", logger.INFO)
 ```
+If no log-level is specified, this method will log INFO level messages.
 
-Note that the Triton server's settings determine which log messages appear within the server log. For example, if a model attempts to log a verbose-level message, but Triton is not set to log verbose-level messages, it will not appear in the server log. For more information on Triton's log settings and how to adjust them dynamically, please see Triton's [logging extension](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_logging.md) document.
+Note that the Triton server's settings determine which log messages appear
+within the server log. For example, if a model attempts to log a verbose-level
+message, but Triton is not set to log verbose-level messages, it will not
+appear in the server log. For more information on Triton's log settings and
+how to adjust them dynamically, please see Triton's 
+[logging extension](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_logging.md)
+documentation.
 
 # Reporting problems, asking questions
 

--- a/src/ipc_message.h
+++ b/src/ipc_message.h
@@ -49,7 +49,6 @@ typedef enum PYTHONSTUB_commandtype_enum {
   PYTHONSTUB_ResponseClose,
   PYTHONSTUB_AutoCompleteRequest,
   PYTHONSTUB_AutoCompleteResponse,
-  PYTHONSTUB_LogRequest,
 } PYTHONSTUB_CommandType;
 
 ///

--- a/src/ipc_message.h
+++ b/src/ipc_message.h
@@ -48,7 +48,8 @@ typedef enum PYTHONSTUB_commandtype_enum {
   PYTHONSTUB_ResponseSend,
   PYTHONSTUB_ResponseClose,
   PYTHONSTUB_AutoCompleteRequest,
-  PYTHONSTUB_AutoCompleteResponse
+  PYTHONSTUB_AutoCompleteResponse,
+  PYTHONSTUB_LogRequest,
 } PYTHONSTUB_CommandType;
 
 ///

--- a/src/ipc_message.h
+++ b/src/ipc_message.h
@@ -48,7 +48,7 @@ typedef enum PYTHONSTUB_commandtype_enum {
   PYTHONSTUB_ResponseSend,
   PYTHONSTUB_ResponseClose,
   PYTHONSTUB_AutoCompleteRequest,
-  PYTHONSTUB_AutoCompleteResponse,
+  PYTHONSTUB_AutoCompleteResponse
 } PYTHONSTUB_CommandType;
 
 ///

--- a/src/pb_log.cc
+++ b/src/pb_log.cc
@@ -119,4 +119,3 @@ PbLogShm::LogMessage()
 }
 
 }}}  // namespace triton::backend::python
-

--- a/src/pb_log.cc
+++ b/src/pb_log.cc
@@ -118,5 +118,4 @@ PbLogShm::LogMessage()
   return log_container_shm_ptr_;
 }
 
-
 }}}  // namespace triton::backend::python

--- a/src/pb_log.cc
+++ b/src/pb_log.cc
@@ -1,0 +1,122 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pb_log.h"
+
+namespace triton { namespace backend { namespace python {
+
+PbLog::PbLog(
+    const std::string& filename, uint32_t line, const std::string& message,
+    LogLevel level)
+    : filename_(filename), line_(line), message_(message), level_(level)
+{
+}
+
+const std::string&
+PbLog::Filename()
+{
+  return filename_;
+}
+const std::string&
+PbLog::Message()
+{
+  return message_;
+}
+const LogLevel&
+PbLog::Level()
+{
+  return level_;
+}
+const uint32_t&
+PbLog::Line()
+{
+  return line_;
+}
+
+PbLogShm::PbLogShm(
+    AllocatedSharedMemory<LogSendMessage>& log_container_shm,
+    std::unique_ptr<PbString>& filename, std::unique_ptr<PbString>& message)
+    : log_container_shm_(std::move(log_container_shm)),
+      filename_pb_string_(std::move(filename)),
+      message_pb_string_(std::move(message))
+{
+  log_container_shm_ptr_ = log_container_shm_.data_.get();
+  log_container_shm_ptr_->filename = filename_pb_string_->ShmHandle();
+  log_container_shm_ptr_->log_message = message_pb_string_->ShmHandle();
+}
+
+std::unique_ptr<PbLogShm>
+PbLogShm::Create(
+    std::unique_ptr<SharedMemoryManager>& shm_pool, const std::string& filename,
+    const uint32_t& line, const std::string& message, const LogLevel& level)
+{
+  std::unique_ptr<PbString> file_name = PbString::Create(shm_pool, filename);
+  std::unique_ptr<PbString> log_message = PbString::Create(shm_pool, message);
+  AllocatedSharedMemory<LogSendMessage> log_send_message =
+      shm_pool->Construct<LogSendMessage>();
+
+  LogSendMessage* send_message_payload = log_send_message.data_.get();
+  new (&(send_message_payload->log_mu)) bi::interprocess_mutex;
+  new (&(send_message_payload->log_cv)) bi::interprocess_condition;
+  send_message_payload->line = line;
+  send_message_payload->level = level;
+
+  return std::unique_ptr<PbLogShm>(
+      new PbLogShm(log_send_message, file_name, log_message));
+}
+
+std::unique_ptr<PbLog>
+PbLogShm::LoadFromSharedMemory(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t handle)
+{
+  AllocatedSharedMemory<LogSendMessage> log_container_shm =
+      shm_pool->Load<LogSendMessage>(handle);
+  std::unique_ptr<PbString> pb_string_filename = PbString::LoadFromSharedMemory(
+      shm_pool, log_container_shm.data_->filename);
+  const std::string& filename = pb_string_filename->String();
+  uint32_t line = log_container_shm.data_->line;
+  std::unique_ptr<PbString> pb_string_msg = PbString::LoadFromSharedMemory(
+      shm_pool, log_container_shm.data_->log_message);
+  const std::string& message = pb_string_msg->String();
+  LogLevel level = log_container_shm.data_->level;
+  return std::unique_ptr<PbLog>(new PbLog(filename, line, message, level));
+}
+
+bi::managed_external_buffer::handle_t
+PbLogShm::ShmHandle()
+{
+  return log_container_shm_.handle_;
+}
+
+LogSendMessage*
+PbLogShm::LogMessage()
+{
+  return log_container_shm_ptr_;
+}
+
+
+}}}  // namespace triton::backend::python

--- a/src/pb_log.cc
+++ b/src/pb_log.cc
@@ -119,3 +119,4 @@ PbLogShm::LogMessage()
 }
 
 }}}  // namespace triton::backend::python
+

--- a/src/pb_log.h
+++ b/src/pb_log.h
@@ -35,15 +35,13 @@ class PbLog {
  public:
   PbLog(
       const std::string& filename, uint32_t line, const std::string& message,
-      LogLevel level, uint32_t verbosity)
-      : filename_(filename), line_(line), message_(message), level_(level),
-        verbosity_(verbosity)
+      LogLevel level)
+      : filename_(filename), line_(line), message_(message), level_(level)
   {
   }
   const std::string& Filename() { return filename_; };
   const std::string& Message() { return message_; };
   const LogLevel& Level() { return level_; };
-  const uint32_t& Verbosity() { return verbosity_; };
   const uint32_t& Line() { return line_; };
 
  private:
@@ -51,14 +49,12 @@ class PbLog {
   uint32_t line_;
   std::string message_;
   LogLevel level_;
-  uint32_t verbosity_;
 };
 struct LogMsgShm {
   bi::managed_external_buffer::handle_t filename;
   uint32_t line;
   bi::managed_external_buffer::handle_t logMsg;
   LogLevel level;
-  uint32_t verbosity;
   bool is_stub_turn;
   bi::managed_external_buffer::handle_t response_mutex;
   bi::managed_external_buffer::handle_t response_cond;

--- a/src/pb_log.h
+++ b/src/pb_log.h
@@ -59,8 +59,7 @@ class PbLogShm {
       bi::managed_external_buffer::handle_t handle);
   bi::managed_external_buffer::handle_t ShmHandle();
   LogSendMessage* LogMessage();
-  AllocatedSharedMemory<LogSendMessage> LogMessageShm();
-  
+
  private:
   AllocatedSharedMemory<LogSendMessage> log_container_shm_;
   std::unique_ptr<PbString> filename_pb_string_;

--- a/src/pb_log.h
+++ b/src/pb_log.h
@@ -1,0 +1,66 @@
+// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <string>
+#include "pb_string.h"
+#include "pb_utils.h"
+
+namespace triton { namespace backend { namespace python {
+class PbLog {
+ public:
+  PbLog(
+      const std::string& filename, uint32_t line, const std::string& message,
+      LogLevel level, uint32_t verbosity)
+      : filename_(filename), line_(line), message_(message), level_(level),
+        verbosity_(verbosity)
+  {
+  }
+  const std::string& Filename() { return filename_; };
+  const std::string& Message() { return message_; };
+  const LogLevel& Level() { return level_; };
+  const uint32_t& Verbosity() { return verbosity_; };
+  const uint32_t& Line() { return line_; };
+
+ private:
+  std::string filename_;
+  uint32_t line_;
+  std::string message_;
+  LogLevel level_;
+  uint32_t verbosity_;
+};
+struct LogMsgShm {
+  bi::managed_external_buffer::handle_t filename;
+  uint32_t line;
+  bi::managed_external_buffer::handle_t logMsg;
+  LogLevel level;
+  uint32_t verbosity;
+  bool is_stub_turn;
+  bi::managed_external_buffer::handle_t response_mutex;
+  bi::managed_external_buffer::handle_t response_cond;
+};
+}}};  // namespace triton::backend::python

--- a/src/pb_log.h
+++ b/src/pb_log.h
@@ -33,12 +33,22 @@
 namespace triton { namespace backend { namespace python {
 class PbLog {
  public:
+
+  /// Create a PbLog instance
   PbLog(
       const std::string& filename, uint32_t line, const std::string& message,
       LogLevel level);
+
+  /// Get the filename where the log was recorded
   const std::string& Filename();
+
+  /// Get the log message
   const std::string& Message();
+
+  /// Get the log level of the message
   const LogLevel& Level();
+
+  /// Get the line number of the log message
   const uint32_t& Line();
 
  private:
@@ -50,14 +60,21 @@ class PbLog {
 
 class PbLogShm {
  public:
+  /// Save PbLog object to shared memory
   static std::unique_ptr<PbLogShm> Create(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       const std::string& filename, const uint32_t& line,
       const std::string& message, const LogLevel& level);
+  
+  /// Load PbLog object to shared memory
   static std::unique_ptr<PbLog> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       bi::managed_external_buffer::handle_t handle);
+
+  /// Get the shared memory handle of the saved log message
   bi::managed_external_buffer::handle_t ShmHandle();
+
+  /// Get a pointer to the saved log message
   LogSendMessage* LogMessage();
 
  private:

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -922,10 +922,11 @@ Stub::SendLogMessage(
       IPCMessage::Create(shm_pool_, false /* inline_response */);
   log_request_msg->Command() = PYTHONSTUB_LogRequest;
   log_request_msg->Args() = log_send_message.handle_;
-   
+
   ScopedDefer _([send_message_payload] {
     {
-      bi::scoped_lock<bi::interprocess_mutex> guard{send_message_payload->log_mu};
+      bi::scoped_lock<bi::interprocess_mutex> guard{
+          send_message_payload->log_mu};
       send_message_payload->waiting_on_stub = false;
       send_message_payload->log_cv.notify_all();
     }
@@ -949,34 +950,6 @@ Logger::log(
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   PbLog* log_msg = new PbLog(filename, line, message, level);
   stub->EnqueueLogRequest(log_msg);
-}
-
-void
-Logger::log_info(
-    const std::string& filename, uint32_t line, const std::string& message)
-{
-  Logger::log(filename, line, message, LogLevel::INFO);
-}
-
-void
-Logger::log_warn(
-    const std::string& filename, uint32_t line, const std::string& message)
-{
-  Logger::log(filename, line, message, LogLevel::WARNINGS);
-}
-
-void
-Logger::log_error(
-    const std::string& filename, uint32_t line, const std::string& message)
-{
-  Logger::log(filename, line, message, LogLevel::ERRORS);
-}
-
-void
-Logger::log_verbose(
-    const std::string& filename, uint32_t line, const std::string& message)
-{
-  Logger::log(filename, line, message, LogLevel::VERBOSE);
 }
 
 PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
@@ -1087,15 +1060,6 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
   logger.def(
       "log", &Logger::log, py::arg("filename"), py::arg("line"),
       py::arg("message") = "", py::arg("level") = LogLevel::INFO);
-  logger.def("log_info", &Logger::log_info,
-    py::arg("filename"), py::arg("line"), py::arg("message") = "");
-  logger.def("log_warn", &Logger::log_warn,
-    py::arg("filename"), py::arg("line"), py::arg("message") = "");
-  logger.def("log_error", &Logger::log_error,
-    py::arg("filename"), py::arg("line"), py::arg("message") = "");
-  logger.def(
-      "log_verbose", &Logger::log_verbose, py::arg("filename"),
-      py::arg("line"), py::arg("message") = "");
 
   // This class is not part of the public API for Python backend. This is only
   // used for internal testing purposes.

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -471,8 +471,6 @@ Stub::Initialize(bi::managed_external_buffer::handle_t map_handle)
   py::setattr(
       python_backend_utils, "InferenceResponse",
       c_python_backend_utils.attr("InferenceResponse"));
-  py::setattr(
-      python_backend_utils, "Logger", c_python_backend_utils.attr("Logger"));
   c_python_backend_utils.attr("shared_memory") = py::cast(shm_pool_.get());
 
   py::object TritonPythonModel = sys.attr("TritonPythonModel");
@@ -1147,12 +1145,12 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
       .export_values();
   logger.def_static(
       "log", py::overload_cast<const std::string&, LogLevel>(&Logger::Log),
-      py::arg("message") = "", py::arg("level") = LogLevel::INFO);
-  logger.def_static("log_info", &Logger::LogInfo, py::arg("message") = "");
-  logger.def_static("log_warn", &Logger::LogWarn, py::arg("message") = "");
-  logger.def_static("log_error", &Logger::LogError, py::arg("message") = "");
+      py::arg("message"), py::arg("level") = LogLevel::INFO);
+  logger.def_static("log_info", &Logger::LogInfo, py::arg("message"));
+  logger.def_static("log_warn", &Logger::LogWarn, py::arg("message"));
+  logger.def_static("log_error", &Logger::LogError, py::arg("message"));
   logger.def_static(
-      "log_verbose", &Logger::LogVerbose, py::arg("message") = "");
+      "log_verbose", &Logger::LogVerbose, py::arg("message"));
 
   // This class is not part of the public API for Python backend. This is only
   // used for internal testing purposes.

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -967,7 +967,7 @@ Logger::Log(const std::string& message, LogLevel level)
   uint32_t line = lineno.cast<uint32_t>();
 
   if (!stub->LogServiceActive()) {
-    Logger::Log(filename, line, message, level);
+    Logger::GetOrCreateInstance().Log(filename, line, level, message);
   } else {
     std::unique_ptr<PbLog> log_msg(new PbLog(filename, line, message, level));
     stub->EnqueueLogRequest(log_msg);

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1248,7 +1248,7 @@ main(int argc, char** argv)
   while (true) {
     if (finalize) {
       stub->Finalize();
-      // Need check or may recieve not joinable error
+      // Need check or may receive not joinable error
       if (stub->LogServiceActive()) {
         stub->TerminateLogRequestThread();
       }

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -108,11 +108,7 @@ class Logger {
     return instance;
   }
 
-  /// Should not be cloneable
-  Logger(Logger const&) = delete;
-
-  /// Should not be assignable
-  void operator=(Logger const&) = delete;
+  DISALLOW_COPY_AND_ASSIGN(Logger);
 
   /// Flush the log.
   void Flush() { std::cerr << std::flush; }

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -80,14 +80,6 @@ class Logger {
   void log(
       const std::string& filename, uint32_t line, const std::string& message,
       LogLevel level = LogLevel::INFO);
-  void log_info(
-      const std::string& filename, uint32_t line, const std::string& message);
-  void log_warn(
-      const std::string& filename, uint32_t line, const std::string& message);
-  void log_error(
-      const std::string& filename, uint32_t line, const std::string& message);
-  void log_verbose(
-      const std::string& filename, uint32_t line, const std::string& message);
 
   // Flush the log.
   void Flush() { std::cerr << std::flush; }

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -229,9 +229,6 @@ class Stub {
   /// Check if log handler is running
   bool LogServiceActive();
 
-  /// Check if the stub is initialized
-  bool Initialized();
-
  private:
   bi::interprocess_mutex* stub_mutex_;
   bi::interprocess_condition* stub_cond_;

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -120,6 +120,7 @@ class Logger {
 
 class LogMessage {
  public:
+  /// Create a log message, stripping the path down to the filename only
   LogMessage(const char* file, int line, LogLevel level) : level_(level)
   {
     std::string path(file);
@@ -130,7 +131,7 @@ class LogMessage {
     file_ = path;
     line_ = static_cast<uint32_t>(line);
   }
-
+  /// Log message to console or send to backend (see Logger::Log for details)
   ~LogMessage()
   {
     Logger::GetOrCreateInstance().Log(file_, line_, level_, stream_.str());

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -79,7 +79,7 @@ class Logger {
 
   void log(
       const std::string& filename, uint32_t line, const std::string& message,
-      LogLevel level = LogLevel::INFO, uint32_t verbosity = 0);
+      LogLevel level = LogLevel::INFO);
   void log_info(
       const std::string& filename, uint32_t line, const std::string& message);
   void log_warn(
@@ -87,8 +87,7 @@ class Logger {
   void log_error(
       const std::string& filename, uint32_t line, const std::string& message);
   void log_verbose(
-      const std::string& filename, uint32_t line, const std::string& message,
-      uint32_t verbosity = 1);
+      const std::string& filename, uint32_t line, const std::string& message);
 
   // Flush the log.
   void Flush() { std::cerr << std::flush; }
@@ -197,7 +196,7 @@ class Stub {
   void ServiceLogRequests();
   void SendLogMessage(
       const std::string& filename, uint32_t line, const std::string& message,
-      LogLevel level, uint32_t verbosity);
+      LogLevel level);
 
  private:
   bi::interprocess_mutex* stub_mutex_;

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -77,7 +77,7 @@ class Logger {
   // Log a message.
   void Log(const std::string& msg) { std::cerr << msg << std::endl; }
 
-  void log(
+  void LogPythonMessage(
       const std::string& filename, uint32_t line, const std::string& message,
       LogLevel level = LogLevel::INFO);
 
@@ -184,11 +184,9 @@ class Stub {
   ~Stub();
   void LaunchLogRequestThread();
   void TerminateLogRequestThread();
-  void EnqueueLogRequest(PbLog* log_ptr);
+  void EnqueueLogRequest(std::shared_ptr<PbLog> log_ptr);
   void ServiceLogRequests();
-  void SendLogMessage(
-      const std::string& filename, uint32_t line, const std::string& message,
-      LogLevel level);
+  void SendLogMessage(std::shared_ptr<PbLog> log_send_message);
 
  private:
   bi::interprocess_mutex* stub_mutex_;
@@ -219,7 +217,7 @@ class Stub {
   bool initialized_;
   static std::unique_ptr<Stub> stub_instance_;
   std::vector<std::shared_ptr<PbTensor>> gpu_tensors_;
-  std::queue<PbLog*> log_request_buffer;
+  std::queue<std::shared_ptr<PbLog>> log_request_buffer;
   std::thread log_monitor_;
   bool log_thread_;
 };

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -160,7 +160,7 @@ struct LogSendMessageBase {
   bool waiting_on_stub;
 };
 
-enum LogLevel { INFO = 0, WARNINGS, ERRORS, VERBOSE };
+enum LogLevel { INFO = 0, WARNING, ERROR, VERBOSE };
 
 struct LogSendMessage : LogSendMessageBase {
   bi::managed_external_buffer::handle_t filename;

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -137,6 +137,7 @@ struct IPCControlShm {
   bi::interprocess_mutex stub_health_mutex;
   bi::managed_external_buffer::handle_t stub_message_queue;
   bi::managed_external_buffer::handle_t parent_message_queue;
+  bi::managed_external_buffer::handle_t log_message_queue;
   bi::managed_external_buffer::handle_t memory_manager_message_queue;
 };
 
@@ -151,6 +152,22 @@ struct ResponseBatch {
 
   // Indicates whether this error has a message or not.
   bool is_error_set;
+};
+
+struct LogSendMessageBase {
+  bi::interprocess_mutex log_mu;
+  bi::interprocess_condition log_cv;
+  bool waiting_on_stub;
+};
+
+enum LogLevel { INFO = 0, WARNINGS, ERRORS, VERBOSE };
+
+struct LogSendMessage : LogSendMessageBase {
+  bi::managed_external_buffer::handle_t filename;
+  int32_t line;
+  bi::managed_external_buffer::handle_t logMsg;
+  LogLevel level;
+  int32_t verbosity;
 };
 
 struct ResponseSenderBase {

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -167,7 +167,6 @@ struct LogSendMessage : LogSendMessageBase {
   int32_t line;
   bi::managed_external_buffer::handle_t logMsg;
   LogLevel level;
-  int32_t verbosity;
 };
 
 struct ResponseSenderBase {

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -165,7 +165,7 @@ enum LogLevel { INFO = 0, WARNINGS, ERRORS, VERBOSE };
 struct LogSendMessage : LogSendMessageBase {
   bi::managed_external_buffer::handle_t filename;
   int32_t line;
-  bi::managed_external_buffer::handle_t logMsg;
+  bi::managed_external_buffer::handle_t log_message;
   LogLevel level;
 };
 

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -832,7 +832,6 @@ ModelInstanceState::LogMessageQueueMonitor()
       std::unique_ptr<PbString> pb_string_msg = PbString::LoadFromSharedMemory(
           Stub()->ShmPool(), log_message.data_->logMsg);
       LogLevel level = log_message.data_->level;
-      uint32_t verbosity = log_message.data_->verbosity;
 
       switch (level) {
         case LogLevel::INFO: {
@@ -856,7 +855,7 @@ ModelInstanceState::LogMessageQueueMonitor()
         case LogLevel::VERBOSE: {
           TRITONSERVER_LogMessage(
               TRITONSERVER_LOG_VERBOSE, (pb_string_filename->String().c_str()),
-              line, (pb_string_msg->String().c_str()), verbosity);
+              line, (pb_string_msg->String().c_str()));
           break;
         }
       }

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -398,6 +398,8 @@ ModelInstanceState::LaunchStubProcess()
   RETURN_IF_ERROR(Stub()->Initialize(model_state));
   RETURN_IF_ERROR(Stub()->Launch());
 
+  log_thread_ = true;
+  log_monitor_ = std::thread(&ModelInstanceState::LogMessageQueueMonitor, this);
   thread_pool_ = std::make_unique<boost::asio::thread_pool>(
       model_state->StateForBackend()->thread_pool_size);
 
@@ -406,8 +408,6 @@ ModelInstanceState::LaunchStubProcess()
     decoupled_monitor_ =
         std::thread(&ModelInstanceState::DecoupledMessageQueueMonitor, this);
   }
-  log_thread_ = true;
-  log_monitor_ = std::thread(&ModelInstanceState::LogMessageQueueMonitor, this);
 
   return nullptr;
 }

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -23,8 +23,8 @@
 // OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 // (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-#include "pb_log.h"
 #include "python_be.h"
+#include "pb_log.h"
 
 namespace triton { namespace backend { namespace python {
 
@@ -838,13 +838,13 @@ ModelInstanceState::LogMessageQueueMonitor()
             (log_message.c_str()));
         break;
       }
-      case LogLevel::WARNINGS: {
+      case LogLevel::WARNING: {
         TRITONSERVER_LogMessage(
             TRITONSERVER_LOG_WARN, (filename.c_str()), line,
             (log_message.c_str()));
         break;
       }
-      case LogLevel::ERRORS: {
+      case LogLevel::ERROR: {
         TRITONSERVER_LogMessage(
             TRITONSERVER_LOG_ERROR, (filename.c_str()), line,
             (log_message.c_str()));

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -34,6 +34,7 @@ ModelInstanceState::ModelInstanceState(
     ModelState* model_state, TRITONBACKEND_ModelInstance* triton_model_instance)
     : BackendModelInstance(model_state, triton_model_instance)
 {
+  log_thread_ = false;
 }
 
 TRITONSERVER_Error*

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -308,6 +308,9 @@ class ModelInstanceState : public BackendModelInstance {
   // from the message queue in the decoupled mode.
   void DecoupledMessageQueueMonitor();
 
+  // This function is executed on a separate thread and monitors the log message
+  // queue. When it receives a message from the stub, it will load it from 
+  // shared memory and log it using the triton server core logging facilities.
   void LogMessageQueueMonitor();
 
   // Convert TRITONBACKEND_Input to Python backend tensors.

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -361,10 +361,10 @@ class ModelInstanceState : public BackendModelInstance {
   // Model instance stub
   std::unique_ptr<StubLauncher>& Stub() { return model_instance_stub_; }
 
-  // Start the log monitor thread
+  // Stop the log monitor thread
   void TerminateLogMonitor();
 
-  // Stop the log monitor thread
+  // Start the log monitor thread
   void StartLogMonitor();
 };
 }}}  // namespace triton::backend::python

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -360,5 +360,11 @@ class ModelInstanceState : public BackendModelInstance {
 
   // Model instance stub
   std::unique_ptr<StubLauncher>& Stub() { return model_instance_stub_; }
+
+  // Start the log monitor thread
+  void TerminateLogMonitor();
+
+  // Stop the log monitor thread
+  void StartLogMonitor();
 };
 }}}  // namespace triton::backend::python

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -261,6 +261,8 @@ class ModelInstanceState : public BackendModelInstance {
   std::vector<intptr_t> closed_requests_;
   std::mutex closed_requests_mutex_;
 
+  std::thread log_monitor_;
+  bool log_thread_;
   // Decoupled monitor thread
   std::thread decoupled_monitor_;
   bool decoupled_thread_;
@@ -305,6 +307,8 @@ class ModelInstanceState : public BackendModelInstance {
   // function during the execute phase. No other thread should pop any message
   // from the message queue in the decoupled mode.
   void DecoupledMessageQueueMonitor();
+
+  void LogMessageQueueMonitor();
 
   // Convert TRITONBACKEND_Input to Python backend tensors.
   TRITONSERVER_Error* GetInputTensor(

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -501,17 +501,8 @@ class ModelConfig:
 
 
 def log(message, level, nested_call=False):
-    # Convenience function calls originiate
-    # 2 function calls back, not 1
-    caller_frame = currentframe().f_back
-    if nested_call:
-        caller_frame = caller_frame.f_back
-
-    caller_info = getframeinfo(caller_frame)
-    caller_line_number = caller_info.lineno
-    caller_filename = caller_info.filename
     logger = Logger()
-    logger.log(caller_filename, caller_line_number, message, level)
+    logger.log(message, level, nested_call)
 
 
 def log_info(message):
@@ -519,11 +510,11 @@ def log_info(message):
 
 
 def log_warn(message):
-    log(message, Logger().WARNINGS, True)
+    log(message, Logger().WARNING, True)
 
 
 def log_error(message):
-    log(message, Logger().ERRORS, True)
+    log(message, Logger().ERROR, True)
 
 
 def log_verbose(message):

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -27,7 +27,6 @@
 import numpy as np
 import struct
 import json
-from c_python_backend_utils import Logger
 
 TRITON_STRING_TO_NUMPY = {
     'TYPE_BOOL': bool,
@@ -497,27 +496,6 @@ class ModelConfig:
                     return
 
         self._model_config["output"].append(output)
-
-logger = Logger()
-
-def log(message, level, nested_call=False):
-    logger.log(message, level, nested_call)
-
-
-def log_info(message):
-    log(message, Logger().INFO, True)
-
-
-def log_warn(message):
-    log(message, Logger().WARNING, True)
-
-
-def log_error(message):
-    log(message, Logger().ERROR, True)
-
-
-def log_verbose(message):
-    log(message, Logger().VERBOSE, True)
 
 
 TRITONSERVER_REQUEST_FLAG_SEQUENCE_START = 1

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -27,9 +27,8 @@
 import numpy as np
 import struct
 import json
-import sys 
+import sys
 from inspect import currentframe, getframeinfo
-from enum import Enum
 
 TRITON_STRING_TO_NUMPY = {
     'TYPE_BOOL': bool,
@@ -364,7 +363,7 @@ class ModelConfig:
             raise ValueError(
                 "Configuration specified scheduling_choice as '" \
                 + found_scheduler + "', but auto-complete-config " \
-                "function for model '" + self._model_config["name"] 
+                "function for model '" + self._model_config["name"]
                 + "' tries to set scheduling_choice as 'dynamic_batching'")
 
         if "dynamic_batching" not in self._model_config:
@@ -500,26 +499,36 @@ class ModelConfig:
 
         self._model_config["output"].append(output)
 
-class level(Enum):
-    INFO = 0,
-    WARNINGS = 1,
-    ERRORS = 2,
-    VERBOSE = 3
 
-def log(message, log_level=level.INFO):
+def log(message, level, nested_call=False):
+    # Convenience function calls originiate
+    # 2 function calls back, not 1
     caller_frame = currentframe().f_back
+    if nested_call:
+        caller_frame = caller_frame.f_back
+
     caller_info = getframeinfo(caller_frame)
     caller_line_number = caller_info.lineno
     caller_filename = caller_info.filename
     logger = Logger()
-    if(log_level == level.INFO):
-        logger.log_info(caller_filename, caller_line_number, message)
-    elif(log_level == level.WARNINGS):
-        logger.log_warn(caller_filename, caller_line_number, message)
-    elif(log_level == level.ERRORS):
-        logger.log_error(caller_filename, caller_line_number, message)
-    elif(log_level == level.VERBOSE):
-        logger.log_verbose(caller_filename, caller_line_number, message)
+    logger.log(caller_filename, caller_line_number, message, level)
+
+
+def log_info(message):
+    log(message, Logger().INFO, True)
+
+
+def log_warn(message):
+    log(message, Logger().WARNINGS, True)
+
+
+def log_error(message):
+    log(message, Logger().ERRORS, True)
+
+
+def log_verbose(message):
+    log(message, Logger().VERBOSE, True)
+
 
 TRITONSERVER_REQUEST_FLAG_SEQUENCE_START = 1
 TRITONSERVER_REQUEST_FLAG_SEQUENCE_END = 2

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -27,6 +27,9 @@
 import numpy as np
 import struct
 import json
+import sys 
+from inspect import currentframe, getframeinfo
+from enum import Enum
 
 TRITON_STRING_TO_NUMPY = {
     'TYPE_BOOL': bool,
@@ -497,6 +500,26 @@ class ModelConfig:
 
         self._model_config["output"].append(output)
 
+class level(Enum):
+    INFO = 0,
+    WARNINGS = 1,
+    ERRORS = 2,
+    VERBOSE = 3
+
+def log(message, log_level=level.INFO):
+    caller_frame = currentframe().f_back
+    caller_info = getframeinfo(caller_frame)
+    caller_line_number = caller_info.lineno
+    caller_filename = caller_info.filename
+    logger = Logger()
+    if(log_level == level.INFO):
+        logger.log_info(caller_filename, caller_line_number, message)
+    elif(log_level == level.WARNINGS):
+        logger.log_warn(caller_filename, caller_line_number, message)
+    elif(log_level == level.ERRORS):
+        logger.log_error(caller_filename, caller_line_number, message)
+    elif(log_level == level.VERBOSE):
+        logger.log_verbose(caller_filename, caller_line_number, message)
 
 TRITONSERVER_REQUEST_FLAG_SEQUENCE_START = 1
 TRITONSERVER_REQUEST_FLAG_SEQUENCE_END = 2

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -27,8 +27,7 @@
 import numpy as np
 import struct
 import json
-import sys
-from inspect import currentframe, getframeinfo
+from c_python_backend_utils import Logger
 
 TRITON_STRING_TO_NUMPY = {
     'TYPE_BOOL': bool,
@@ -499,9 +498,9 @@ class ModelConfig:
 
         self._model_config["output"].append(output)
 
+logger = Logger()
 
 def log(message, level, nested_call=False):
-    logger = Logger()
     logger.log(message, level, nested_call)
 
 

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -197,7 +197,6 @@ StubLauncher::Setup()
 TRITONSERVER_Error*
 StubLauncher::Launch()
 {
-  RETURN_IF_ERROR(Setup());
 
   std::string stub_name;
   if (stub_process_kind_ == "AUTOCOMPLETE_STUB") {
@@ -312,7 +311,6 @@ StubLauncher::Launch()
         int status;
         stub_message_queue_.reset();
         parent_message_queue_.reset();
-        log_message_queue_.reset();
         memory_manager_.reset();
         waitpid(stub_pid_, &status, 0);
       }
@@ -498,7 +496,6 @@ StubLauncher::TerminateStub()
 
       stub_message_queue_.reset();
       parent_message_queue_.reset();
-      log_message_queue_.reset();
       memory_manager_.reset();
     } else {
       force_kill = true;
@@ -516,8 +513,13 @@ StubLauncher::TerminateStub()
   ipc_control_.reset();
   stub_message_queue_.reset();
   parent_message_queue_.reset();
-  log_message_queue_.reset();
   memory_manager_.reset();
+}
+
+void
+StubLauncher::ClearLogQueue()
+{
+  log_message_queue_.reset();
 }
 
 void

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -132,6 +132,7 @@ StubLauncher::Setup()
   ipc_control_ = nullptr;
   stub_message_queue_ = nullptr;
   parent_message_queue_ = nullptr;
+  log_message_queue_ = nullptr;
   memory_manager_ = nullptr;
 
   try {
@@ -160,6 +161,10 @@ StubLauncher::Setup()
       parent_message_queue_ =
           MessageQueue<bi::managed_external_buffer::handle_t>::Create(
               shm_pool_, shm_message_queue_size_));
+  RETURN_IF_EXCEPTION(
+      log_message_queue_ =
+          MessageQueue<bi::managed_external_buffer::handle_t>::Create(
+              shm_pool_, shm_message_queue_size_));
 
   std::unique_ptr<MessageQueue<intptr_t>> memory_manager_message_queue;
   RETURN_IF_EXCEPTION(
@@ -174,6 +179,7 @@ StubLauncher::Setup()
   memory_manager_ =
       std::make_unique<MemoryManager>(std::move(memory_manager_message_queue));
   ipc_control_->parent_message_queue = parent_message_queue_->ShmHandle();
+  ipc_control_->log_message_queue = log_message_queue_->ShmHandle();
   ipc_control_->stub_message_queue = stub_message_queue_->ShmHandle();
 
   new (&(ipc_control_->stub_health_mutex)) bi::interprocess_mutex;
@@ -181,6 +187,7 @@ StubLauncher::Setup()
 
   stub_message_queue_->ResetSemaphores();
   parent_message_queue_->ResetSemaphores();
+  log_message_queue_->ResetSemaphores();
 
   is_initialized_ = false;
 
@@ -305,6 +312,7 @@ StubLauncher::Launch()
         int status;
         stub_message_queue_.reset();
         parent_message_queue_.reset();
+        log_message_queue_.reset();
         memory_manager_.reset();
         waitpid(stub_pid_, &status, 0);
       }
@@ -490,6 +498,7 @@ StubLauncher::TerminateStub()
 
       stub_message_queue_.reset();
       parent_message_queue_.reset();
+      log_message_queue_.reset();
       memory_manager_.reset();
     } else {
       force_kill = true;
@@ -507,6 +516,7 @@ StubLauncher::TerminateStub()
   ipc_control_.reset();
   stub_message_queue_.reset();
   parent_message_queue_.reset();
+  log_message_queue_.reset();
   memory_manager_.reset();
 }
 

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -97,6 +97,13 @@ class StubLauncher {
     return parent_message_queue_;
   }
 
+  // Parent message queue
+  std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>&
+  LogMessageQueue()
+  {
+    return log_message_queue_;
+  }
+
   // Memory Manager
   std::unique_ptr<MemoryManager>& GetMemoryManager() { return memory_manager_; }
 
@@ -163,6 +170,8 @@ class StubLauncher {
       stub_message_queue_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>
       parent_message_queue_;
+  std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>
+      log_message_queue_;
   std::unique_ptr<MemoryManager> memory_manager_;
   std::unique_ptr<IPCControlShm, std::function<void(IPCControlShm*)>>
       ipc_control_;

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -97,7 +97,7 @@ class StubLauncher {
     return parent_message_queue_;
   }
 
-  // Parent message queue
+  // Log message queue
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>&
   LogMessageQueue()
   {

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -132,6 +132,9 @@ class StubLauncher {
   // Destruct Stub process
   void TerminateStub();
 
+  // Reset log queue pointer
+  void ClearLogQueue();
+
   // Kill stub process
   void KillStubProcess();
 


### PR DESCRIPTION
Triton server logging functionality can now be invoked from python models. Here are a few example formats:
```python
logger = pb_utils.Logger
logger.log("Specific Msg!", logger.INFO)
logger.log_info("Info Msg!")
logger.log_warn("Warning Msg!")
logger.log_error("Error Msg!")
logger.log_verbose("Verbose Msg!")
```