### PR TITLE
added ALLOCATE_BUFFERS_ON_INSTANCE_DEVICE.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1040,7 +1040,13 @@ behaviour is to allocate a buffer on the same device as the model response.
 As a result, when the response is retrieved in Python, it may be on a different
 device than the original Python BLS instance device. You can force the Python
 backend to keep all memory allocations on the same device as the BLS instance
-by setting `ALLOCATE_BUFFERS_ON_INSTANCE_DEVICE` to `yes`.
+by setting `ALLOCATE_BUFFERS_ON_INSTANCE_DEVICE` to `yes`. To use this, simply 
+add this setting to the `parameters` section of model configuration:
+
+```
+parameters: { key: "ALLOCATE_BUFFERS_ON_INSTANCE_DEVICE" value: {string_value:"yes"}}
+```
+
 
 # Examples
 

--- a/README.md
+++ b/README.md
@@ -65,6 +65,7 @@ any C++ code.
   - [`pb_utils.Tensor.from_dlpack() -> Tensor`](#pb_utilstensorfrom_dlpack---tensor)
   - [`pb_utils.Tensor.is_cpu() -> bool`](#pb_utilstensoris_cpu---bool)
   - [Input Tensor Device Placement](#input-tensor-device-placement)
+  - [Inference Reponse Device Placement](#inference-reponse-device-placement)
 - [Examples](#examples)
   - [AddSub in NumPy](#addsub-in-numpy)
   - [AddSubNet in PyTorch](#addsubnet-in-pytorch)
@@ -1032,6 +1033,14 @@ CPU and GPU memory. To enable this setting, you need to add this setting to the
 ```
 parameters: { key: "FORCE_CPU_ONLY_INPUT_TENSORS" value: {string_value:"no"}}
 ```
+
+## Inference Reponse Device Placement
+To collect the response from other models during BLS execution, the default
+behaviour is to allocate a buffer on the same device as the model response.
+As a result, when the response is retrieved in Python, it may be on a different
+device than the original Python BLS instance device. You can force the Python
+backend to keep all memory allocations on the same device as the BLS instance
+by setting `ALLOCATE_BUFFERS_ON_INSTANCE_DEVICE` to `yes`.
 
 # Examples
 

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -229,6 +229,9 @@ class ModelState : public BackendModel {
   // Force CPU only tensors
   bool ForceCPUOnlyInputTensors() { return force_cpu_only_input_tensors_; }
 
+  // Allocate GPU buffers on the same device as the python model.
+  bool AllocateBuffersOnInstanceDevice() { return allocate_buffers_on_instance_device_; }
+
   // Is decoupled API being used.
   bool IsDecoupled() { return decoupled_; }
 
@@ -246,6 +249,7 @@ class ModelState : public BackendModel {
   BackendState* backend_state_;
   std::string python_execution_env_;
   bool force_cpu_only_input_tensors_;
+  bool allocate_buffers_on_instance_device_;
   bool decoupled_;
   std::unique_ptr<StubLauncher> auto_complete_stub_;
 };

--- a/src/request_executor.h
+++ b/src/request_executor.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include <memory>
+
 #include "infer_request.h"
 #include "infer_response.h"
 
@@ -34,6 +35,15 @@ namespace triton { namespace backend { namespace python {
 
 TRITONSERVER_Error* CreateTritonErrorFromException(
     const PythonBackendException& pb_exception);
+
+struct UserpAndDeviceID {
+  // This data structure is used to pass the userp and device ID to the
+  // TRITONSERVER_InferenceRequestSetResponseCallback function.
+  // We need the buffer device id to allocate memory for the response
+  // on the correct device.
+  void* userp;
+  int32_t buffer_device_id;
+};
 
 class RequestExecutor {
   TRITONSERVER_ResponseAllocator* response_allocator_ = nullptr;
@@ -43,7 +53,7 @@ class RequestExecutor {
  public:
   std::unique_ptr<InferResponse> Infer(
       const std::shared_ptr<InferRequest>& infer_request,
-      TRITONSERVER_InferenceResponse** response);
+      TRITONSERVER_InferenceResponse** response, const int32_t device_id);
 
   RequestExecutor(
       std::unique_ptr<SharedMemoryManager>& shm_pool,


### PR DESCRIPTION
Thanks for the very useful Python backend implementation.

When using BLS to perform inference on other models, the default behaviour allocates a buffer on the same devices as the other model.
```
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A   1439550      C   ...onserver/bin/tritonserver     5034MiB |
|    0   N/A  N/A   1440233      C   ...riton_python_backend_stub      678MiB |
|    0   N/A  N/A   1440361      C   ...riton_python_backend_stub      616MiB |
|    1   N/A  N/A   1439550      C   ...onserver/bin/tritonserver     5034MiB |
|    1   N/A  N/A   1440233      C   ...riton_python_backend_stub      616MiB |
|    1   N/A  N/A   1440361      C   ...riton_python_backend_stub      702MiB |
+-----------------------------------------------------------------------------+
```
In the above example, PID `1440233`, even though residing on device 0, is allocating `616MiB` on device 1.
Similarly, PID `1440361`, although residing on device 1, is allocating `616MiB` on device 0.

This is a **major scaling issue**. If you have 8-GPUs in your Triton setup and just one BLS on each device, you'll end up with `7 x 616MB = 4.2 GB` lost just for buffers on every device. Because of this, it also becomes impractical to have more than 1 BLS run on each device.

To address this, I made this pull request that results in this:

```
+-----------------------------------------------------------------------------+
| Processes:                                                                  |
|  GPU   GI   CI        PID   Type   Process name                  GPU Memory |
|        ID   ID                                                   Usage      |
|=============================================================================|
|    0   N/A  N/A   1447653      C   ...onserver/bin/tritonserver     5034MiB |
|    0   N/A  N/A   1448447      C   ...riton_python_backend_stub      678MiB |
|    1   N/A  N/A   1447653      C   ...onserver/bin/tritonserver     5034MiB |
|    1   N/A  N/A   1448561      C   ...riton_python_backend_stub      664MiB |
+-----------------------------------------------------------------------------+
```
As you can see each BLS model stays on its own device.

To implement it, I added a new boolean flag `ALLOCATE_BUFFERS_ON_INSTANCE_DEVICE` that can enable/disable the default behaviour. To stay backward compatible, the default behaviour is the same as before. However, once this flag is active, it only allocates memory on the instance device.

`python_be` contains the logic for parsing the configuration and the default flag. During the call to `request_executor->Infer` I pass the instance device id.
```C++
  int32_t instance_device_id = DeviceId();
  if (!model_state->AllocateBuffersOnInstanceDevice()){
    instance_device_id = -1; // No preference.
  }
  infer_response = request_executor->Infer(
      infer_request, &inference_response, instance_device_id);
```
I personally don't like doing this, but couldn't think of a better pattern. Is there an easy way to access `ModelState` and `ModelInstanceState` once inside the request executor? The alternative/better approaches would make the code more complex by increasing the dependencies.

Once inside the executor, we need to update the `userp` for `InferResponseComplete` callback. The function takes a pointer as `userp` and is currently used to pass `shm_pool_.get()`.

We need to pass the preferred device id so that during the callback we specify the correct device id. We will need to have a more complex object that contains the original `userp` and the new data. We could construct an array on the fly with the `shm_pool_.get()` and the preferred device id and pass the pointer, keeping it backward compatible (as the first entry will be the same as if used with `void*`, but the type of the second entry will not be known and may make the code dirtier than it should be. I ended up creating a simple data structure to hold the two objects.
```
struct UserpAndDeviceID {
  // This data structure is used to pass the userp and device ID to the
  // TRITONSERVER_InferenceRequestSetResponseCallback function.
  // We need the buffer device id to allocate memory for the response
  // on the correct device.
  void* userp;
  int32_t buffer_device_id;
};
```
which again, I don't like, but I can't think of a better way to handle it. Finally, on the callback I simply do:
```C++
  if (preferred_memory_type == TRITONSERVER_MEMORY_GPU) {
    // We have a response data from a GPU model and need to allocate
    // the response buffer.
    if (userp_and_device_id->buffer_device_id != -1){
      // The buffer must be allocated on the BLS instance device id.
      *actual_memory_type_id = userp_and_device_id->buffer_device_id;
    }else{
      // We allocate the buffer on the same device as response.
      *actual_memory_type_id = preferred_memory_type_id;
    }
  }
```

While this addresses the cross-gpu memory allocation issue, there's also another case that I think should be handled differently. If the BLS kind is set to `CPU` the response tensors from other models may be on a `GPU` device, which is counter-intuitive and pattern-breaking, to say, at least. In these cases, the default behaviour should be to transfer the response to `CPU` before returning to Python.

I'd be more than happy to incorporate improvements and fixes into this.