### PR TITLE
Add decoupled support for BLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -194,6 +194,8 @@ set(
   src/response_sender.h
   src/pb_stub.h
   src/pb_stub.cc
+  src/pb_generator.h
+  src/pb_generator.cc
 )
 
 list(APPEND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -174,6 +174,8 @@ set(
   src/request_executor.h
   src/stub_launcher.h
   src/stub_launcher.cc
+  src/infer_payload.h
+  src/infer_payload.cc
 )
 
 list(APPEND

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -43,7 +43,7 @@ set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 
 if(NOT CMAKE_BUILD_TYPE)
-  set(CMAKE_BUILD_TYPE Debug)
+  set(CMAKE_BUILD_TYPE Release)
 endif()
 
 #

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -42,6 +42,10 @@ set(TRITON_BACKEND_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server
 set(TRITON_COMMON_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/common repo")
 set(TRITON_CORE_REPO_TAG "main" CACHE STRING "Tag for triton-inference-server/core repo")
 
+if(NOT CMAKE_BUILD_TYPE)
+  set(CMAKE_BUILD_TYPE Debug)
+endif()
+
 #
 # Dependencies
 #

--- a/README.md
+++ b/README.md
@@ -858,13 +858,13 @@ class TritonPythonModel:
           requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
           inputs=[<pb_utils.Tensor object>])
 
-      # `pb_utils.InferenceRequest` supports request_id, correlation_id, and
-      # model version in addition to the arguments described above. These
-      # arguments are optional. An example containing all the arguments:
+      # `pb_utils.InferenceRequest` supports request_id, correlation_id,
+      # model version and timeout in addition to the arguments described above.
+      # These arguments are optional. An example containing all the arguments:
       # inference_request = pb_utils.InferenceRequest(model_name='model_name',
       #   requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
       #   inputs=[<list of pb_utils.Tensor objects>],
-      #   request_id="1", correlation_id=4, model_version=1, flags=0)
+      #   request_id="1", correlation_id=4, model_version=1, flags=0, timeout=5)
 
       # Execute the inference_request and wait for the response
       inference_response = inference_request.exec()
@@ -951,10 +951,13 @@ models in both [default mode](#default-mode) and
 [generator](https://docs.python.org/3/glossary.html#term-generator) of
 inference responses returned by a decouple model. If the `decoupled` parameter
 is set to `False`, the `exec` and `async_exec` function will return a single
-response as shown in the example above. Besides, you can set the timeout via
-the parameter 'timeout' in microseconds. If the request times out, the request
-will respond with an error. The default of 'timeout' is 0 which indicates
-that the request has no timeout. Example below shows how to use this feature:
+response as shown in the example above.
+
+Besides, you can set the timeout via the parameter 'timeout' in microseconds
+within the constructor of `InferenceRequest`. If the request times out, the
+request will respond with an error. The default of 'timeout' is 0 which
+indicates that the request has no timeout. Example below shows how to use this
+feature:
 
 ```python
 import triton_python_backend_utils as pb_utils
@@ -974,18 +977,18 @@ class TritonPythonModel:
           requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
           inputs=[<pb_utils.Tensor object>])
 
-      # `pb_utils.InferenceRequest` supports request_id, correlation_id, and
-      # model version in addition to the arguments described above. These
-      # arguments are optional. An example containing all the arguments:
+      # `pb_utils.InferenceRequest` supports request_id, correlation_id,
+      # model version and timeout in addition to the arguments described above.
+      # These arguments are optional. An example containing all the arguments:
       # inference_request = pb_utils.InferenceRequest(model_name='model_name',
       #   requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
       #   inputs=[<list of pb_utils.Tensor objects>],
-      #   request_id="1", correlation_id=4, model_version=1, flags=0)
+      #   request_id="1", correlation_id=4, model_version=1, flags=0, timeout=5)
 
       # Execute the inference_request and wait for the response. Here we are
       # running a BLS request on a decoupled model, hence setting the parameter
       # 'decoupled' to 'True'.
-      inference_responses = inference_request.exec(decoupled=True, timeout=10)
+      inference_responses = inference_request.exec(decoupled=True)
 
       for inference_response in inference_responses:
         # Check if the inference response has an error
@@ -1041,7 +1044,7 @@ class TritonPythonModel:
         # [Awaitable](https://docs.python.org/3/library/asyncio-task.html#awaitables)
         # object.
         infer_response_awaits.append(
-          inference_request.async_exec(decoupled=True, timeout=10))
+          inference_request.async_exec(decoupled=True))
 
       # Wait for all of the inference requests to complete.
       async_responses = await asyncio.gather(*infer_response_awaits)

--- a/README.md
+++ b/README.md
@@ -200,28 +200,31 @@ class TritonPythonModel:
 
     @staticmethod
     def auto_complete_config(auto_complete_model_config):
-        """`auto_complete_config` is called only once when loading the model assuming
-        the server was not started with `--disable-auto-complete-config`. Implementing
-        this function is optional. No implementation of `auto_complete_config` will
-        do nothing. This function can be used to set `max_batch_size`, `input` and
-        `output` properties of the model using `set_max_batch_size`, `add_input`, and
-        `add_output`. These properties will allow Triton to load the model with minimal
-        model configuration in absence of a configuration file. This function returns
-        the `pb_utils.ModelConfig` object with these properties. You can use the `as_dict`
-        function to gain read-only access to the `pb_utils.ModelConfig` object.
-        The `pb_utils.ModelConfig` object being returned from here will be used as
-        the final configuration for the model.
+        """`auto_complete_config` is called only once when loading the model
+        assuming the server was not started with
+        `--disable-auto-complete-config`. Implementing this function is
+        optional. No implementation of `auto_complete_config` will do nothing.
+        This function can be used to set `max_batch_size`, `input` and `output`
+        properties of the model using `set_max_batch_size`, `add_input`, and
+        `add_output`. These properties will allow Triton to load the model with
+        minimal model configuration in absence of a configuration file. This
+        function returns the `pb_utils.ModelConfig` object with these
+        properties. You can use the `as_dict` function to gain read-only access
+        to the `pb_utils.ModelConfig` object. The `pb_utils.ModelConfig` object
+        being returned from here will be used as the final configuration for
+        the model.
 
-        Note: The Python interpreter used to invoke this function will be destroyed
-        upon returning from this function and as a result none of the objects created
-        here will be available in the `initialize`, `execute`, or `finalize` functions.
+        Note: The Python interpreter used to invoke this function will be
+        destroyed upon returning from this function and as a result none of the
+        objects created here will be available in the `initialize`, `execute`,
+        or `finalize` functions.
 
         Parameters
         ----------
         auto_complete_model_config : pb_utils.ModelConfig
-          An object containing the existing model configuration. You can build upon
-          the configuration given by this object when setting the properties for
-          this model.
+          An object containing the existing model configuration. You can build
+          upon the configuration given by this object when setting the
+          properties for this model.
 
         Returns
         -------
@@ -294,7 +297,8 @@ class TritonPythonModel:
           Both keys and values are strings. The dictionary keys and values are:
           * model_config: A JSON string containing the model configuration
           * model_instance_kind: A string containing model instance kind
-          * model_instance_device_id: A string containing model instance device ID
+          * model_instance_device_id: A string containing model instance device
+            ID
           * model_repository: Model repository path
           * model_version: Model version
           * model_name: Model name
@@ -328,7 +332,8 @@ class TritonPythonModel:
         # make a copy of the underlying NumPy array and store it if it is
         # required.
         for request in requests:
-            # Perform inference on the request and append it to responses list...
+            # Perform inference on the request and append it to responses
+            # list...
 
         # You must return a list of pb_utils.InferenceResponse. Length
         # of this list must match the length of `requests` list.
@@ -358,11 +363,13 @@ Implementing this function is optional. No implementation of
 [dynamic_batching](
   https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#dynamic-batcher),
 [`input`](
-  https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#inputs-and-outputs) and
+  https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#inputs-and-outputs)
+and
 [`output`](
   https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#inputs-and-outputs)
-properties of the model using `set_max_batch_size`, `set_dynamic_batching`, `add_input`, and
-`add_output`. These properties will allow Triton to load the model with
+properties of the model using `set_max_batch_size`, `set_dynamic_batching`,
+`add_input`, and `add_output`. These properties will allow Triton to load the
+model with
 [minimal model configuration](
   https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#minimal-model-configuration)
 in absence of a configuration file. This function returns the
@@ -397,11 +404,12 @@ below:
 
 ### `execute`
 
-`execute` function is called whenever an inference request is made. Every Python
-model must implement `execute` function. In the `execute` function you are given
-a list of `InferenceRequest` objects. There are two modes of implementing this
-function. The mode you choose should depend on your use case. That is whether
-or not you want to return decoupled responses from this model or not.
+`execute` function is called whenever an inference request is made. Every
+Python model must implement `execute` function. In the `execute` function you
+are given a list of `InferenceRequest` objects. There are two modes of
+implementing this function. The mode you choose should depend on your use case.
+That is whether or not you want to return decoupled responses from this model
+or not.
 
 #### Default Mode
 
@@ -452,7 +460,8 @@ class TritonPythonModel:
             if an_error_occurred:
               # If there is an error, the output_tensors are ignored
               responses.append(pb_utils.InferenceResponse(
-                output_tensors=[], error=pb_utils.TritonError("An Error Occurred")))
+                output_tensors=[],
+                error=pb_utils.TritonError("An Error Occurred")))
 
         return responses
 ```
@@ -485,9 +494,10 @@ request. The workflow in this mode may look like:
   2. Create and populate pb_utils.InferenceResponse to be sent back.
 
   3. Use InferenceResponseSender.send() to send the above response. If
-     this is the last request then pass pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL
-     as a flag with InferenceResponseSender.send(). Otherwise continue with
-     Step 1 for sending next request.
+     this is the last request then pass
+     pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL as a flag with
+     InferenceResponseSender.send(). Otherwise continue with Step 1 for sending
+     next request.
 
 * The return value for `execute` function in this mode should be None.
 
@@ -536,9 +546,9 @@ necessary functions, you should save this file as `model.py`.
 ## Model Config File
 
 Every Python Triton model must provide a `config.pbtxt` file describing
-the model configuration. In order to use this backend you must set the `backend`
-field of your model `config.pbtxt` file to `python`. You shouldn't set
-`platform` field of the configuration.
+the model configuration. In order to use this backend you must set the
+`backend` field of your model `config.pbtxt` file to `python`. You
+shouldn't set `platform` field of the configuration.
 
 Your models directory should look like below:
 ```
@@ -765,7 +775,8 @@ class TritonPythonModel:
 
     def finalize(self):
       if error_during_finalize:
-        raise pb_utils.TritonModelException("An error occurred during finalize.")
+        raise pb_utils.TritonModelException(
+          "An error occurred during finalize.")
 ```
 
 ## Managing Shared Memory
@@ -784,8 +795,8 @@ You can also configure the timeout used for connecting Triton main process
 to the Python backend stubs using the `stub-timeout-seconds`. The default
 value is 30 seconds.
 
-The config values described above can be passed to Triton using `--backend-config`
-flag:
+The config values described above can be passed to Triton using
+`--backend-config` flag:
 
 ```
 /opt/tritonserver/bin/tritonserver --model-repository=`pwd`/models --backend-config=python,<config-key>=<config-value>
@@ -807,10 +818,10 @@ to work around this issue, Python backend spawns a separate process for each
 [model instance](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#multiple-model-instances).
 This is in contrast with how other Triton backends such as
 [ONNXRuntime](https://github.com/triton-inference-server/onnxruntime_backend),
-[TensorFlow](https://github.com/triton-inference-server/tensorflow_backend), and
-[PyTorch](https://github.com/triton-inference-server/pytorch_backend) handle
-multiple instances. Increasing the instance count for these backends will create
-additional threads instead of spawning separate processes.
+[TensorFlow](https://github.com/triton-inference-server/tensorflow_backend),
+and [PyTorch](https://github.com/triton-inference-server/pytorch_backend)
+handle multiple instances. Increasing the instance count for these backends
+will create additional threads instead of spawning separate processes.
 
 # Business Logic Scripting
 
@@ -825,9 +836,9 @@ call this combination of custom logic and model executions *Business Logic
 Scripting (BLS)*.
 
 Starting from 21.08, you can implement BLS in your Python model. A new set of
-utility functions allows you to execute inference requests on other models being
-served by Triton as a part of executing your Python model. Example below shows
-how to use this feature:
+utility functions allows you to execute inference requests on other models
+being served by Triton as a part of executing your Python model. Example below
+shows how to use this feature:
 
 ```python
 import triton_python_backend_utils as pb_utils
@@ -839,16 +850,17 @@ class TritonPythonModel:
       ...
       # Create an InferenceRequest object. `model_name`,
       # `requested_output_names`, and `inputs` are the required arguments and
-      # must be provided when constructing an InferenceRequest object. Make sure
-      # to replace `inputs` argument with a list of `pb_utils.Tensor` objects.
+      # must be provided when constructing an InferenceRequest object. Make
+      # sure to replace `inputs` argument with a list of `pb_utils.Tensor`
+      # objects.
       inference_request = pb_utils.InferenceRequest(
           model_name='model_name',
           requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
           inputs=[<pb_utils.Tensor object>])
 
-      # `pb_utils.InferenceRequest` supports request_id, correlation_id, and model
-      # version in addition to the arguments described above. These arguments
-      # are optional. An example containing all the arguments:
+      # `pb_utils.InferenceRequest` supports request_id, correlation_id, and
+      # model version in addition to the arguments described above. These
+      # arguments are optional. An example containing all the arguments:
       # inference_request = pb_utils.InferenceRequest(model_name='model_name',
       #   requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
       #   inputs=[<list of pb_utils.Tensor objects>],
@@ -859,15 +871,18 @@ class TritonPythonModel:
 
       # Check if the inference response has an error
       if inference_response.has_error():
-          raise pb_utils.TritonModelException(inference_response.error().message())
+          raise pb_utils.TritonModelException(
+            inference_response.error().message())
       else:
           # Extract the output tensors from the inference response.
-          output1 = pb_utils.get_output_tensor_by_name(inference_response, 'REQUESTED_OUTPUT_1')
-          output2 = pb_utils.get_output_tensor_by_name(inference_response, 'REQUESTED_OUTPUT_2')
+          output1 = pb_utils.get_output_tensor_by_name(
+            inference_response, 'REQUESTED_OUTPUT_1')
+          output2 = pb_utils.get_output_tensor_by_name(
+            inference_response, 'REQUESTED_OUTPUT_2')
 
-          # Decide the next steps for model execution based on the received output
-          # tensors. It is possible to use the same output tensors to for the final
-          # inference response too.
+          # Decide the next steps for model execution based on the received
+          # output tensors. It is possible to use the same output tensors
+          # to for the final inference response too.
 ```
 
 
@@ -892,8 +907,9 @@ class TritonPythonModel:
       ...
       # Create an InferenceRequest object. `model_name`,
       # `requested_output_names`, and `inputs` are the required arguments and
-      # must be provided when constructing an InferenceRequest object. Make sure
-      # to replace `inputs` argument with a list of `pb_utils.Tensor` objects.
+      # must be provided when constructing an InferenceRequest object. Make
+      # sure to replace `inputs` argument with a list of `pb_utils.Tensor`
+      # objects.
       inference_request = pb_utils.InferenceRequest(
           model_name='model_name',
           requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
@@ -912,14 +928,17 @@ class TritonPythonModel:
       for infer_response in infer_responses:
         # Check if the inference response has an error
         if inference_response.has_error():
-            raise pb_utils.TritonModelException(inference_response.error().message())
+            raise pb_utils.TritonModelException(
+              inference_response.error().message())
         else:
             # Extract the output tensors from the inference response.
-            output1 = pb_utils.get_output_tensor_by_name(inference_response, 'REQUESTED_OUTPUT_1')
-            output2 = pb_utils.get_output_tensor_by_name(inference_response, 'REQUESTED_OUTPUT_2')
+            output1 = pb_utils.get_output_tensor_by_name(
+              inference_response, 'REQUESTED_OUTPUT_1')
+            output2 = pb_utils.get_output_tensor_by_name(
+              inference_response, 'REQUESTED_OUTPUT_2')
 
-            # Decide the next steps for model execution based on the received output
-            # tensors.
+            # Decide the next steps for model execution based on the received
+            # output tensors.
 ```
 
 A complete example for sync and async BLS in Python backend is included in the
@@ -942,40 +961,44 @@ class TritonPythonModel:
       ...
       # Create an InferenceRequest object. `model_name`,
       # `requested_output_names`, and `inputs` are the required arguments and
-      # must be provided when constructing an InferenceRequest object. Make sure
-      # to replace `inputs` argument with a list of `pb_utils.Tensor` objects.
+      # must be provided when constructing an InferenceRequest object. Make
+      # sure to replace `inputs` argument with a list of `pb_utils.Tensor`
+      # objects.
       inference_request = pb_utils.InferenceRequest(
           model_name='model_name',
           requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
           inputs=[<pb_utils.Tensor object>])
 
-      # `pb_utils.InferenceRequest` supports request_id, correlation_id, and model
-      # version in addition to the arguments described above. These arguments
-      # are optional. An example containing all the arguments:
+      # `pb_utils.InferenceRequest` supports request_id, correlation_id, and
+      # model version in addition to the arguments described above. These
+      # arguments are optional. An example containing all the arguments:
       # inference_request = pb_utils.InferenceRequest(model_name='model_name',
       #   requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
       #   inputs=[<list of pb_utils.Tensor objects>],
       #   request_id="1", correlation_id=4, model_version=1, flags=0)
 
-      # Execute the inference_request and wait for the response. You can set the
-      # exectuion timeout via the parameter 'execution_timeout' in microseconds.
-      # If the request times out, the request will respond with an error. The
-      # default of 'execution_timeout' is 0 which indicates that the request has
-      # no timeout.
+      # Execute the inference_request and wait for the response. You can set
+      # the exectuion timeout via the parameter 'execution_timeout' in
+      # microseconds. If the request times out, the request will respond with
+      # an error. The default of 'execution_timeout' is 0 which indicates that
+      # the request has no timeout.
       inference_responses = inference_request.stream_exec(execution_timeout=10)
 
       for inference_response in inference_responses:
         # Check if the inference response has an error
         if inference_response.has_error():
-            raise pb_utils.TritonModelException(inference_response.error().message())
+            raise pb_utils.TritonModelException(
+              inference_response.error().message())
         else:
             # Extract the output tensors from the inference response.
-            output1 = pb_utils.get_output_tensor_by_name(inference_response, 'REQUESTED_OUTPUT_1')
-            output2 = pb_utils.get_output_tensor_by_name(inference_response, 'REQUESTED_OUTPUT_2')
+            output1 = pb_utils.get_output_tensor_by_name(
+              inference_response, 'REQUESTED_OUTPUT_1')
+            output2 = pb_utils.get_output_tensor_by_name(
+              inference_response, 'REQUESTED_OUTPUT_2')
 
-            # Decide the next steps for model execution based on the received output
-            # tensors. It is possible to use the same output tensors to for the final
-            # inference response too.
+            # Decide the next steps for model execution based on the received
+            # output tensors. It is possible to use the same output tensors to
+            # for the final inference response too.
 ```
 
 
@@ -1000,8 +1023,9 @@ class TritonPythonModel:
       ...
       # Create an InferenceRequest object. `model_name`,
       # `requested_output_names`, and `inputs` are the required arguments and
-      # must be provided when constructing an InferenceRequest object. Make sure
-      # to replace `inputs` argument with a list of `pb_utils.Tensor` objects.
+      # must be provided when constructing an InferenceRequest object. Make
+      # sure to replace `inputs` argument with a list of `pb_utils.Tensor`
+      # objects.
       inference_request = pb_utils.InferenceRequest(
           model_name='model_name',
           requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
@@ -1012,7 +1036,8 @@ class TritonPythonModel:
         # async_exec function returns an
         # [Awaitable](https://docs.python.org/3/library/asyncio-task.html#awaitables)
         # object.
-        infer_response_awaits.append(inference_request.async_stream_exec(execution_timeout=10))
+        infer_response_awaits.append(
+          inference_request.async_stream_exec(execution_timeout=10))
 
       # Wait for all of the inference requests to complete.
       async_responses = await asyncio.gather(*infer_response_awaits)
@@ -1021,14 +1046,17 @@ class TritonPythonModel:
         for infer_response in infer_responses:
           # Check if the inference response has an error
           if inference_response.has_error():
-              raise pb_utils.TritonModelException(inference_response.error().message())
+              raise pb_utils.TritonModelException(
+                inference_response.error().message())
           else:
               # Extract the output tensors from the inference response.
-              output1 = pb_utils.get_output_tensor_by_name(inference_response, 'REQUESTED_OUTPUT_1')
-              output2 = pb_utils.get_output_tensor_by_name(inference_response, 'REQUESTED_OUTPUT_2')
+              output1 = pb_utils.get_output_tensor_by_name(
+                inference_response, 'REQUESTED_OUTPUT_1')
+              output2 = pb_utils.get_output_tensor_by_name(
+                inference_response, 'REQUESTED_OUTPUT_2')
 
-              # Decide the next steps for model execution based on the received output
-              # tensors.
+              # Decide the next steps for model execution based on the received
+              # output tensors.
 ```
 
 A complete example for sync and async BLS for decoupled models is included in
@@ -1037,11 +1065,11 @@ the [Examples](#examples) section.
 Starting from the 22.04 release, the lifetime of the BLS output tensors have
 been improved such that if a tensor is no longer needed in your Python model it
 will be automatically deallocated. This can increase the number of BLS requests
-that you can execute in your model without running into the out of GPU or shared
-memory error.
+that you can execute in your model without running into the out of GPU or
+shared memory error.
 
-Note: Async BLS is not supported on Python 3.6 or lower due to the `async` keyword
-and `asyncio.run` being introduced in Python 3.7.
+Note: Async BLS is not supported on Python 3.6 or lower due to the `async`
+keyword and `asyncio.run` being introduced in Python 3.7.
 
 ## Using BLS with Stateful Models
 
@@ -1056,7 +1084,8 @@ sequence:
 inference_request = pb_utils.InferenceRequest(model_name='model_name',
   requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
   inputs=[<list of pb_utils.Tensor objects>],
-  request_id="1", correlation_id=4, flags=pb_utils.TRITONSERVER_REQUEST_FLAG_SEQUENCE_START)
+  request_id="1", correlation_id=4,
+  flags=pb_utils.TRITONSERVER_REQUEST_FLAG_SEQUENCE_START)
 ```
 
 For indicating the ending of the sequence you can use the
@@ -1071,10 +1100,11 @@ flags = pb_utils.TRITONSERVER_REQUEST_FLAG_SEQUENCE_START | pb_utils.TRITONSERVE
 
 ## Limitation
 
-- You need to make sure that the inference requests performed as a part of your model
-do not create a circular dependency. For example, if model A performs an inference request
-on itself and there are no more model instances ready to execute the inference request, the
-model will block on the inference execution forever.
+- You need to make sure that the inference requests performed as a part of your
+model do not create a circular dependency. For example, if model A performs an
+inference request on itself and there are no more model instances ready to
+execute the inference request, the model will block on the inference execution
+forever.
 
 - BLS can not run inference on a decoupled model using functions
 `inference_request.exec` and `inference_request.async_exec`.
@@ -1178,7 +1208,8 @@ You can find the files for this example in [examples/pytorch](examples/pytorch).
 ## AddSub in JAX
 
 The JAX example shows how to serve JAX in Triton using Python Backend.
-You can find the complete example instructions in [examples/jax](examples/jax/README.md).
+You can find the complete example instructions in
+[examples/jax](examples/jax/README.md).
 
 ## Business Logic Scripting
 
@@ -1189,14 +1220,17 @@ You can find the complete example instructions in
 
 ## Preprocessing
 
-The Preprocessing example shows how to use Python Backend to do model preprocessing.
-You can find the complete example instructions in [examples/preprocessing](examples/preprocessing/README.md).
+The Preprocessing example shows how to use Python Backend to do model
+preprocessing.
+You can find the complete example instructions in
+[examples/preprocessing](examples/preprocessing/README.md).
 
 ## Decoupled Models
 
 The examples of decoupled models shows how to develop and serve
 [decoupled models](#decoupled-mode) in Triton using Python backend.
-You can find the complete example instructions in [examples/decoupled](examples/decoupled/README.md).
+You can find the complete example instructions in
+[examples/decoupled](examples/decoupled/README.md).
 
 # Running with Inferentia
 
@@ -1206,7 +1240,8 @@ located in the python_backend/inferentia sub folder.
 
 # Logging
 
-Starting from 22.09 release, your Python model can log information using the following methods:
+Starting from 22.09 release, your Python model can log information using the
+following methods:
 
 ```python
 import triton_python_backend_utils as pb_utils

--- a/README.md
+++ b/README.md
@@ -949,7 +949,7 @@ models in both [default mode](#default-mode) and
 [decoupled mode](#decoupled-mode). By setting the `decoupled` parameter to
 `True`, the `exec` and `async_exec` function will return a
 [generator](https://docs.python.org/3/glossary.html#term-generator) of
-inference responses returned by a decouple model. If the `decoupled` parameter
+inference responses returned by a decoupled model. If the `decoupled` parameter
 is set to `False`, the `exec` and `async_exec` function will return a single
 response as shown in the example above.
 

--- a/README.md
+++ b/README.md
@@ -946,14 +946,14 @@ A complete example for sync and async BLS in Python backend is included in the
 
 Starting from 23.02 release, you can execute inference requests on decoupled
 models in both [default mode](#default-mode) and
-[decoupled mode](#decoupled-mode). By setting the parameter `decoupled` to
-`True` in function `exec`, you can get a
+[decoupled mode](#decoupled-mode). By setting the `decoupled` parameter to
+`True`, the `exec` and `async_exec` function will return a
 [generator](https://docs.python.org/3/glossary.html#term-generator) of
-responses returned by a decouple model. (By default the parameter `decoupled`
-is set to `False`, which makes the function return a single response as the
-example above.) Besides, you can set the exectuion timeout via the parameter
-'execution_timeout' in microseconds. If the request times out, the request will
-respond with an error. The default of 'execution_timeout' is 0 which indicates
+inference responses returned by a decouple model. If the `decoupled` parameter
+is set to `False`, the `exec` and `async_exec` function will return a single
+response as shown in the example above. Besides, you can set the timeout via
+the parameter 'timeout' in microseconds. If the request times out, the request
+will respond with an error. The default of 'timeout' is 0 which indicates
 that the request has no timeout. Example below shows how to use this feature:
 
 ```python
@@ -985,8 +985,7 @@ class TritonPythonModel:
       # Execute the inference_request and wait for the response. Here we are
       # running a BLS request on a decoupled model, hence setting the parameter
       # 'decoupled' to 'True'.
-      inference_responses = inference_request.exec(
-        decoupled=True, execution_timeout=10)
+      inference_responses = inference_request.exec(decoupled=True, timeout=10)
 
       for inference_response in inference_responses:
         # Check if the inference response has an error
@@ -1042,8 +1041,7 @@ class TritonPythonModel:
         # [Awaitable](https://docs.python.org/3/library/asyncio-task.html#awaitables)
         # object.
         infer_response_awaits.append(
-          inference_request.async_exec(
-            decoupled=True, execution_timeout=10))
+          inference_request.async_exec(decoupled=True, timeout=10))
 
       # Wait for all of the inference requests to complete.
       async_responses = await asyncio.gather(*infer_response_awaits)
@@ -1111,9 +1109,6 @@ model do not create a circular dependency. For example, if model A performs an
 inference request on itself and there are no more model instances ready to
 execute the inference request, the model will block on the inference execution
 forever.
-
-- BLS can not run inference on a decoupled model using functions
-`inference_request.exec` and `inference_request.async_exec`.
 
 - BLS can not run inference on a decoupled model in *async* decoupled mode.
 

--- a/README.md
+++ b/README.md
@@ -161,8 +161,8 @@ as the Python backend repository branch that you are trying to compile.
 * triton-inference-server/core: `-DTRITON_CORE_REPO_TAG=<GIT_BRANCH_NAME>`
 
 
-Set `-DCMAKE_INSTALL_PREFIX` to the location where the Triton Server is installed. In the released containers,
-this location is `/opt/tritonserver`.
+Set `-DCMAKE_INSTALL_PREFIX` to the location where the Triton Server is
+installed. In the released containers, this location is `/opt/tritonserver`.
 
 3. Copy example model and configuration
 
@@ -348,7 +348,8 @@ Every Python backend can implement four main functions:
 ### `auto_complete_config`
 
 `auto_complete_config` is called only once when loading the model assuming
-the server was not started with [`--disable-auto-complete-config`](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#auto-generated-model-configuration).
+the server was not started with
+[`--disable-auto-complete-config`](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#auto-generated-model-configuration).
 
 Implementing this function is optional. No implementation of
 `auto_complete_config` will do nothing. This function can be used to set
@@ -463,7 +464,8 @@ This mode allows user to send multiple responses for a request or
 not send any responses for a request. A model may also send
 responses out-of-order relative to the order that the request batches
 are executed. Such models are called *decoupled* models. In
-order to use this mode, the [transaction policy](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#model-transaction-policy)
+order to use this mode, the
+[transaction policy](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_configuration.md#model-transaction-policy)
 in the model configuration must be set to decoupled.
 
 
@@ -571,12 +573,14 @@ default in the Triton containers.**
 Python backend uses a *stub* process to connect your `model.py` file to the
 Triton C++ core. This stub process has an embedded Python interpreter with
 a fixed Python version. If you intend to use a Python interpreter with
-different version from the default Python backend stub, you need to compile your own
-Python backend stub by following the steps below:
+different version from the default Python backend stub, you need to compile
+your own Python backend stub by following the steps below:
 
 1. Install the software packages below:
 * [cmake](https://cmake.org)
-* rapidjson and libarchive (instructions for installing these packages in Ubuntu or Debian are included in [Building from Source Section](#building-from-source))
+* rapidjson and libarchive (instructions for installing these packages in
+Ubuntu or Debian are included in
+[Building from Source Section](#building-from-source))
 
 2. Make sure that the expected Python version is available in your environment.
 
@@ -629,7 +633,8 @@ models
     `-- triton_python_backend_stub
 ```
 
-Note the location of `triton_python_backend_stub` in the directory structure above.
+Note the location of `triton_python_backend_stub` in the directory structure
+above.
 
 ### Creating Custom Execution Environments
 
@@ -649,8 +654,10 @@ Packing environment at '/home/iman/miniconda3/envs/python-3-6' to 'python-3-6.ta
 [########################################] | 100% Completed |  4.5s
 ```
 
-**Important Note:** Before installing the packages in your conda environment, make sure that you
-have exported [`PYTHONNOUSERSITE`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONNOUSERSITE) environment variable:
+**Important Note:** Before installing the packages in your conda environment,
+make sure that you have exported
+[`PYTHONNOUSERSITE`](https://docs.python.org/3/using/cmdline.html#envvar-PYTHONNOUSERSITE)
+environment variable:
 
 ```
 export PYTHONNOUSERSITE=True
@@ -704,7 +711,8 @@ models
 |   `-- triton_python_backend_stub
 ```
 
-In the example above, `$$TRITON_MODEL_DIRECTORY` is resolved to `$pwd/models/model_a`.
+In the example above, `$$TRITON_MODEL_DIRECTORY` is resolved to
+`$pwd/models/model_a`.
 
 This is useful if you want to use S3, GCS, or Azure and you do not have access
 to the absolute path of the execution env that is stored in the cloud object
@@ -723,8 +731,8 @@ still applies here and the version of the Python interpreter inside the conda
 environment must match the Python version of stub used by Python backend. The
 default version of the stub is Python 3.8.
 
-3. You can share a single execution environment across multiple models. You need to
-provide the path to the tar file in the `EXECUTION_ENV_PATH` in the
+3. You can share a single execution environment across multiple models. You
+need to provide the path to the tar file in the `EXECUTION_ENV_PATH` in the
 `config.pbtxt` of all the models that want to use the execution environment.
 
 4. If `$$TRITON_MODEL_DIRECTORY` is used in the `EXECUTION_ENV_PATH`, the final
@@ -920,8 +928,9 @@ A complete example for sync and async BLS in Python backend is included in the
 Starting from 23.02 release, you can execute inference requests on decoupled
 models in both [default mode](#default-mode) and
 [decoupled mode](#decoupled-mode). By using function `stream_exec`, you can get
-a list of responses returned by a decouple model. Example below shows how to use
-this feature:
+a [generator](https://docs.python.org/3/glossary.html#term-generator) of
+responses returned by a decouple model. Example below shows how to use this
+feature:
 
 ```python
 import triton_python_backend_utils as pb_utils
@@ -1141,7 +1150,8 @@ parameters: { key: "FORCE_CPU_ONLY_INPUT_TENSORS" value: {string_value:"no"}}
 # Examples
 
 For using the Triton Python client in these examples you need to install
-the [Triton Python Client Library](https://github.com/triton-inference-server/client#getting-the-client-libraries-and-examples).
+the
+[Triton Python Client Library](https://github.com/triton-inference-server/client#getting-the-client-libraries-and-examples).
 The Python client for each of the examples is in the `client.py` file.
 
 ## AddSub in NumPy
@@ -1153,9 +1163,11 @@ find the files in [examples/add_sub](examples/add_sub).
 ## AddSubNet in PyTorch
 
 In order to use this model, you need to install PyTorch. We recommend using
-`pip` method mentioned in the [PyTorch website](https://pytorch.org/get-started/locally/).
+`pip` method mentioned in the
+[PyTorch website](https://pytorch.org/get-started/locally/).
 Make sure that PyTorch is available in the same Python environment as other
-dependencies. Alternatively, you can create a [Python Execution Environment](#using-custom-python-execution-environments).
+dependencies. Alternatively, you can create a
+[Python Execution Environment](#using-custom-python-execution-environments).
 You can find the files for this example in [examples/pytorch](examples/pytorch).
 
 ## AddSub in JAX
@@ -1166,7 +1178,9 @@ You can find the complete example instructions in [examples/jax](examples/jax/RE
 ## Business Logic Scripting
 
 The BLS example needs the dependencies required for both of the above examples.
-You can find the complete example instructions in [examples/bls](examples/bls/README.md) and [examples/bls_decoupled](examples/bls_decoupled/README.md).
+You can find the complete example instructions in
+[examples/bls](examples/bls/README.md) and
+[examples/bls_decoupled](examples/bls_decoupled/README.md).
 
 ## Preprocessing
 
@@ -1181,7 +1195,9 @@ You can find the complete example instructions in [examples/decoupled](examples/
 
 # Running with Inferentia
 
-Please see the [README.md](https://github.com/triton-inference-server/python_backend/tree/main/inferentia/README.md) located in the python_backend/inferentia sub folder.
+Please see the
+[README.md](https://github.com/triton-inference-server/python_backend/tree/main/inferentia/README.md)
+located in the python_backend/inferentia sub folder.
 
 # Logging
 

--- a/README.md
+++ b/README.md
@@ -957,8 +957,12 @@ class TritonPythonModel:
       #   inputs=[<list of pb_utils.Tensor objects>],
       #   request_id="1", correlation_id=4, model_version=1, flags=0)
 
-      # Execute the inference_request and wait for the response
-      inference_responses = inference_request.stream_exec()
+      # Execute the inference_request and wait for the response. You can set the
+      # exectuion timeout via the parameter 'execution_timeout' in microseconds.
+      # If the request times out, the request will respond with an error. The
+      # default of 'execution_timeout' is 0 which indicates that the request has
+      # no timeout.
+      inference_responses = inference_request.stream_exec(execution_timeout=10)
 
       for inference_response in inference_responses:
         # Check if the inference response has an error
@@ -1008,7 +1012,7 @@ class TritonPythonModel:
         # async_exec function returns an
         # [Awaitable](https://docs.python.org/3/library/asyncio-task.html#awaitables)
         # object.
-        infer_response_awaits.append(inference_request.async_stream_exec())
+        infer_response_awaits.append(inference_request.async_stream_exec(execution_timeout=10))
 
       # Wait for all of the inference requests to complete.
       async_responses = await asyncio.gather(*infer_response_awaits)
@@ -1075,6 +1079,7 @@ model will block on the inference execution forever.
 - BLS can not run inference on a decoupled model using functions
 `inference_request.exec` and `inference_request.async_exec`.
 
+- BLS can not run inference on a decoupled model in *async* decoupled mode.
 
 # Interoperability and GPU Support
 

--- a/README.md
+++ b/README.md
@@ -1113,7 +1113,7 @@ inference request on itself and there are no more model instances ready to
 execute the inference request, the model will block on the inference execution
 forever.
 
-- BLS can not run inference on a decoupled model in *async* decoupled mode.
+- Async BLS is not supported when running a Python model in decoupled mode.
 
 # Interoperability and GPU Support
 

--- a/README.md
+++ b/README.md
@@ -944,7 +944,7 @@ class TritonPythonModel:
 A complete example for sync and async BLS in Python backend is included in the
 [Examples](#examples) section.
 
-Starting from 23.02 release, you can execute inference requests on decoupled
+Starting from 23.03 release, you can execute inference requests on decoupled
 models in both [default mode](#default-mode) and
 [decoupled mode](#decoupled-mode). By setting the `decoupled` parameter to
 `True`, the `exec` and `async_exec` function will return a

--- a/examples/bls_decoupled/README.md
+++ b/examples/bls_decoupled/README.md
@@ -37,7 +37,7 @@ output `OUT` will equal the value of `IN`. This example is broken into two
 sections. The first section demonstrates how to perform synchronous BLS requests
 and the second section shows how to execute asynchronous BLS requests.
 
-## Synchronous BLS Requests with decoupled models
+## Synchronous BLS Requests with Decoupled Models
 
 The goal of `bls_decoupled_sync` model is to caculate the sum of the responses
 returned from the [square](../decoupled) model and return the summation as the final response. The value of input 'IN' will be passed as an input to the
@@ -97,7 +97,7 @@ The [client.py](./sync_client.py) sends 4 inference requests to the
 respectively. In compliance with the behavior of the sync BLS model,
 it will expect the output to be the square value of the input.
 
-## Asynchronous BLS Requests with decoupled models
+## Asynchronous BLS Requests with Decoupled Models
 
 In this section we explain how to send multiple BLS requests without waiting for
 their response. Asynchronous execution of BLS requests will not block your

--- a/examples/bls_decoupled/README.md
+++ b/examples/bls_decoupled/README.md
@@ -31,22 +31,18 @@
 In this section we demonstrate an end-to-end example for
 [BLS](../../README.md#business-logic-scripting) in Python backend. The
 [model repository](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md)
-should contain [pytorch](../pytorch), [addsub](../add_sub).  The
-[pytorch](../pytorch) and [addsub](../add_sub) models calculate the sum and
-difference of the `INPUT0` and `INPUT1` and put the results in `OUTPUT0` and
-`OUTPUT1` respectively. This example is broken into two sections. The first
-section demonstrates how to perform synchronous BLS requests and the second
-section shows how to execute asynchronous BLS requests.
+should contain [square](../decoupled) model. The [square](../decoupled) model
+will send 'n' responses where 'n' is the value of input `IN`. For each response,
+output `OUT` will equal the value of `IN`. This example is broken into two
+sections. The first section demonstrates how to perform synchronous BLS requests
+and the second section shows how to execute asynchronous BLS requests.
 
-## Synchronous BLS Requests
+## Synchronous BLS Requests with decoupled models
 
-The goal of sync BLS model is the same as [pytorch](../pytorch) and
-[addsub](../add_sub) models but the difference is that the BLS model will not
-calculate the sum and difference by itself. The sync BLS model will pass the
-input tensors to the [pytorch](../pytorch) or [addsub](../add_sub) models and
-return the responses of that model as the final response. The additional
-parameter `MODEL_NAME` determines which model will be used for calculating the
-final outputs.
+The goal of `bls_decoupled_sync` model is to caculate the sum of the responses
+returned from the [square](../decoupled) model and return the summation as the final response. The value of input 'IN' will be passed as an input to the
+[square](../decoupled) model which determines how many responses the
+[square](../decoupled) model will generate.
 
 1. Create the model repository:
 
@@ -96,25 +92,22 @@ explanations about each of the function calls.
 
 ### Explanation of the Client Output
 
-The [client.py](./sync_client.py) sends three inference requests to the 'bls_sync'
-model with different values for the "MODEL_NAME" input. As explained earlier,
-"MODEL_NAME" determines the model name that the "bls" model will use for
-calculating the final outputs. In the first request, it will use the "add_sub"
-model and in the second request it will use the "pytorch" model. The third
-request uses an incorrect model name to demonstrate error handling during
-the inference request execution.
+The [client.py](./sync_client.py) sends 4 inference requests to the
+`bls_decoupled_sync` model with the input as: [4], [2], [0] and [1]
+respectively. In compliance with the behavior of the sync BLS model,
+it will expect the output to be the square value of the input.
 
-## Asynchronous BLS Requests
+## Asynchronous BLS Requests with decoupled models
 
 In this section we explain how to send multiple BLS requests without waiting for
 their response. Asynchronous execution of BLS requests will not block your
 model execution and can lead to speedups under certain conditions.
 
-The `bls_async` model will perform two async BLS requests on the
-[pytorch](../pytorch) and [addsub](../add_sub) models. Then, it will wait until
-the inference requests on these models is completed. It will extract `OUTPUT0`
-from the [pytorch](../pytorch) and `OUTPUT1` from the [addsub](../add_sub) model
-to construct the final inference response object using these tensors.
+The `bls_decoupled_async` model will perform two async BLS requests on the
+[square](../decoupled) model. Then, it will wait until the inference requests
+are completed. It will caculate the sum of the output `OUT` from the
+[square](../decoupled) model in both two requests to construct the final
+inference response object using these tensors.
 
 1. Create the model repository:
 
@@ -158,3 +151,13 @@ Two times the square value of [1] is [2]
 
 PASS: BLS Decoupled Async
 ```
+
+The [async_model.py](./async_model.py) model file is heavily commented with
+explanations about each of the function calls.
+
+### Explanation of the Client Output
+
+The [client.py](./async_client.py) sends 4 inference requests to the
+'bls_decoupled_sync' model with the input as: [4], [2], [0] and [1]
+respectively. In compliance with the behavior of sync BLS model model,
+it will expect the output to be two time the square value of the input.

--- a/examples/bls_decoupled/README.md
+++ b/examples/bls_decoupled/README.md
@@ -1,0 +1,160 @@
+<!--
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+-->
+
+# Example of using BLS with decoupled models
+
+In this section we demonstrate an end-to-end example for
+[BLS](../../README.md#business-logic-scripting) in Python backend. The
+[model repository](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/model_repository.md)
+should contain [pytorch](../pytorch), [addsub](../add_sub).  The
+[pytorch](../pytorch) and [addsub](../add_sub) models calculate the sum and
+difference of the `INPUT0` and `INPUT1` and put the results in `OUTPUT0` and
+`OUTPUT1` respectively. This example is broken into two sections. The first
+section demonstrates how to perform synchronous BLS requests and the second
+section shows how to execute asynchronous BLS requests.
+
+## Synchronous BLS Requests
+
+The goal of sync BLS model is the same as [pytorch](../pytorch) and
+[addsub](../add_sub) models but the difference is that the BLS model will not
+calculate the sum and difference by itself. The sync BLS model will pass the
+input tensors to the [pytorch](../pytorch) or [addsub](../add_sub) models and
+return the responses of that model as the final response. The additional
+parameter `MODEL_NAME` determines which model will be used for calculating the
+final outputs.
+
+1. Create the model repository:
+
+```console
+mkdir -p models/bls_decoupled_sync/1
+mkdir -p models/square_int32/1
+
+# Copy the Python models
+cp examples/bls_decoupled/sync_model.py models/bls_decoupled_sync/1/model.py
+cp examples/bls_decoupled/sync_config.pbtxt models/bls_decoupled_sync/config.pbtxt
+cp examples/decoupled/square_model.py models/square_int32/1/model.py
+cp examples/decoupled/square_config.pbtxt models/square_int32/config.pbtxt
+```
+
+2. Start the tritonserver:
+
+```
+tritonserver --model-repository `pwd`/models
+```
+
+3. Send inference requests to server:
+
+```
+python3 examples/bls_decoupled/sync_client.py
+```
+
+You should see an output similar to the output below:
+
+```
+==========model result==========
+The square value of [4] is [16]
+
+==========model result==========
+The square value of [2] is [4]
+
+==========model result==========
+The square value of [0] is [0]
+
+==========model result==========
+The square value of [1] is [1]
+
+PASS: BLS Decoupled Sync
+```
+
+The [sync_model.py](./sync_model.py) model file is heavily commented with
+explanations about each of the function calls.
+
+### Explanation of the Client Output
+
+The [client.py](./sync_client.py) sends three inference requests to the 'bls_sync'
+model with different values for the "MODEL_NAME" input. As explained earlier,
+"MODEL_NAME" determines the model name that the "bls" model will use for
+calculating the final outputs. In the first request, it will use the "add_sub"
+model and in the second request it will use the "pytorch" model. The third
+request uses an incorrect model name to demonstrate error handling during
+the inference request execution.
+
+## Asynchronous BLS Requests
+
+In this section we explain how to send multiple BLS requests without waiting for
+their response. Asynchronous execution of BLS requests will not block your
+model execution and can lead to speedups under certain conditions.
+
+The `bls_async` model will perform two async BLS requests on the
+[pytorch](../pytorch) and [addsub](../add_sub) models. Then, it will wait until
+the inference requests on these models is completed. It will extract `OUTPUT0`
+from the [pytorch](../pytorch) and `OUTPUT1` from the [addsub](../add_sub) model
+to construct the final inference response object using these tensors.
+
+1. Create the model repository:
+
+```console
+mkdir -p models/bls_decoupled_async/1
+mkdir -p models/square_int32/1
+
+# Copy the Python models
+cp examples/bls_decoupled/async_model.py models/bls_decoupled_async/1/model.py
+cp examples/bls_decoupled/async_config.pbtxt models/bls_decoupled_async/config.pbtxt
+cp examples/decoupled/square_model.py models/square_int32/1/model.py
+cp examples/decoupled/square_config.pbtxt models/square_int32/config.pbtxt
+```
+
+2. Start the tritonserver:
+
+```
+tritonserver --model-repository `pwd`/models
+```
+
+3. Send inference requests to server:
+
+```
+python3 examples/bls_decoupled/async_client.py
+```
+
+You should see an output similar to the output below:
+
+```
+==========model result==========
+Two times the square value of [4] is [32]
+
+==========model result==========
+Two times the square value of [2] is [8]
+
+==========model result==========
+Two times the square value of [0] is [0]
+
+==========model result==========
+Two times the square value of [1] is [2]
+
+PASS: BLS Decoupled Async
+```

--- a/examples/bls_decoupled/async_client.py
+++ b/examples/bls_decoupled/async_client.py
@@ -1,0 +1,65 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from tritonclient.utils import *
+import tritonclient.http as httpclient
+import numpy as np
+import sys
+
+model_name = "bls_decoupled_async"
+shape = [1]
+
+with httpclient.InferenceServerClient("localhost:8000") as client:
+    in_values = [4, 2, 0, 1]
+
+    for in_value in in_values:
+        input_data = np.array([in_value], dtype=np.int32)
+        inputs = [
+            httpclient.InferInput("IN", input_data.shape,
+                                  np_to_triton_dtype(input_data.dtype))
+        ]
+        inputs[0].set_data_from_numpy(input_data)
+        outputs = [httpclient.InferRequestedOutput("SUM")]
+
+        response = client.infer(model_name,
+                                inputs,
+                                request_id=str(1),
+                                outputs=outputs)
+
+        result = response.get_response()
+        # output_data contains two times of the square value of the input value.
+        output_data = response.as_numpy("SUM")
+        print("==========model result==========")
+        print("Two times the square value of {} is {}\n".format(input_data, output_data))
+
+        if not np.allclose((2*input_data*input_data), output_data):
+            print(
+                "BLS Decoupled Async example error: incorrect output value. Expected {}, got {}."
+            .format((2*input_data*input_data), output_data))
+            sys.exit(1)
+
+    print('PASS: BLS Decoupled Async')
+    sys.exit(0)

--- a/examples/bls_decoupled/async_config.pbtxt
+++ b/examples/bls_decoupled/async_config.pbtxt
@@ -1,0 +1,45 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "bls_decoupled_async"
+backend: "python"
+
+input [
+  {
+    name: "IN"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+output [
+  {
+    name: "SUM"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+
+instance_group [{ kind: KIND_CPU }]

--- a/examples/bls_decoupled/async_model.py
+++ b/examples/bls_decoupled/async_model.py
@@ -131,9 +131,9 @@ class TritonPythonModel:
         # The variable that will store the sum of the responses.
         response_sum = np.array([0])
 
-        # Iterate over the list of responses returned by the BLS request. This
-        # interface can support zero, one, and many inference responses per
-        # request.
+        # Iterate over the list of generators of responses returned by the BLS
+        # request. This interface can support zero, one, and many inference
+        # responses per request.
         for infer_responses in async_responses:
             for infer_response in infer_responses:
                 # If inference response has an error, raise an exception

--- a/examples/bls_decoupled/async_model.py
+++ b/examples/bls_decoupled/async_model.py
@@ -1,0 +1,162 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# triton_python_backend_utils is available in every Triton Python model. You
+# need to use this module to create inference requests and responses. It also
+# contains some utility functions for extracting information from model_config
+# and converting Triton input/output types to numpy types.
+import triton_python_backend_utils as pb_utils
+import numpy as np
+import asyncio
+import json
+
+
+class TritonPythonModel:
+    """Your Python model must use the same class name. Every Python model
+    that is created must have "TritonPythonModel" as the class name.
+
+    This model demonstrates how to use BLS with decoupled models.
+
+    This model has a single input and a single output. The model does not
+    support batching.
+      - Input 'IN' shape must be equal to [1], datatype must be INT32.
+      - For each response, output 'SUM' shape must be equal to [1], datatype
+        must be INT32.
+    
+    For every request, the model will send a single response that contains an
+    output named 'SUM'. We will send two BLS requests to the square model and
+    the 'SUM' will contain the summation of the 'OUT' response output returned
+    by the square model in the two BLS requests. The input 'IN' determines how
+    many responses the square model will generate.
+    """
+
+    def initialize(self, args):
+        """`initialize` is called only once when the model is being loaded.
+        Implementing `initialize` function is optional. This function allows
+        the model to intialize any state associated with this model.
+
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
+
+        # You must parse model_config. JSON string is not parsed here
+        self.model_config = json.loads(args['model_config'])
+
+    # You must add the Python 'async' keyword to the beginning of `execute`
+    # function if you want to use `async_exec` function.
+    async def execute(self, requests):
+        """`execute` must be implemented in every Python model. `execute`
+        function receives a list of pb_utils.InferenceRequest as the only
+        argument. This function is called when an inference request is made
+        for this model. Depending on the batching configuration (e.g. Dynamic
+        Batching) used, `requests` may contain multiple requests. Every
+        Python model, must create one pb_utils.InferenceResponse for every
+        pb_utils.InferenceRequest in `requests`. If there is an error, you can
+        set the error argument when creating a pb_utils.InferenceResponse
+
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+
+        Returns
+        -------
+        list
+          A list of pb_utils.InferenceResponse. The length of this list must
+          be the same as `requests`
+        """
+
+        # This model does not support batching, so 'request_count' should
+        # always be 1.
+        if len(requests) != 1:
+            raise pb_utils.TritonModelException("unsupported batch size " +
+                                                len(requests))
+
+        response_num = pb_utils.get_input_tensor_by_name(requests[0], "IN")
+
+        # List of awaitables containing inflight inference responses.
+        inference_response_awaits = []
+
+        # For detailed explanation about the inputs of the repeat model, refer
+        # to the example below:
+        # https://github.com/triton-inference-server/python_backend/blob/r22.12/examples/decoupled/square_model.py
+        # Construct two BLS requests
+        for _ in range(2):
+            infer_request = pb_utils.InferenceRequest(
+                model_name="square_int32",
+                inputs=[response_num],
+                requested_output_names=["OUT"])
+            # Store the awaitable inside the array. We don't need
+            # the inference response immediately so we do not `await`
+            # here.
+            inference_response_awaits.append(infer_request.async_stream_exec())
+
+        # Wait for all the inference requests to finish. The execution
+        # of the Python script will be blocked until all the awaitables
+        # are resolved.
+        async_responses = await asyncio.gather(
+            *inference_response_awaits)
+
+        # The variable that will store the sum of the responses.
+        response_sum = np.array([0])
+
+        # Iterate over the list of responses returned by the BLS request. This
+        # interface can support zero, one, and many inference responses per
+        # request.
+        for infer_responses in async_responses:
+            if infer_responses:
+                for infer_response in infer_responses:
+                    # If inference response has an error, raise an exception
+                    if infer_response.has_error():
+                        raise pb_utils.TritonModelException(
+                            infer_response.error().message())
+
+                    response_sum += pb_utils.get_output_tensor_by_name(
+                        infer_response, "OUT").as_numpy()
+
+        response = [
+            pb_utils.InferenceResponse(
+                output_tensors=[pb_utils.Tensor("SUM", response_sum)])
+        ]
+
+        # Since the model is using the default mode in this example, we
+        # will be returning a single response.
+        return response
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is OPTIONAL. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print('Cleaning up...')

--- a/examples/bls_decoupled/async_model.py
+++ b/examples/bls_decoupled/async_model.py
@@ -135,15 +135,14 @@ class TritonPythonModel:
         # interface can support zero, one, and many inference responses per
         # request.
         for infer_responses in async_responses:
-            if infer_responses:
-                for infer_response in infer_responses:
-                    # If inference response has an error, raise an exception
-                    if infer_response.has_error():
-                        raise pb_utils.TritonModelException(
-                            infer_response.error().message())
+            for infer_response in infer_responses:
+                # If inference response has an error, raise an exception
+                if infer_response.has_error():
+                    raise pb_utils.TritonModelException(
+                        infer_response.error().message())
 
-                    response_sum += pb_utils.get_output_tensor_by_name(
-                        infer_response, "OUT").as_numpy()
+                response_sum += pb_utils.get_output_tensor_by_name(
+                    infer_response, "OUT").as_numpy()
 
         response = [
             pb_utils.InferenceResponse(

--- a/examples/bls_decoupled/async_model.py
+++ b/examples/bls_decoupled/async_model.py
@@ -120,7 +120,8 @@ class TritonPythonModel:
             # Store the awaitable inside the array. We don't need
             # the inference response immediately so we do not `await`
             # here.
-            inference_response_awaits.append(infer_request.async_stream_exec())
+            inference_response_awaits.append(
+                infer_request.async_exec(decoupled=True))
 
         # Wait for all the inference requests to finish. The execution
         # of the Python script will be blocked until all the awaitables

--- a/examples/bls_decoupled/sync_client.py
+++ b/examples/bls_decoupled/sync_client.py
@@ -1,0 +1,64 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+from tritonclient.utils import *
+import tritonclient.http as httpclient
+import numpy as np
+import sys
+
+model_name = "bls_decoupled_sync"
+shape = [1]
+
+with httpclient.InferenceServerClient("localhost:8000") as client:
+    in_values = [4, 2, 0, 1]
+
+    for in_value in in_values:
+        input_data = np.array([in_value], dtype=np.int32)
+        inputs = [
+            httpclient.InferInput("IN", input_data.shape,
+                                  np_to_triton_dtype(input_data.dtype))
+        ]
+        inputs[0].set_data_from_numpy(input_data)
+        outputs = [httpclient.InferRequestedOutput("SUM")]
+
+        response = client.infer(model_name,
+                                inputs,
+                                request_id=str(1),
+                                outputs=outputs)
+
+        result = response.get_response()
+        output_data = response.as_numpy("SUM")
+        print("==========model result==========")
+        print("The square value of {} is {}\n".format(input_data, output_data))
+
+        if not np.allclose(input_data * input_data, output_data):
+            print(
+                "BLS Decoupled Sync example error: incorrect output value. Expected {}, got {}."
+            ).format(input_data * input_data, output_data)
+            sys.exit(1)
+
+    print('PASS: BLS Decoupled Sync')
+    sys.exit(0)

--- a/examples/bls_decoupled/sync_config.pbtxt
+++ b/examples/bls_decoupled/sync_config.pbtxt
@@ -1,0 +1,45 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+name: "bls_decoupled_sync"
+backend: "python"
+
+input [
+  {
+    name: "IN"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+output [
+  {
+    name: "SUM"
+    data_type: TYPE_INT32
+    dims: [ 1 ]
+  }
+]
+
+instance_group [{ kind: KIND_CPU }]

--- a/examples/bls_decoupled/sync_model.py
+++ b/examples/bls_decoupled/sync_model.py
@@ -118,15 +118,14 @@ class TritonPythonModel:
         # request.
         infer_responses = infer_request.stream_exec()
 
-        if infer_responses:
-            for infer_response in infer_responses:
-                # If inference response has an error, raise an exception
-                if infer_response.has_error():
-                    raise pb_utils.TritonModelException(
-                        infer_response.error().message())
+        for infer_response in infer_responses:
+            # If inference response has an error, raise an exception
+            if infer_response.has_error():
+                raise pb_utils.TritonModelException(
+                    infer_response.error().message())
 
-                response_sum += pb_utils.get_output_tensor_by_name(
-                    infer_response, "OUT").as_numpy()
+            response_sum += pb_utils.get_output_tensor_by_name(
+                infer_response, "OUT").as_numpy()
 
         response = [
             pb_utils.InferenceResponse(

--- a/examples/bls_decoupled/sync_model.py
+++ b/examples/bls_decoupled/sync_model.py
@@ -113,9 +113,9 @@ class TritonPythonModel:
         # The variable that will store the sum of the responses.
         response_sum = np.array([0])
 
-        # Iterate over the list of responses returned by the BLS request. This
-        # interface can support zero, one, and many inference responses per
-        # request.
+        # Iterate over the generator of responses returned by the BLS request.
+        # This interface can support zero, one, and many inference responses
+        # per request.
         infer_responses = infer_request.stream_exec()
 
         for infer_response in infer_responses:

--- a/examples/bls_decoupled/sync_model.py
+++ b/examples/bls_decoupled/sync_model.py
@@ -116,7 +116,7 @@ class TritonPythonModel:
         # Iterate over the generator of responses returned by the BLS request.
         # This interface can support zero, one, and many inference responses
         # per request.
-        infer_responses = infer_request.stream_exec()
+        infer_responses = infer_request.exec(decoupled=True)
 
         for infer_response in infer_responses:
             # If inference response has an error, raise an exception

--- a/examples/bls_decoupled/sync_model.py
+++ b/examples/bls_decoupled/sync_model.py
@@ -1,0 +1,145 @@
+# Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+#
+# Redistribution and use in source and binary forms, with or without
+# modification, are permitted provided that the following conditions
+# are met:
+#  * Redistributions of source code must retain the above copyright
+#    notice, this list of conditions and the following disclaimer.
+#  * Redistributions in binary form must reproduce the above copyright
+#    notice, this list of conditions and the following disclaimer in the
+#    documentation and/or other materials provided with the distribution.
+#  * Neither the name of NVIDIA CORPORATION nor the names of its
+#    contributors may be used to endorse or promote products derived
+#    from this software without specific prior written permission.
+#
+# THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+# EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+# IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+# PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+# CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+# EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+# PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+# PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+# OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+# (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+# OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+# triton_python_backend_utils is available in every Triton Python model. You
+# need to use this module to create inference requests and responses. It also
+# contains some utility functions for extracting information from model_config
+# and converting Triton input/output types to numpy types.
+import triton_python_backend_utils as pb_utils
+import numpy as np
+import json
+
+
+class TritonPythonModel:
+    """Your Python model must use the same class name. Every Python model
+    that is created must have "TritonPythonModel" as the class name.
+
+    This model demonstrates how to use BLS with decoupled models.
+
+    This model has a single input and a single output. The model does not
+    support batching.
+      - Input 'IN' shape must be equal to [1], datatype must be INT32.
+      - For each response, output 'SUM' shape must be equal to [1], datatype
+        must be INT32.
+    
+    For every request, the model will send a single response that contains an
+    output named 'SUM'. The 'SUM' will contain the summation of the 'OUT'
+    response output returned by the square model. The input 'IN' determines how
+    many responses the square model will generate.
+    """
+
+    def initialize(self, args):
+        """`initialize` is called only once when the model is being loaded.
+        Implementing `initialize` function is optional. This function allows
+        the model to intialize any state associated with this model.
+
+        Parameters
+        ----------
+        args : dict
+          Both keys and values are strings. The dictionary keys and values are:
+          * model_config: A JSON string containing the model configuration
+          * model_instance_kind: A string containing model instance kind
+          * model_instance_device_id: A string containing model instance device ID
+          * model_repository: Model repository path
+          * model_version: Model version
+          * model_name: Model name
+        """
+
+        # You must parse model_config. JSON string is not parsed here
+        self.model_config = json.loads(args['model_config'])
+
+    def execute(self, requests):
+        """`execute` must be implemented in every Python model. `execute`
+        function receives a list of pb_utils.InferenceRequest as the only
+        argument. This function is called when an inference request is made
+        for this model. Depending on the batching configuration (e.g. Dynamic
+        Batching) used, `requests` may contain multiple requests. Every
+        Python model, must create one pb_utils.InferenceResponse for every
+        pb_utils.InferenceRequest in `requests`. If there is an error, you can
+        set the error argument when creating a pb_utils.InferenceResponse
+
+        Parameters
+        ----------
+        requests : list
+          A list of pb_utils.InferenceRequest
+
+        Returns
+        -------
+        list
+          A list of pb_utils.InferenceResponse. The length of this list must
+          be the same as `requests`
+        """
+
+        # This model does not support batching, so 'request_count' should
+        # always be 1.
+        if len(requests) != 1:
+            raise pb_utils.TritonModelException("unsupported batch size " +
+                                                len(requests))
+
+        response_num = pb_utils.get_input_tensor_by_name(requests[0], "IN")
+
+        # For detailed explanation about the inputs of the repeat model, refer
+        # to the example below:
+        # https://github.com/triton-inference-server/python_backend/blob/r22.12/examples/decoupled/square_model.py
+        # Construct the BLS request
+        infer_request = pb_utils.InferenceRequest(
+            model_name="square_int32",
+            inputs=[response_num],
+            requested_output_names=["OUT"])
+
+        # The variable that will store the sum of the responses.
+        response_sum = np.array([0])
+
+        # Iterate over the list of responses returned by the BLS request. This
+        # interface can support zero, one, and many inference responses per
+        # request.
+        infer_responses = infer_request.stream_exec()
+
+        if infer_responses:
+            for infer_response in infer_responses:
+                # If inference response has an error, raise an exception
+                if infer_response.has_error():
+                    raise pb_utils.TritonModelException(
+                        infer_response.error().message())
+
+                response_sum += pb_utils.get_output_tensor_by_name(
+                    infer_response, "OUT").as_numpy()
+
+        response = [
+            pb_utils.InferenceResponse(
+                output_tensors=[pb_utils.Tensor("SUM", response_sum)])
+        ]
+
+        # Since the model is using the default mode in this example, we
+        # will be returning a single response.
+        return response
+
+    def finalize(self):
+        """`finalize` is called only once when the model is being unloaded.
+        Implementing `finalize` function is OPTIONAL. This function allows
+        the model to perform any necessary clean ups before exit.
+        """
+        print('Cleaning up...')

--- a/src/infer_payload.h
+++ b/src/infer_payload.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -26,30 +26,24 @@
 
 #pragma once
 
-#include <memory>
-#include "infer_payload.h"
-#include "infer_request.h"
 #include "infer_response.h"
 
 namespace triton { namespace backend { namespace python {
 
-TRITONSERVER_Error* CreateTritonErrorFromException(
-    const PythonBackendException& pb_exception);
-
-class RequestExecutor {
-  TRITONSERVER_ResponseAllocator* response_allocator_ = nullptr;
-  TRITONSERVER_Server* server_;
-  std::unique_ptr<SharedMemoryManager>& shm_pool_;
-
+class InferPayload {
  public:
-  std::future<std::unique_ptr<InferResponse>> Infer(
-      std::shared_ptr<InferRequest>& infer_request,
-      std::shared_ptr<InferPayload>& infer_payload);
+  InferPayload(const bool is_decoupled);
+  ~InferPayload();
 
-  RequestExecutor(
-      std::unique_ptr<SharedMemoryManager>& shm_pool,
-      TRITONSERVER_Server* server);
+  void SetPrevPromise(std::promise<std::unique_ptr<InferResponse>>** promise);
+  void SetValueForPrevPromise(std::unique_ptr<InferResponse> infer_response);
+  void ResetPrevPromise();
+  void SetFuture(std::future<std::unique_ptr<InferResponse>>& response_future);
+  bool IsDecoupled();
 
-  ~RequestExecutor();
+ private:
+  std::unique_ptr<std::promise<std::unique_ptr<InferResponse>>> prev_promise_;
+  bool is_decoupled_;
 };
+
 }}}  // namespace triton::backend::python

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -46,7 +46,7 @@ InferRequest::InferRequest(
       requested_output_names_(requested_output_names), model_name_(model_name),
       model_version_(model_version), flags_(flags),
       response_factory_address_(response_factory_address),
-      request_address_(request_address), execution_timeout_(0)
+      request_address_(request_address), timeout_(0)
 {
   for (auto& input : inputs) {
     if (!input) {
@@ -134,15 +134,15 @@ InferRequest::ShmHandle()
 }
 
 int32_t
-InferRequest::ExecTimeout()
+InferRequest::Timeout()
 {
-  return execution_timeout_;
+  return timeout_;
 }
 
 void
-InferRequest::SetExecTimeout(int32_t execution_timeout)
+InferRequest::SetTimeout(int32_t timeout)
 {
-  execution_timeout_ = execution_timeout;
+  timeout_ = timeout;
 }
 
 void
@@ -199,7 +199,7 @@ InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
   infer_request_shm_ptr_->address = request_address_;
   infer_request_shm_ptr_->response_factory_address = response_factory_address_;
   infer_request_shm_ptr_->is_decoupled = is_decoupled_;
-  infer_request_shm_ptr_->execution_timeout = execution_timeout_;
+  infer_request_shm_ptr_->timeout = timeout_;
 
   output_names_handle_shm_ptr_ =
       reinterpret_cast<bi::managed_external_buffer::handle_t*>(
@@ -359,7 +359,7 @@ InferRequest::InferRequest(
   request_address_ = infer_request_shm_ptr_->address;
   response_factory_address_ = infer_request_shm_ptr_->response_factory_address;
   is_decoupled_ = infer_request_shm_ptr_->is_decoupled;
-  execution_timeout_ = infer_request_shm_ptr_->execution_timeout;
+  timeout_ = infer_request_shm_ptr_->timeout;
 
 #ifdef TRITON_PB_STUB
   response_sender_ = std::make_shared<ResponseSender>(

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -66,7 +66,6 @@ InferRequest::InferRequest(
 
   inputs_ = inputs;
   requested_output_names_ = requested_output_names;
-  std::cout << "=====infer request constructor: " << timeout_ << "=====\n";
 #ifdef TRITON_PB_STUB
   response_sender_ = std::make_shared<ResponseSender>(
       request_address_, response_factory_address_,

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -381,7 +381,7 @@ InferRequest::GetResponseSender()
 }
 
 std::vector<std::shared_ptr<InferResponse>>
-InferRequest::Exec(const bool is_decoupled_supported)
+InferRequest::Exec(const bool is_stream)
 {
   ResponseBatch* response_batch = nullptr;
   bool responses_is_set = false;
@@ -406,7 +406,7 @@ InferRequest::Exec(const bool is_decoupled_supported)
     bool has_exception = false;
     PythonBackendException pb_exception(std::string{});
 
-    if (is_decoupled_supported) {
+    if (is_stream) {
       ipc_message->Command() =
           PYTHONSTUB_CommandType::PYTHONSTUB_InferStreamExecRequest;
     } else {

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -140,26 +140,6 @@ InferRequest::Timeout()
 }
 
 void
-InferRequest::SetPrevPromise(
-    std::promise<std::unique_ptr<InferResponse>>** promise)
-{
-  prev_promise_.reset(std::move(*promise));
-}
-
-void
-InferRequest::SetValueForPrevPromise(
-    std::unique_ptr<InferResponse> infer_response)
-{
-  prev_promise_->set_value(std::move(infer_response));
-}
-
-void
-InferRequest::ResetPrevPromise()
-{
-  prev_promise_.reset();
-}
-
-void
 InferRequest::SetIsDecoupled(const bool is_decoupled)
 {
   is_decoupled_ = is_decoupled;

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -134,6 +134,38 @@ InferRequest::ShmHandle()
 }
 
 void
+InferRequest::SetPrevPromise(
+    std::promise<std::unique_ptr<InferResponse>>** promise)
+{
+  prev_promise_.reset(std::move(*promise));
+}
+
+void
+InferRequest::SetValueForPrevPromise(
+    std::unique_ptr<InferResponse> infer_response)
+{
+  prev_promise_->set_value(std::move(infer_response));
+}
+
+void
+InferRequest::ResetPrevPromise()
+{
+  prev_promise_.reset();
+}
+
+void
+InferRequest::SetIsDecoupled(const bool is_decoupled)
+{
+  is_decoupled_ = is_decoupled;
+}
+
+bool
+InferRequest::IsDecoupled()
+{
+  return is_decoupled_;
+}
+
+void
 InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {
   AllocatedSharedMemory<char> infer_request_shm = shm_pool->Construct<char>(
@@ -348,15 +380,15 @@ InferRequest::GetResponseSender()
   return response_sender_;
 }
 
-
-std::shared_ptr<InferResponse>
-InferRequest::Exec()
+std::vector<std::shared_ptr<InferResponse>>
+InferRequest::Exec(const bool is_decoupled_supported)
 {
   ResponseBatch* response_batch = nullptr;
   bool responses_is_set = false;
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   std::unique_ptr<SharedMemoryManager>& shm_pool = stub->SharedMemory();
   bi::managed_external_buffer::handle_t* response_handle = nullptr;
+  std::vector<std::shared_ptr<InferResponse>> infer_responses;
 
   PythonBackendException pb_exception(std::string{});
   std::unique_ptr<IPCMessage> ipc_message;
@@ -374,8 +406,13 @@ InferRequest::Exec()
     bool has_exception = false;
     PythonBackendException pb_exception(std::string{});
 
-    ipc_message->Command() =
-        PYTHONSTUB_CommandType::PYTHONSTUB_InferExecRequest;
+    if (is_decoupled_supported) {
+      ipc_message->Command() =
+          PYTHONSTUB_CommandType::PYTHONSTUB_InferStreamExecRequest;
+    } else {
+      ipc_message->Command() =
+          PYTHONSTUB_CommandType::PYTHONSTUB_InferExecRequest;
+    }
 
     request_batch = shm_pool->Construct<char>(
         sizeof(RequestBatch) + sizeof(bi::managed_external_buffer::handle_t));
@@ -472,45 +509,62 @@ InferRequest::Exec()
       if (response_batch->is_error_set) {
         std::unique_ptr<PbString> pb_string =
             PbString::LoadFromSharedMemory(shm_pool, response_batch->error);
-        return std::make_unique<InferResponse>(
+        auto error_response = std::make_unique<InferResponse>(
             std::vector<std::shared_ptr<PbTensor>>{},
             std::make_shared<PbError>(pb_string->String()));
+        infer_responses.emplace_back(std::move(error_response));
+
+        return infer_responses;
       } else {
-        return std::make_unique<InferResponse>(
+        auto error_response = std::make_unique<InferResponse>(
             std::vector<std::shared_ptr<PbTensor>>{},
             std::make_shared<PbError>(
                 "An error occurred while performing BLS request."));
+        infer_responses.emplace_back(std::move(error_response));
+
+        return infer_responses;
       }
     }
   }
   catch (const PythonBackendException& pb_exception) {
-    return std::make_unique<InferResponse>(
+    auto error_response = std::make_unique<InferResponse>(
         std::vector<std::shared_ptr<PbTensor>>{},
         std::make_shared<PbError>(pb_exception.what()));
+    infer_responses.emplace_back(std::move(error_response));
+
+    return infer_responses;
   }
 
   if (responses_is_set) {
-    std::unique_ptr<InferResponse> infer_response =
-        InferResponse::LoadFromSharedMemory(
-            shm_pool, *response_handle, true /* open cuda handle */);
+    uint32_t response_count = response_batch->response_size;
     auto& memory_manager_message_queue = stub->MemoryManagerQueue();
+    for (size_t idx = 0; idx < response_count; idx++) {
+      std::unique_ptr<InferResponse> response =
+          InferResponse::LoadFromSharedMemory(
+              shm_pool, response_handle[idx], true /* open cuda handle */);
 
-    for (auto& output_tensor : infer_response->OutputTensors()) {
-      if (!output_tensor->IsCPU()) {
-        uint64_t memory_release_id = output_tensor->Memory()->MemoryReleaseId();
-        output_tensor->Memory()->SetMemoryReleaseCallback(
-            [&memory_manager_message_queue, memory_release_id]() {
-              memory_manager_message_queue->Push(memory_release_id);
-            });
+      for (auto& output_tensor : response->OutputTensors()) {
+        if (!output_tensor->IsCPU()) {
+          uint64_t memory_release_id =
+              output_tensor->Memory()->MemoryReleaseId();
+          output_tensor->Memory()->SetMemoryReleaseCallback(
+              [&memory_manager_message_queue, memory_release_id]() {
+                memory_manager_message_queue->Push(memory_release_id);
+              });
+        }
       }
+      infer_responses.emplace_back(std::move(response));
     }
 
-    return infer_response;
+    return infer_responses;
   } else {
-    return std::make_unique<InferResponse>(
+    auto error_response = std::make_unique<InferResponse>(
         std::vector<std::shared_ptr<PbTensor>>{},
         std::make_shared<PbError>(
             "An error occurred while performing BLS request."));
+    infer_responses.emplace_back(std::move(error_response));
+
+    return infer_responses;
   }
 }
 

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -40,13 +40,13 @@ InferRequest::InferRequest(
     const std::vector<std::shared_ptr<PbTensor>>& inputs,
     const std::set<std::string>& requested_output_names,
     const std::string& model_name, const int64_t model_version,
-    const uint32_t flags, const intptr_t response_factory_address,
-    const intptr_t request_address)
+    const uint32_t flags, const int32_t timeout,
+    const intptr_t response_factory_address, const intptr_t request_address)
     : request_id_(request_id), correlation_id_(correlation_id), inputs_(inputs),
       requested_output_names_(requested_output_names), model_name_(model_name),
-      model_version_(model_version), flags_(flags),
+      model_version_(model_version), flags_(flags), timeout_(timeout),
       response_factory_address_(response_factory_address),
-      request_address_(request_address), timeout_(0)
+      request_address_(request_address)
 {
   for (auto& input : inputs) {
     if (!input) {
@@ -66,6 +66,7 @@ InferRequest::InferRequest(
 
   inputs_ = inputs;
   requested_output_names_ = requested_output_names;
+  std::cout << "=====infer request constructor: " << timeout_ << "=====\n";
 #ifdef TRITON_PB_STUB
   response_sender_ = std::make_shared<ResponseSender>(
       request_address_, response_factory_address_,
@@ -137,12 +138,6 @@ int32_t
 InferRequest::Timeout()
 {
   return timeout_;
-}
-
-void
-InferRequest::SetTimeout(int32_t timeout)
-{
-  timeout_ = timeout;
 }
 
 void

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -80,8 +80,7 @@ class InferRequest {
   void SetIsDecoupled(const bool is_decoupled);
 
 #ifdef TRITON_PB_STUB
-  std::vector<std::shared_ptr<InferResponse>> Exec(
-      const bool is_decoupled_supported);
+  std::vector<std::shared_ptr<InferResponse>> Exec(const bool is_stream);
   std::shared_ptr<ResponseSender> GetResponseSender();
 #endif
 

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -75,10 +75,6 @@ class InferRequest {
   const std::set<std::string>& RequestedOutputNames();
   bi::managed_external_buffer::handle_t ShmHandle();
   int32_t Timeout();
-
-  void SetPrevPromise(std::promise<std::unique_ptr<InferResponse>>** promise);
-  void SetValueForPrevPromise(std::unique_ptr<InferResponse> infer_response);
-  void ResetPrevPromise();
   bool IsDecoupled();
   void SetIsDecoupled(const bool is_decoupled);
 
@@ -144,8 +140,6 @@ class InferRequest {
   bi::managed_external_buffer::handle_t* output_names_handle_shm_ptr_;
   bi::managed_external_buffer::handle_t* input_tensors_handle_ptr_;
   bi::managed_external_buffer::handle_t shm_handle_;
-
-  std::unique_ptr<std::promise<std::unique_ptr<InferResponse>>> prev_promise_;
 
 #ifdef TRITON_PB_STUB
   std::shared_ptr<ResponseSender> response_sender_;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -61,7 +61,8 @@ class InferRequest {
       const std::vector<std::shared_ptr<PbTensor>>& inputs,
       const std::set<std::string>& requested_output_names,
       const std::string& model_name, const int64_t model_version,
-      const uint32_t flags = 0, const intptr_t response_factory_address = 0,
+      const uint32_t flags = 0, const int32_t timeout = 0,
+      const intptr_t response_factory_address = 0,
       const intptr_t request_address = 0);
 
   const std::vector<std::shared_ptr<PbTensor>>& Inputs();
@@ -73,7 +74,6 @@ class InferRequest {
   void SetFlags(uint32_t flags);
   const std::set<std::string>& RequestedOutputNames();
   bi::managed_external_buffer::handle_t ShmHandle();
-  void SetTimeout(int32_t timeout);
   int32_t Timeout();
 
   void SetPrevPromise(std::promise<std::unique_ptr<InferResponse>>** promise);
@@ -129,10 +129,10 @@ class InferRequest {
   std::string model_name_;
   int64_t model_version_;
   uint32_t flags_;
+  int32_t timeout_;
   intptr_t response_factory_address_;
   intptr_t request_address_;
   bool is_decoupled_;
-  int32_t timeout_;
 
   // Shared Memory Data Structures
   AllocatedSharedMemory<char> infer_request_shm_;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -50,6 +50,8 @@ struct InferRequestShm {
   uint32_t flags;
   intptr_t address;
   intptr_t response_factory_address;
+  bool is_decoupled;
+  int32_t execution_timeout;
 };
 
 class InferRequest {
@@ -71,6 +73,8 @@ class InferRequest {
   void SetFlags(uint32_t flags);
   const std::set<std::string>& RequestedOutputNames();
   bi::managed_external_buffer::handle_t ShmHandle();
+  void SetExecTimeout(int32_t execution_timeout);
+  int32_t ExecTimeout();
 
   void SetPrevPromise(std::promise<std::unique_ptr<InferResponse>>** promise);
   void SetValueForPrevPromise(std::unique_ptr<InferResponse> infer_response);
@@ -79,7 +83,7 @@ class InferRequest {
   void SetIsDecoupled(const bool is_decoupled);
 
 #ifdef TRITON_PB_STUB
-  std::vector<std::shared_ptr<InferResponse>> Exec(const bool is_stream);
+  std::vector<std::shared_ptr<InferResponse>> Exec(const bool is_decoupled);
   std::shared_ptr<ResponseSender> GetResponseSender();
 #endif
 
@@ -128,6 +132,7 @@ class InferRequest {
   intptr_t response_factory_address_;
   intptr_t request_address_;
   bool is_decoupled_;
+  int32_t execution_timeout_;
 
   // Shared Memory Data Structures
   AllocatedSharedMemory<char> infer_request_shm_;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -62,7 +62,6 @@ class InferRequest {
       const uint32_t flags = 0, const intptr_t response_factory_address = 0,
       const intptr_t request_address = 0);
 
-  std::unique_ptr<std::promise<std::unique_ptr<InferResponse>>> prev_promise_;
   const std::vector<std::shared_ptr<PbTensor>>& Inputs();
   const std::string& RequestId();
   uint64_t CorrelationId();
@@ -140,6 +139,8 @@ class InferRequest {
   bi::managed_external_buffer::handle_t* output_names_handle_shm_ptr_;
   bi::managed_external_buffer::handle_t* input_tensors_handle_ptr_;
   bi::managed_external_buffer::handle_t shm_handle_;
+
+  std::unique_ptr<std::promise<std::unique_ptr<InferResponse>>> prev_promise_;
 
 #ifdef TRITON_PB_STUB
   std::shared_ptr<ResponseSender> response_sender_;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -51,7 +51,7 @@ struct InferRequestShm {
   intptr_t address;
   intptr_t response_factory_address;
   bool is_decoupled;
-  int32_t execution_timeout;
+  int32_t timeout;
 };
 
 class InferRequest {
@@ -73,8 +73,8 @@ class InferRequest {
   void SetFlags(uint32_t flags);
   const std::set<std::string>& RequestedOutputNames();
   bi::managed_external_buffer::handle_t ShmHandle();
-  void SetExecTimeout(int32_t execution_timeout);
-  int32_t ExecTimeout();
+  void SetTimeout(int32_t timeout);
+  int32_t Timeout();
 
   void SetPrevPromise(std::promise<std::unique_ptr<InferResponse>>** promise);
   void SetValueForPrevPromise(std::unique_ptr<InferResponse> infer_response);
@@ -132,7 +132,7 @@ class InferRequest {
   intptr_t response_factory_address_;
   intptr_t request_address_;
   bool is_decoupled_;
-  int32_t execution_timeout_;
+  int32_t timeout_;
 
   // Shared Memory Data Structures
   AllocatedSharedMemory<char> infer_request_shm_;

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -204,13 +204,6 @@ InferResponse::GetNextResponse()
   return std::move(next_response_future_);
 }
 
-void
-InferResponse::SetNextResponseHandle(
-    bi::managed_external_buffer::handle_t next_response_handle)
-{
-  next_response_handle_ = next_response_handle;
-}
-
 #ifndef TRITON_PB_STUB
 std::shared_ptr<TRITONSERVER_Error*>
 InferResponse::Send(

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -39,6 +39,22 @@ namespace triton { namespace backend { namespace python {
 InferResponse::InferResponse(
     const std::vector<std::shared_ptr<PbTensor>>& output_tensors,
     std::shared_ptr<PbError> error)
+    : error_(error), next_response_future_(nullptr)
+{
+  for (auto& output : output_tensors) {
+    if (!output) {
+      throw PythonBackendException(
+          "Output tensor for inference response should not be empty.");
+    }
+  }
+
+  output_tensors_ = output_tensors;
+}
+
+InferResponse::InferResponse(
+    const std::vector<std::shared_ptr<PbTensor>>& output_tensors,
+    std::promise<std::unique_ptr<InferResponse>>* promise,
+    std::shared_ptr<PbError> error)
     : error_(error)
 {
   for (auto& output : output_tensors) {
@@ -49,6 +65,9 @@ InferResponse::InferResponse(
   }
 
   output_tensors_ = output_tensors;
+  next_response_future_ =
+      std::make_unique<std::future<std::unique_ptr<InferResponse>>>(
+          promise->get_future());
 }
 
 std::vector<std::shared_ptr<PbTensor>>&
@@ -186,7 +205,6 @@ InferResponse::SetNextResponseFuture(
   next_response_future_ =
       std::make_unique<std::future<std::unique_ptr<InferResponse>>>(
           promise->get_future());
-  ;
 }
 
 void

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -179,6 +179,47 @@ InferResponse::Error()
   return error_;
 }
 
+void
+InferResponse::SetNextResponseFuture(
+    std::promise<std::unique_ptr<InferResponse>>* promise)
+{
+  next_response_future_ =
+      std::make_unique<std::future<std::unique_ptr<InferResponse>>>(
+          promise->get_future());
+  ;
+}
+
+void
+InferResponse::ResetNextResponseFuture()
+{
+  next_response_future_.reset();
+}
+
+void
+InferResponse::SetCompletedResponse(TRITONSERVER_InferenceResponse* response)
+{
+  completed_response_ = reinterpret_cast<void*>(response);
+}
+
+void*
+InferResponse::CompletedResponse()
+{
+  return completed_response_;
+}
+
+std::unique_ptr<std::future<std::unique_ptr<InferResponse>>>
+InferResponse::GetNextResponse()
+{
+  return std::move(next_response_future_);
+}
+
+void
+InferResponse::SetNextResponseHandle(
+    bi::managed_external_buffer::handle_t next_response_handle)
+{
+  next_response_handle_ = next_response_handle;
+}
+
 #ifndef TRITON_PB_STUB
 std::shared_ptr<TRITONSERVER_Error*>
 InferResponse::Send(

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -195,18 +195,6 @@ InferResponse::ResetNextResponseFuture()
   next_response_future_.reset();
 }
 
-void
-InferResponse::SetCompletedResponse(TRITONSERVER_InferenceResponse* response)
-{
-  completed_response_ = reinterpret_cast<void*>(response);
-}
-
-void*
-InferResponse::CompletedResponse()
-{
-  return completed_response_;
-}
-
 std::unique_ptr<std::future<std::unique_ptr<InferResponse>>>
 InferResponse::GetNextResponse()
 {
@@ -406,6 +394,13 @@ ResponseGenerator::Next()
 
   return responses_[index_++];
 }
+
+int
+ResponseGenerator::Length()
+{
+  return responses_.size();
+}
+
 std::vector<std::shared_ptr<InferResponse>>::iterator
 ResponseGenerator::Begin()
 {

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -381,40 +381,4 @@ InferResponse::DeferredSendCallback()
 }
 #endif
 
-#ifdef TRITON_PB_STUB
-ResponseGenerator::ResponseGenerator(
-    const std::vector<std::shared_ptr<InferResponse>>& responses)
-    : responses_(responses), index_(0)
-{
-}
-
-std::shared_ptr<InferResponse>
-ResponseGenerator::Next()
-{
-  if (index_ == responses_.size()) {
-    throw py::stop_iteration("Iteration is done for the responses.");
-  }
-
-  return responses_[index_++];
-}
-
-int
-ResponseGenerator::Length()
-{
-  return responses_.size();
-}
-
-std::vector<std::shared_ptr<InferResponse>>::iterator
-ResponseGenerator::Begin()
-{
-  return responses_.begin();
-}
-
-std::vector<std::shared_ptr<InferResponse>>::iterator
-ResponseGenerator::End()
-{
-  return responses_.end();
-}
-#endif
-
 }}}  // namespace triton::backend::python

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -390,4 +390,33 @@ InferResponse::DeferredSendCallback()
 }
 #endif
 
+#ifdef TRITON_PB_STUB
+ResponseGenerator::ResponseGenerator(
+    const std::vector<std::shared_ptr<InferResponse>>& responses)
+    : responses_(responses), index_(0)
+{
+}
+
+std::shared_ptr<InferResponse>
+ResponseGenerator::Next()
+{
+  if (index_ == responses_.size()) {
+    throw py::stop_iteration("Iteration is done for the responses.");
+  }
+
+  return responses_[index_++];
+}
+std::vector<std::shared_ptr<InferResponse>>::iterator
+ResponseGenerator::Begin()
+{
+  return responses_.begin();
+}
+
+std::vector<std::shared_ptr<InferResponse>>::iterator
+ResponseGenerator::End()
+{
+  return responses_.end();
+}
+#endif
+
 }}}  // namespace triton::backend::python

--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -198,21 +198,6 @@ InferResponse::Error()
   return error_;
 }
 
-void
-InferResponse::SetNextResponseFuture(
-    std::promise<std::unique_ptr<InferResponse>>* promise)
-{
-  next_response_future_ =
-      std::make_unique<std::future<std::unique_ptr<InferResponse>>>(
-          promise->get_future());
-}
-
-void
-InferResponse::ResetNextResponseFuture()
-{
-  next_response_future_.reset();
-}
-
 std::unique_ptr<std::future<std::unique_ptr<InferResponse>>>
 InferResponse::GetNextResponse()
 {

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -69,6 +69,10 @@ class InferResponse {
   InferResponse(
       const std::vector<std::shared_ptr<PbTensor>>& output_tensors,
       std::shared_ptr<PbError> error = nullptr);
+  InferResponse(
+      const std::vector<std::shared_ptr<PbTensor>>& output_tensors,
+      std::promise<std::unique_ptr<InferResponse>>* promise,
+      std::shared_ptr<PbError> error = nullptr);
   std::vector<std::shared_ptr<PbTensor>>& OutputTensors();
   void SaveToSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool, bool copy_gpu = true);

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -128,4 +128,21 @@ class InferResponse {
   // The TRITONSERVER_InferenceResponse object associated with this response.
   void* completed_response_;
 };
+
+#ifdef TRITON_PB_STUB
+class ResponseGenerator {
+ public:
+  ResponseGenerator(
+      const std::vector<std::shared_ptr<InferResponse>>& responses);
+
+  std::shared_ptr<InferResponse> Next();
+  std::vector<std::shared_ptr<InferResponse>>::iterator Begin();
+  std::vector<std::shared_ptr<InferResponse>>::iterator End();
+
+ private:
+  std::vector<std::shared_ptr<InferResponse>> responses_;
+  size_t index_;
+};
+#endif
+
 }}}  // namespace triton::backend::python

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -83,10 +83,8 @@ class InferResponse {
   void SetNextResponseFuture(
       std::promise<std::unique_ptr<InferResponse>>* promise);
   void ResetNextResponseFuture();
-  void SetCompletedResponse(TRITONSERVER_InferenceResponse* response);
   std::unique_ptr<std::future<std::unique_ptr<InferResponse>>>
   GetNextResponse();
-  void* CompletedResponse();
   void SetNextResponseHandle(
       bi::managed_external_buffer::handle_t next_response_handle);
   bi::managed_external_buffer::handle_t NextResponseHandle();
@@ -136,6 +134,7 @@ class ResponseGenerator {
       const std::vector<std::shared_ptr<InferResponse>>& responses);
 
   std::shared_ptr<InferResponse> Next();
+  int Length();
   std::vector<std::shared_ptr<InferResponse>>::iterator Begin();
   std::vector<std::shared_ptr<InferResponse>>::iterator End();
 

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -126,21 +126,4 @@ class InferResponse {
   bi::managed_external_buffer::handle_t next_response_handle_;
 };
 
-#ifdef TRITON_PB_STUB
-class ResponseGenerator {
- public:
-  ResponseGenerator(
-      const std::vector<std::shared_ptr<InferResponse>>& responses);
-
-  std::shared_ptr<InferResponse> Next();
-  int Length();
-  std::vector<std::shared_ptr<InferResponse>>::iterator Begin();
-  std::vector<std::shared_ptr<InferResponse>>::iterator End();
-
- private:
-  std::vector<std::shared_ptr<InferResponse>> responses_;
-  size_t index_;
-};
-#endif
-
 }}}  // namespace triton::backend::python

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -123,7 +123,6 @@ class InferResponse {
 
   std::unique_ptr<std::future<std::unique_ptr<InferResponse>>>
       next_response_future_;
-  bi::managed_external_buffer::handle_t next_response_handle_;
 };
 
 }}}  // namespace triton::backend::python

--- a/src/infer_response.h
+++ b/src/infer_response.h
@@ -84,9 +84,6 @@ class InferResponse {
   std::shared_ptr<PbError>& Error();
   bi::managed_external_buffer::handle_t ShmHandle();
   void PruneOutputTensors(const std::set<std::string>& requested_output_names);
-  void SetNextResponseFuture(
-      std::promise<std::unique_ptr<InferResponse>>* promise);
-  void ResetNextResponseFuture();
   std::unique_ptr<std::future<std::unique_ptr<InferResponse>>>
   GetNextResponse();
   void SetNextResponseHandle(
@@ -127,8 +124,6 @@ class InferResponse {
   std::unique_ptr<std::future<std::unique_ptr<InferResponse>>>
       next_response_future_;
   bi::managed_external_buffer::handle_t next_response_handle_;
-  // The TRITONSERVER_InferenceResponse object associated with this response.
-  void* completed_response_;
 };
 
 #ifdef TRITON_PB_STUB

--- a/src/ipc_message.h
+++ b/src/ipc_message.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/ipc_message.h
+++ b/src/ipc_message.h
@@ -44,6 +44,7 @@ typedef enum PYTHONSTUB_commandtype_enum {
   PYTHONSTUB_FinalizeResponse,
   PYTHONSTUB_LoadGPUBuffers,
   PYTHONSTUB_InferExecRequest,
+  PYTHONSTUB_InferStreamExecRequest,
   PYTHONSTUB_InferExecResponse,
   PYTHONSTUB_ResponseSend,
   PYTHONSTUB_ResponseClose,

--- a/src/pb_generator.cc
+++ b/src/pb_generator.cc
@@ -47,12 +47,6 @@ ResponseGenerator::Next()
   return responses_[index_++];
 }
 
-int
-ResponseGenerator::Length()
-{
-  return responses_.size();
-}
-
 std::vector<std::shared_ptr<InferResponse>>::iterator
 ResponseGenerator::Begin()
 {

--- a/src/pb_generator.cc
+++ b/src/pb_generator.cc
@@ -1,0 +1,68 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pb_generator.h"
+
+#include <pybind11/embed.h>
+namespace py = pybind11;
+
+namespace triton { namespace backend { namespace python {
+
+ResponseGenerator::ResponseGenerator(
+    const std::vector<std::shared_ptr<InferResponse>>& responses)
+    : responses_(responses), index_(0)
+{
+}
+
+std::shared_ptr<InferResponse>
+ResponseGenerator::Next()
+{
+  if (index_ == responses_.size()) {
+    throw py::stop_iteration("Iteration is done for the responses.");
+  }
+
+  return responses_[index_++];
+}
+
+int
+ResponseGenerator::Length()
+{
+  return responses_.size();
+}
+
+std::vector<std::shared_ptr<InferResponse>>::iterator
+ResponseGenerator::Begin()
+{
+  return responses_.begin();
+}
+
+std::vector<std::shared_ptr<InferResponse>>::iterator
+ResponseGenerator::End()
+{
+  return responses_.end();
+}
+
+}}}  // namespace triton::backend::python

--- a/src/pb_generator.h
+++ b/src/pb_generator.h
@@ -1,0 +1,48 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include "infer_response.h"
+
+namespace triton { namespace backend { namespace python {
+
+class ResponseGenerator {
+ public:
+  ResponseGenerator(
+      const std::vector<std::shared_ptr<InferResponse>>& responses);
+
+  std::shared_ptr<InferResponse> Next();
+  int Length();
+  std::vector<std::shared_ptr<InferResponse>>::iterator Begin();
+  std::vector<std::shared_ptr<InferResponse>>::iterator End();
+
+ private:
+  std::vector<std::shared_ptr<InferResponse>> responses_;
+  size_t index_;
+};
+
+}}}  // namespace triton::backend::python

--- a/src/pb_generator.h
+++ b/src/pb_generator.h
@@ -36,7 +36,6 @@ class ResponseGenerator {
       const std::vector<std::shared_ptr<InferResponse>>& responses);
 
   std::shared_ptr<InferResponse> Next();
-  int Length();
   std::vector<std::shared_ptr<InferResponse>>::iterator Begin();
   std::vector<std::shared_ptr<InferResponse>>::iterator End();
 

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1091,8 +1091,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
       .def(
           "exec",
           [](std::shared_ptr<InferRequest>& infer_request) {
-            auto responses =
-                infer_request->Exec(false /* is_decoupled_supported*/);
+            auto responses = infer_request->Exec(false /* is_stream*/);
             return responses[0];
           })
       .def(
@@ -1107,8 +1106,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
             py::object loop =
                 py::module_::import("asyncio").attr("get_running_loop")();
             py::cpp_function callback = [infer_request]() {
-              auto responses =
-                  infer_request->Exec(false /* is_decoupled_supported*/);
+              auto responses = infer_request->Exec(false /* is_stream*/);
               return responses[0];
             };
             py::object future =
@@ -1123,7 +1121,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
             std::condition_variable timeout_cv;
             std::vector<std::shared_ptr<InferResponse>> responses;
             std::thread t([&timeout_cv, &responses, &infer_request]() {
-              responses = infer_request->Exec(true /* is_decoupled_supported*/);
+              responses = infer_request->Exec(true /* is_stream*/);
               timeout_cv.notify_one();
             });
 
@@ -1155,8 +1153,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
               py::object loop =
                   py::module_::import("asyncio").attr("get_running_loop")();
               py::cpp_function callback = [infer_request]() {
-                auto responses =
-                    infer_request->Exec(true /* is_decoupled_supported*/);
+                auto responses = infer_request->Exec(true /* is_stream*/);
                 return responses;
               };
               future = loop.attr("run_in_executor")(py::none(), callback);

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -43,6 +43,7 @@
 #include <unordered_map>
 #include "infer_response.h"
 #include "pb_error.h"
+#include "pb_generator.h"
 #include "pb_map.h"
 #include "pb_string.h"
 #include "pb_utils.h"

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1091,8 +1091,8 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
       .def(
           "exec",
           [](std::shared_ptr<InferRequest>& infer_request, const bool decoupled,
-             const int32_t execution_timeout) {
-            infer_request->SetExecTimeout(execution_timeout);
+             const int32_t timeout) {
+            infer_request->SetTimeout(timeout);
             std::vector<std::shared_ptr<InferResponse>> responses =
                 infer_request->Exec(decoupled);
             py::object response_object;
@@ -1105,18 +1105,18 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
             return response_object;
           },
           py::arg("decoupled").none(false) = false,
-          py::arg("execution_timeout").none(false) = 0)
+          py::arg("timeout").none(false) = 0)
       .def(
           "async_exec",
           [](std::shared_ptr<InferRequest>& infer_request, const bool decoupled,
-             const int32_t execution_timeout) {
+             const int32_t timeout) {
             std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
             if (stub->IsDecoupled()) {
               throw PythonBackendException(
                   "Async BLS request execution is not support in the decoupled "
                   "API.");
             }
-            infer_request->SetExecTimeout(execution_timeout);
+            infer_request->SetTimeout(timeout);
             py::object loop =
                 py::module_::import("asyncio").attr("get_running_loop")();
             py::cpp_function callback = [infer_request, decoupled]() {
@@ -1136,7 +1136,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
             return future;
           },
           py::arg("decoupled").none(false) = false,
-          py::arg("execution_timeout").none(false) = 0)
+          py::arg("timeout").none(false) = 0)
       .def(
           "requested_output_names", &InferRequest::RequestedOutputNames,
           py::return_value_policy::reference_internal)

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1186,8 +1186,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
             return py::make_iterator(self.Begin(), self.End());
           },
           py::keep_alive<0, 1>())
-      .def("__next__", &ResponseGenerator::Next)
-      .def("__len__", &ResponseGenerator::Length);
+      .def("__next__", &ResponseGenerator::Next);
 
   py::class_<Logger> logger(module, "Logger");
   py::enum_<LogLevel>(logger, "LogLevel")

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1091,12 +1091,6 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
       .def(
           "exec",
           [](std::shared_ptr<InferRequest>& infer_request) {
-            std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
-            if (stub->IsDecoupled()) {
-              throw PythonBackendException(
-                  "Async BLS request execution is not support in the decoupled "
-                  "API.");
-            }
             auto responses =
                 infer_request->Exec(false /* is_decoupled_supported*/);
             return responses[0];

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -152,6 +152,8 @@ struct ResponseBatch {
 
   // Indicates whether this error has a message or not.
   bool is_error_set;
+
+  uint32_t response_size;
 };
 
 struct LogSendMessageBase {

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -614,7 +614,7 @@ ModelInstanceState::GetBLSResponses(
 
 void
 ModelInstanceState::ExecuteBLSRequest(
-    std::shared_ptr<IPCMessage> ipc_message, const bool is_decoupled_supported)
+    std::shared_ptr<IPCMessage> ipc_message, const bool is_stream)
 {
   ModelState* model_state = reinterpret_cast<ModelState*>(Model());
   auto request_executor = std::make_unique<RequestExecutor>(
@@ -733,7 +733,7 @@ ModelInstanceState::ExecuteBLSRequest(
 
       if (pb_exception.what() != nullptr) {
         auto response_future =
-            request_executor->Infer(infer_request, is_decoupled_supported);
+            request_executor->Infer(infer_request, is_stream);
         GetBLSResponses(infer_responses, std::move(response_future));
 
         size_t response_length = infer_responses.size();

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -25,6 +25,7 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "python_be.h"
 
+#include "infer_payload.h"
 #include "pb_log.h"
 
 namespace triton { namespace backend { namespace python {
@@ -733,8 +734,10 @@ ModelInstanceState::ExecuteBLSRequest(
       }
 
       if (pb_exception.what() != nullptr) {
+        std::shared_ptr<InferPayload> infer_payload =
+            std::make_shared<InferPayload>(is_decoupled);
         auto response_future =
-            request_executor->Infer(infer_request, is_decoupled);
+            request_executor->Infer(infer_request, infer_payload);
         GetBLSResponses(infer_responses, std::move(response_future));
 
         size_t response_length = infer_responses.size();

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -373,12 +373,13 @@ ModelInstanceState::SaveRequestsToSharedMemory(
       infer_request = std::make_unique<InferRequest>(
           id, correlation_id, pb_input_tensors, requested_output_names,
           model_state->Name(), model_state->Version(), flags,
-          reinterpret_cast<intptr_t>(factory_ptr),
+          0 /* BLS request timeout*/, reinterpret_cast<intptr_t>(factory_ptr),
           reinterpret_cast<intptr_t>(request));
     } else {
       infer_request = std::make_unique<InferRequest>(
           id, correlation_id, pb_input_tensors, requested_output_names,
-          model_state->Name(), model_state->Version(), flags, 0,
+          model_state->Name(), model_state->Version(), flags,
+          0 /* BLS request timeout*/, 0 /* response_factory_address */,
           reinterpret_cast<intptr_t>(request));
     }
 

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -813,19 +813,6 @@ ModelInstanceState::ExecuteBLSRequest(
     ipc_message->ResponseCondition()->notify_all();
     ipc_message->ResponseCondition()->wait(lock);
   }
-
-  for (auto& response : infer_responses) {
-    if (response) {
-      auto inference_response =
-          reinterpret_cast<TRITONSERVER_InferenceResponse*>(
-              response->CompletedResponse());
-      if (inference_response != nullptr) {
-        LOG_IF_ERROR(
-            TRITONSERVER_InferenceResponseDelete(inference_response),
-            " failed to release BLS inference response.");
-      }
-    }
-  }
 }
 
 void

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -614,7 +614,7 @@ ModelInstanceState::GetBLSResponses(
 
 void
 ModelInstanceState::ExecuteBLSRequest(
-    std::shared_ptr<IPCMessage> ipc_message, const bool is_stream)
+    std::shared_ptr<IPCMessage> ipc_message, const bool is_decoupled)
 {
   ModelState* model_state = reinterpret_cast<ModelState*>(Model());
   auto request_executor = std::make_unique<RequestExecutor>(
@@ -733,7 +733,7 @@ ModelInstanceState::ExecuteBLSRequest(
 
       if (pb_exception.what() != nullptr) {
         auto response_future =
-            request_executor->Infer(infer_request, is_stream);
+            request_executor->Infer(infer_request, is_decoupled);
         GetBLSResponses(infer_responses, std::move(response_future));
 
         size_t response_length = infer_responses.size();

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -334,8 +334,7 @@ class ModelInstanceState : public BackendModelInstance {
 
   // Execute a BLS Request
   void ExecuteBLSRequest(
-      std::shared_ptr<IPCMessage> ipc_message,
-      const bool is_decoupled_supported);
+      std::shared_ptr<IPCMessage> ipc_message, const bool is_stream);
 
   // Cleanup BLS responses
   void CleanupBLSResponses();

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -309,7 +309,7 @@ class ModelInstanceState : public BackendModelInstance {
   void DecoupledMessageQueueMonitor();
 
   // This function is executed on a separate thread and monitors the log message
-  // queue. When it receives a message from the stub, it will load it from 
+  // queue. When it receives a message from the stub, it will load it from
   // shared memory and log it using the triton server core logging facilities.
   void LogMessageQueueMonitor();
 
@@ -333,13 +333,20 @@ class ModelInstanceState : public BackendModelInstance {
   bool ExistsInClosedRequests(intptr_t closed_request);
 
   // Execute a BLS Request
-  void ExecuteBLSRequest(std::shared_ptr<IPCMessage> ipc_message);
+  void ExecuteBLSRequest(
+      std::shared_ptr<IPCMessage> ipc_message,
+      const bool is_decoupled_supported);
 
   // Cleanup BLS responses
   void CleanupBLSResponses();
 
   // Wait for BLS requests to complete
   void WaitForBLSRequestsToFinish();
+
+  // Get BLS responses
+  void GetBLSResponses(
+      std::vector<std::unique_ptr<InferResponse>>& responses,
+      std::future<std::unique_ptr<InferResponse>> future);
 
   // Check the incoming requests for errors
   TRITONSERVER_Error* CheckIncomingRequests(

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -323,7 +323,7 @@ RequestExecutor::Infer(
         irequest, infer_request->Flags()));
 
     THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetTimeoutMicroseconds(
-        irequest, infer_request->ExecTimeout()));
+        irequest, infer_request->Timeout()));
 
     THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetReleaseCallback(
         irequest, InferRequestComplete, nullptr /* request_release_userp */));

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -56,12 +56,110 @@ void
 InferResponseComplete(
     TRITONSERVER_InferenceResponse* response, const uint32_t flags, void* userp)
 {
+  auto p = reinterpret_cast<std::shared_ptr<InferRequest>*>(userp);
+  std::unique_ptr<InferResponse> infer_response;
+
   if (response != nullptr) {
-    // Send 'response' to the future.
-    std::promise<TRITONSERVER_InferenceResponse*>* p =
-        reinterpret_cast<std::promise<TRITONSERVER_InferenceResponse*>*>(userp);
-    p->set_value(response);
-    delete p;
+    try {
+      THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceResponseError(response));
+
+      uint32_t output_count;
+      THROW_IF_TRITON_ERROR(
+          TRITONSERVER_InferenceResponseOutputCount(response, &output_count));
+
+      std::vector<std::shared_ptr<PbTensor>> output_tensors;
+      for (uint32_t idx = 0; idx < output_count; ++idx) {
+        const char* cname;
+        TRITONSERVER_DataType datatype;
+        const int64_t* shape;
+        uint64_t dim_count;
+        const void* base;
+        size_t byte_size;
+        TRITONSERVER_MemoryType memory_type;
+        int64_t memory_type_id;
+        void* userp;
+
+        THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceResponseOutput(
+            response, idx, &cname, &datatype, &shape, &dim_count, &base,
+            &byte_size, &memory_type, &memory_type_id, &userp));
+        std::string sname = cname;
+        std::vector<int64_t> dims_vector{shape, shape + dim_count};
+
+        // userp is only set for the CPU tensors
+        if (memory_type != TRITONSERVER_MEMORY_GPU) {
+          if (byte_size != 0) {
+            std::shared_ptr<PbTensor> pb_tensor = std::make_shared<PbTensor>(
+                sname, dims_vector, datatype, memory_type, memory_type_id,
+                const_cast<void*>(base), byte_size,
+                nullptr /* DLManagedTensor */);
+
+            // Load the data so that it is deallocated automatically.
+            std::unique_ptr<PbMemory> pb_memory(
+                reinterpret_cast<PbMemory*>(userp));
+            pb_tensor->SetMemory(std::move(pb_memory));
+            output_tensors.push_back(pb_tensor);
+          } else {
+            output_tensors.push_back(std::make_shared<PbTensor>(
+                sname, dims_vector, datatype, memory_type, memory_type_id,
+                const_cast<void*>(base), byte_size,
+                nullptr /* DLManagedTensor */));
+          }
+        } else {
+          output_tensors.push_back(std::make_shared<PbTensor>(
+              sname, dims_vector, datatype, memory_type, memory_type_id,
+              const_cast<void*>(base), byte_size,
+              nullptr /* DLManagedTensor */));
+        }
+      }
+      std::shared_ptr<PbError> pb_error;
+      infer_response =
+          std::make_unique<InferResponse>(output_tensors, pb_error);
+    }
+    catch (const PythonBackendException& pb_exception) {
+      if (response != nullptr) {
+        LOG_IF_ERROR(
+            TRITONSERVER_InferenceResponseDelete(response),
+            "Failed to delete inference response.");
+
+        response = nullptr;
+      }
+      std::shared_ptr<PbError> pb_error =
+          std::make_shared<PbError>(pb_exception.what());
+      infer_response = std::make_unique<InferResponse>(
+          std::vector<std::shared_ptr<PbTensor>>{}, pb_error);
+    }
+
+    infer_response->SetCompletedResponse(response);
+
+    if (!(*p)->IsDecoupled()) {
+      infer_response->ResetNextResponseFuture();
+      (*p)->SetValueForPrevPromise(std::move(infer_response));
+      (*p)->ResetPrevPromise();
+    } else {
+      if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
+        // Not the last reponse. Need to store the promise associated with the
+        // next future.
+        auto promise = new std::promise<std::unique_ptr<InferResponse>>();
+        infer_response->SetNextResponseFuture(promise);
+        (*p)->SetValueForPrevPromise(std::move(infer_response));
+        (*p)->SetPrevPromise(&promise);
+      } else {
+        // The last response.
+        infer_response->ResetNextResponseFuture();
+        (*p)->SetValueForPrevPromise(std::move(infer_response));
+        (*p)->ResetPrevPromise();
+      }
+    }
+  } else if (
+      (*p)->IsDecoupled() &&
+      (flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) != 0) {
+    // An empty response may be the last reponse for decoupled models.
+    (*p)->SetValueForPrevPromise(std::unique_ptr<InferResponse>{});
+    (*p)->ResetPrevPromise();
+  } else {
+    (*p)->SetValueForPrevPromise(std::unique_ptr<InferResponse>{});
+    (*p)->ResetPrevPromise();
+    throw PythonBackendException("Unexpected empty response.");
   }
 }
 
@@ -171,21 +269,16 @@ RequestExecutor::RequestExecutor(
   response_allocator_ = allocator;
 }
 
-std::unique_ptr<InferResponse>
+std::future<std::unique_ptr<InferResponse>>
 RequestExecutor::Infer(
-    const std::shared_ptr<InferRequest>& infer_request,
-    TRITONSERVER_InferenceResponse** triton_response)
+    std::shared_ptr<InferRequest>& infer_request,
+    const bool is_decoupled_supported)
 {
+  std::future<std::unique_ptr<InferResponse>> response_future;
   std::unique_ptr<InferResponse> infer_response;
   bool is_ready = false;
   const char* model_name = infer_request->ModelName().c_str();
   TRITONSERVER_InferenceRequest* irequest = nullptr;
-  TRITONSERVER_InferenceResponse* response = nullptr;
-
-  // This variable indicates whether the InferenceRequest should be deleted as a
-  // part of the catch block or it will be automatically deleted using the
-  // InferResponseComplete callback.
-  bool delete_inference_request = true;
 
   try {
     int64_t model_version = infer_request->ModelVersion();
@@ -202,9 +295,11 @@ RequestExecutor::Infer(
     uint32_t txn_flags;
     THROW_IF_TRITON_ERROR(TRITONSERVER_ServerModelTransactionProperties(
         server_, model_name, model_version, &txn_flags, nullptr /* voidp */));
+    infer_request->SetIsDecoupled(
+        (txn_flags & TRITONSERVER_TXN_DECOUPLED) != 0);
 
-    // Decoupled API is not supported in the current BLS interface
-    if ((txn_flags & TRITONSERVER_TXN_DECOUPLED) != 0) {
+    if (!is_decoupled_supported && infer_request->IsDecoupled()) {
+      // Decoupled API is not supported in the current BLS interface
       throw PythonBackendException(
           std::string("Model ") + model_name +
           " is using the decoupled. BLS doesn't support models using the "
@@ -245,98 +340,30 @@ RequestExecutor::Infer(
     }
 
     {
-      auto p = new std::promise<TRITONSERVER_InferenceResponse*>();
-      std::future<TRITONSERVER_InferenceResponse*> completed = p->get_future();
+      auto p = new std::promise<std::unique_ptr<InferResponse>>();
+      response_future = p->get_future();
+      // infer_request->SetPrevPromise(&p);
+      infer_request->prev_promise_.reset(std::move(p));
 
       THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetResponseCallback(
           irequest, response_allocator_, shm_pool_.get(), InferResponseComplete,
-          reinterpret_cast<void*>(p)));
+          reinterpret_cast<void*>(&infer_request)));
 
       THROW_IF_TRITON_ERROR(TRITONSERVER_ServerInferAsync(
           server_, irequest, nullptr /* trace */));
-
-      // Wait for the inference to complete.
-      response = completed.get();
-      *triton_response = response;
-      delete_inference_request = false;
-      THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceResponseError(response));
-
-      uint32_t output_count;
-      THROW_IF_TRITON_ERROR(
-          TRITONSERVER_InferenceResponseOutputCount(response, &output_count));
-
-      std::vector<std::shared_ptr<PbTensor>> output_tensors;
-      for (uint32_t idx = 0; idx < output_count; ++idx) {
-        const char* cname;
-        TRITONSERVER_DataType datatype;
-        const int64_t* shape;
-        uint64_t dim_count;
-        const void* base;
-        size_t byte_size;
-        TRITONSERVER_MemoryType memory_type;
-        int64_t memory_type_id;
-        void* userp;
-
-        THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceResponseOutput(
-            response, idx, &cname, &datatype, &shape, &dim_count, &base,
-            &byte_size, &memory_type, &memory_type_id, &userp));
-        std::string sname = cname;
-        std::vector<int64_t> dims_vector{shape, shape + dim_count};
-
-        // userp is only set for the CPU tensors
-        if (memory_type != TRITONSERVER_MEMORY_GPU) {
-          if (byte_size != 0) {
-            std::shared_ptr<PbTensor> pb_tensor = std::make_shared<PbTensor>(
-                sname, dims_vector, datatype, memory_type, memory_type_id,
-                const_cast<void*>(base), byte_size,
-                nullptr /* DLManagedTensor */);
-
-            // Load the data so that it is deallocated automatically.
-            std::unique_ptr<PbMemory> pb_memory(
-                reinterpret_cast<PbMemory*>(userp));
-            pb_tensor->SetMemory(std::move(pb_memory));
-            output_tensors.push_back(pb_tensor);
-          } else {
-            output_tensors.push_back(std::make_shared<PbTensor>(
-                sname, dims_vector, datatype, memory_type, memory_type_id,
-                const_cast<void*>(base), byte_size,
-                nullptr /* DLManagedTensor */));
-          }
-        } else {
-          output_tensors.push_back(std::make_shared<PbTensor>(
-              sname, dims_vector, datatype, memory_type, memory_type_id,
-              const_cast<void*>(base), byte_size,
-              nullptr /* DLManagedTensor */));
-        }
-      }
-
-      std::shared_ptr<PbError> pb_error;
-      infer_response =
-          std::make_unique<InferResponse>(output_tensors, pb_error);
     }
   }
   catch (const PythonBackendException& pb_exception) {
-    if (response != nullptr) {
-      LOG_IF_ERROR(
-          TRITONSERVER_InferenceResponseDelete(response),
-          "Failed to delete inference response.");
+    LOG_IF_ERROR(
+        TRITONSERVER_InferenceRequestDelete(irequest),
+        "Failed to delete inference request.");
 
-      *triton_response = nullptr;
-    }
-
-    if (delete_inference_request) {
-      LOG_IF_ERROR(
-          TRITONSERVER_InferenceRequestDelete(irequest),
-          "Failed to delete inference request.");
-    }
-
-    std::shared_ptr<PbError> pb_error =
-        std::make_shared<PbError>(pb_exception.what());
-    infer_response = std::make_unique<InferResponse>(
-        std::vector<std::shared_ptr<PbTensor>>{}, pb_error);
+    throw PythonBackendException(
+        std::string("Model ") + model_name +
+        " - Error when running inference: " + pb_exception.what());
   }
 
-  return infer_response;
+  return response_future;
 }
 
 RequestExecutor::~RequestExecutor()

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -271,8 +271,7 @@ RequestExecutor::RequestExecutor(
 
 std::future<std::unique_ptr<InferResponse>>
 RequestExecutor::Infer(
-    std::shared_ptr<InferRequest>& infer_request,
-    const bool is_decoupled_supported)
+    std::shared_ptr<InferRequest>& infer_request, const bool is_stream)
 {
   std::future<std::unique_ptr<InferResponse>> response_future;
   std::unique_ptr<InferResponse> infer_response;
@@ -298,12 +297,14 @@ RequestExecutor::Infer(
     infer_request->SetIsDecoupled(
         (txn_flags & TRITONSERVER_TXN_DECOUPLED) != 0);
 
-    if (!is_decoupled_supported && infer_request->IsDecoupled()) {
-      // Decoupled API is not supported in the current BLS interface
+    if (!is_stream && infer_request->IsDecoupled()) {
+      // Decoupled API is only supported by using stream API
       throw PythonBackendException(
           std::string("Model ") + model_name +
-          " is using the decoupled. BLS doesn't support models using the "
-          "decoupled transaction policy.");
+          " is using the decoupled. The current BLS request call doesn't "
+          "support models using the decoupled transaction policy. Please use "
+          "stream API 'stream_exec()' or 'async_stream_exec() for decoupled "
+          "models.'");
     }
 
     // Inference

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -56,7 +56,6 @@ void
 InferResponseComplete(
     TRITONSERVER_InferenceResponse* response, const uint32_t flags, void* userp)
 {
-  // auto p = reinterpret_cast<std::shared_ptr<InferRequest>*>(userp);
   auto p = reinterpret_cast<std::shared_ptr<InferPayload>*>(userp);
   std::unique_ptr<InferResponse> infer_response;
   std::vector<std::shared_ptr<PbTensor>> output_tensors;

--- a/src/request_executor.h
+++ b/src/request_executor.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/request_executor.h
+++ b/src/request_executor.h
@@ -42,8 +42,7 @@ class RequestExecutor {
 
  public:
   std::future<std::unique_ptr<InferResponse>> Infer(
-      std::shared_ptr<InferRequest>& infer_request,
-      const bool is_decoupled_supported);
+      std::shared_ptr<InferRequest>& infer_request, const bool is_stream);
 
   RequestExecutor(
       std::unique_ptr<SharedMemoryManager>& shm_pool,

--- a/src/request_executor.h
+++ b/src/request_executor.h
@@ -42,7 +42,7 @@ class RequestExecutor {
 
  public:
   std::future<std::unique_ptr<InferResponse>> Infer(
-      std::shared_ptr<InferRequest>& infer_request, const bool is_stream);
+      std::shared_ptr<InferRequest>& infer_request, const bool is_decoupled);
 
   RequestExecutor(
       std::unique_ptr<SharedMemoryManager>& shm_pool,

--- a/src/request_executor.h
+++ b/src/request_executor.h
@@ -41,9 +41,9 @@ class RequestExecutor {
   std::unique_ptr<SharedMemoryManager>& shm_pool_;
 
  public:
-  std::unique_ptr<InferResponse> Infer(
-      const std::shared_ptr<InferRequest>& infer_request,
-      TRITONSERVER_InferenceResponse** response);
+  std::future<std::unique_ptr<InferResponse>> Infer(
+      std::shared_ptr<InferRequest>& infer_request,
+      const bool is_decoupled_supported);
 
   RequestExecutor(
       std::unique_ptr<SharedMemoryManager>& shm_pool,


### PR DESCRIPTION
In this PR, ~~two APIs, `InferenceRequest.stream_exec()` and `InferenceRequest.async_stream_exec()` are added for BLS decoupled support.~~ two arguments, `decoupled` and `execution_timeout` are added to the original `exec()` and `async_exec()` funstion for BLS decoupled support. [Here ](https://docs.google.com/document/d/1_bb574D4_XPR-_CzztJjHL9LUYcNSI5bdbuFF22I1oU/edit)is the design doc for reference.

Under the hood, chained futures were used for retrieving responses from decoupled models (please refer to the design [here](https://docs.google.com/presentation/d/1aIDFLy0KPe1r-Vv88H4bRt1t9BMdSsjOn5At0hWFUhQ/edit#slide=id.p)). ~~hence, instead of using the [generator](https://docs.python.org/3/glossary.html#term-generator), the futures will gather the responses and the responses will be returned as a list~~. A generator that contains all the responses will be returned.

**Update: Currently, all the responses will be retrieved first and then transfer it to the user's Python model. For the next release, we would fix this issue and send the responses as they are being received.**

For the timeout parameter mentioned in the design doc, the timeout in between two different responses from the generator will not be needed since the implementation of using chained futures handles the possible missing `TRITONSERVER_RESPONSE_COMPLETE_FINAL` flag leading to infinite loop situation, 

Testing: https://github.com/triton-inference-server/server/pull/5245