### PR TITLE
Update use of NEURON_GROUP_SIZES in inferentia backend

### DIFF
--- a/inferentia/qa/setup_test_enviroment_and_test.sh
+++ b/inferentia/qa/setup_test_enviroment_and_test.sh
@@ -121,12 +121,12 @@ sudo ${TRITON_PATH}/python_backend/inferentia/scripts/setup-pre-container.sh
 # If container version is not known, look up container version and upstream container version from build.py
 cd ${TRITON_PATH}/server
 if [ "${CONTAINER_VERSION}" = "" ]; then
-    QUERY_STRING="import build; container_version,_= build.get_container_versions('$(cat TRITON_VERSION)', None, None); print(container_version)"
+    QUERY_STRING="import build; container_version,_= build.container_versions('$(cat TRITON_VERSION)', None, None); print(container_version)"
     CONTAINER_VERSION=$(python3 -c "${QUERY_STRING}")
     echo "found container version: ${CONTAINER_VERSION} from build.py"
 fi
 if [ "${UPSTREAM_CONTAINER_VERSION}" = "" ]; then
-    QUERY_STRING="import build; _,upstream_container_version = build.get_container_versions('$(cat TRITON_VERSION)', None, None); print(upstream_container_version)"
+    QUERY_STRING="import build; _,upstream_container_version = build.container_versions('$(cat TRITON_VERSION)', None, None); print(upstream_container_version)"
     UPSTREAM_CONTAINER_VERSION=$(python3 -c "${QUERY_STRING}")
     echo "found upstream container version: ${UPSTREAM_CONTAINER_VERSION} from build.py"
 fi
@@ -134,9 +134,7 @@ fi
 # Build container with only python backend 
 cd ${TRITON_PATH}/server
 pip3 install docker
-./build.py --build-dir=/tmp/tritonbuild \
-           --cmake-dir=${TRITON_PATH}/server/build \
-           --container-version=${CONTAINER_VERSION} \
+./build.py --container-version=${CONTAINER_VERSION} \
            --upstream-container-version=${UPSTREAM_CONTAINER_VERSION} \
            --enable-logging --enable-stats --enable-tracing \
            --enable-metrics --enable-gpu-metrics --enable-gpu \
@@ -149,7 +147,7 @@ pip3 install docker
            --backend=identity:${IDENTITY_BACKEND_REPO_TAG} \
            --backend=python:${PYTHON_BACKEND_REPO_TAG} \
            --repoagent=checksum:${CHECKSUM_REPOAGENT_REPO_TAG}
-docker tag tritonserver_build "${BUILD_IMAGE}"
+docker tag tritonserver_buildbase "${BUILD_IMAGE}"
 docker tag tritonserver "${BASE_IMAGE}"
 
 # Build docker container for SDK

--- a/inferentia/scripts/gen_triton_model.py
+++ b/inferentia/scripts/gen_triton_model.py
@@ -272,9 +272,7 @@ def get_tensorflow_initialize_impl():
 
         # TODO: Validate input/output from the model
 
-        # TODO: NEURONCORE_GROUP_SIZES is deprecated by AWS Neuron
-        group_sizes = [str(1)] * cores_per_instance
-        os.environ["NEURONCORE_GROUP_SIZES"] = ','.join(group_sizes)
+        os.environ["NEURON_RT_NUM_CORES"] = str(cores_per_instance)
 
         self.pred_list = [
             tf.contrib.predictor.from_saved_model(compiled_model)

--- a/inferentia/scripts/setup.sh
+++ b/inferentia/scripts/setup.sh
@@ -159,9 +159,9 @@ if [ $USE_TENSORFLOW -eq 1 ]; then
     pip install --upgrade tensorboard-plugin-neuron
     # Update Neuron TensorFlow
     if [ $TENSORFLOW_VERSION -eq 1 ]; then
-        pip install --upgrade tensorflow-neuron==1.15.5.* neuron-cc
+        pip install --upgrade tensorflow-neuron==1.15.5.* neuron-cc "protobuf<4"
     else
-        pip install --upgrade tensorflow-neuron[cc]
+        pip install --upgrade tensorflow-neuron[cc] "protobuf<4"
     fi
 fi
 
@@ -169,7 +169,7 @@ if [ $USE_PYTORCH -eq 1 ]
 then
     conda install torch-neuron torchvision -y
     # Upgrade torch-neuron and install transformers
-    pip install --upgrade torch-neuron neuron-cc[tensorflow] torchvision "transformers==4.6.0"
+    pip install --upgrade torch-neuron neuron-cc[tensorflow] "protobuf<4" torchvision "transformers==4.6.0"
 fi
 
 # Upgrade the python backend stub, rules and sockets


### PR DESCRIPTION
There are two changes in this PR: 
1. Update `inferentia/qa/setup_test_enviroment_and_test.sh` to build on the latest `build.py`.
2. Change `NEURONCORE_GROUP_SIZES` to `NEURON_RT_NUM_CORES`

Related PR: https://github.com/triton-inference-server/server/pull/4794