### PR TITLE
Acquire GIL lock when releasing DLPack tensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -74,7 +74,7 @@ FetchContent_MakeAvailable(repo-common repo-core repo-backend)
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY "https://github.com/pybind/pybind11"
-  GIT_TAG "v2.6"
+  GIT_TAG "v2.10"
   GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(pybind11)
@@ -85,7 +85,7 @@ FetchContent_MakeAvailable(pybind11)
 FetchContent_Declare(
   dlpack
   GIT_REPOSITORY "https://github.com/dmlc/dlpack"
-  GIT_TAG "v0.5"
+  GIT_TAG "v0.7"
   GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(dlpack)

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -247,6 +247,9 @@ PbTensor::ToDLPack()
   dlpack_tensor->dl_tensor.strides = nullptr;
   dlpack_tensor->manager_ctx = this;
   dlpack_tensor->deleter = [](DLManagedTensor* m) {
+    // We need to acquire GIL since the framework that deleted the dlpack tensor
+    // may not have acquired GIL when calling this function.
+    py::gil_scoped_acquire gil;
     if (m->manager_ctx == nullptr) {
       return;
     }


### PR DESCRIPTION
There has been some changes in PyTorch and it no longer has GIL lock acquired when releasing the tensors (See this [PR ](https://github.com/pytorch/pytorch/pull/83623/)and this [issue ](https://github.com/pytorch/pytorch/issues/88082)for more details).

We need to acquire this lock when in the deleter.

Closes: https://github.com/triton-inference-server/server/issues/5073
Closes: https://github.com/triton-inference-server/server/issues/5055