### PR TITLE
bug fix for model repository path

### DIFF
--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -404,7 +404,7 @@ StubLauncher::ModelInstanceStubProcess()
       {"model_instance_kind", kind_},
       {"model_instance_name", model_instance_name_},
       {"model_instance_device_id", std::to_string(device_id_)},
-      {"model_repository", model_path_},
+      {"model_repository", model_repository_path_},
       {"model_version", std::to_string(model_version_)},
       {"model_name", model_name_}};
 


### PR DESCRIPTION
I think the model repository has been mistakenly set to "model_path_" and instead it should return the directory of the model (model_repository_path_).