### PR TITLE
Make sure to use correct shared memory mapping before deallocation

### DIFF
--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -179,6 +179,7 @@ class SharedMemoryManager {
                                        shm_ownership_data](T* memory) {
       bool destroy = false;
       bi::scoped_lock<bi::interprocess_mutex> gaurd{*shm_mutex_};
+      GrowIfNeeded(0);
       shm_ownership_data->ref_count_ -= 1;
       if (shm_ownership_data->ref_count_ == 0) {
         destroy = true;

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -179,6 +179,10 @@ class SharedMemoryManager {
                                        shm_ownership_data](T* memory) {
       bool destroy = false;
       bi::scoped_lock<bi::interprocess_mutex> gaurd{*shm_mutex_};
+      // Before using any shared memory function you need to make sure that you
+      // are using the correct mapping. For example, shared memory growth may
+      // happen between the time an object was created and the time the object
+      // gets destructed.
       GrowIfNeeded(0);
       shm_ownership_data->ref_count_ -= 1;
       if (shm_ownership_data->ref_count_ == 0) {


### PR DESCRIPTION
The problem was that on deallocate, we didn't update the shared map. As a result if shared memory growth happened and the object was using an old shared memory map, the shared memory data became corrupted.