### PR TITLE
Implement GetBackendAttribute to provide instance kind hint

### DIFF
--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1908,5 +1908,24 @@ TRITONBACKEND_ModelInstanceFinalize(TRITONBACKEND_ModelInstance* instance)
   return nullptr;
 }
 
+TRITONSERVER_Error*
+TRITONBACKEND_GetBackendAttribute(
+    TRITONBACKEND_Backend* backend,
+    TRITONBACKEND_BackendAttribute* backend_attributes)
+{
+  LOG_MESSAGE(
+      TRITONSERVER_LOG_VERBOSE,
+      "TRITONBACKEND_GetBackendAttribute: setting attributes");
+#ifdef TRITON_ENABLE_GPU
+  RETURN_IF_ERROR(TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup(backend_attributes,
+      TRITONSERVER_INSTANCEGROUPKIND_GPU, 0, nullptr, 0));
+#else
+  RETURN_IF_ERROR(TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup(backend_attributes,
+      TRITONSERVER_INSTANCEGROUPKIND_CPU, 0, nullptr, 0));
+#endif
+
+  return nullptr;
+}
+
 }  // extern "C"
 }}}  // namespace triton::backend::python

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1916,7 +1916,7 @@ TRITONBACKEND_GetBackendAttribute(
   LOG_MESSAGE(
       TRITONSERVER_LOG_VERBOSE,
       "TRITONBACKEND_GetBackendAttribute: setting attributes");
-  // Specify different preferred instance kind baseds on backend compatibility,
+  // Specify different preferred instance kind based on backend compatibility,
   // so Triton core won't blindly auto-complete kind that may not be supported.
   // Other instance groups setting are set to "no value" so that Triton core
   // will auto-complete them with default policy.

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1916,6 +1916,10 @@ TRITONBACKEND_GetBackendAttribute(
   LOG_MESSAGE(
       TRITONSERVER_LOG_VERBOSE,
       "TRITONBACKEND_GetBackendAttribute: setting attributes");
+  // Specify different preferred instance kind baseds on backend compatibility,
+  // so Triton core won't blindly auto-complete kind that may not be supported.
+  // Other instance groups setting are set to "no value" so that Triton core
+  // will auto-complete them with default policy.
 #ifdef TRITON_ENABLE_GPU
   RETURN_IF_ERROR(TRITONBACKEND_BackendAttributeAddPreferredInstanceGroup(backend_attributes,
       TRITONSERVER_INSTANCEGROUPKIND_GPU, 0, nullptr, 0));


### PR DESCRIPTION
core: https://github.com/triton-inference-server/core/pull/109
example:
if model has below config and build with ENABLE_GPU=OFF:
```
name: "add_sub"
backend: "python"

input [
...
]
output [
...
]
# not providing instance group
#instance_group [{ kind: KIND_CPU }]
```
Before this change, Triton will always fill KIND_GPU on GPU system and result in:
```
...
I0816 00:00:09.814568 21489 python_be.cc:1767] TRITONBACKEND_ModelInstanceInitialize: add_sub (GPU device 0)
E0816 00:00:09.814760 21489 model_lifecycle.cc:596] failed to load 'add_sub' version 1: Internal: GPU instances not supported
...
```
After:
```
...
I0815 23:57:16.036978 21355 python_be.cc:1767] TRITONBACKEND_ModelInstanceInitialize: add_sub (CPU device 0)
I0815 23:57:16.209357 21355 model_lifecycle.cc:693] successfully loaded 'add_sub' version 1
...
````
And config API will return:
`... "instance_group":[{"name":"add_sub","kind":"KIND_CPU","count":1,"gpus":[],"secondary_devices":[],"profile":[],"passive":false,"host_policy":""} ...`