### PR TITLE
Atomically increase/read stub process count and fix random boost truncate fail

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-# Copyright 2020-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2020-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -95,8 +95,8 @@ FetchContent_MakeAvailable(dlpack)
 #
 ExternalProject_Add(
   boostorg
-  URL https://boostorg.jfrog.io/artifactory/main/release/1.76.0/source/boost_1_76_0.tar.gz
-  URL_HASH SHA256=7bd7ddceec1a1dfdcbdb3e609b60d01739c38390a5f956385a12f3122049f0ca
+  URL https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz
+  URL_HASH SHA256=273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c
   PREFIX "boost-src"
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E copy_directory
                     <SOURCE_DIR>/boost/ ${CMAKE_BINARY_DIR}/boost

--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -43,10 +43,27 @@ SharedMemoryManager::SharedMemoryManager(
 
   try {
     if (create) {
-      shm_obj_ = std::make_unique<bi::shared_memory_object>(
-          bi::open_or_create, shm_region_name.c_str(), bi::read_write);
-      shm_obj_->truncate(shm_size);
+      // Remove (if any) and create the region. Truncate the shm region could
+      // occasionally fail, allow up to max_retry for stability.
+      int max_retry = 3;
+      while (true) {
+        try {
+          bi::shared_memory_object::remove(shm_region_name.c_str());
+          shm_obj_ = std::make_unique<bi::shared_memory_object>(
+              bi::create_only, shm_region_name.c_str(), bi::read_write);
+          shm_obj_->truncate(shm_size);
+          break;
+        }
+        catch (bi::interprocess_exception& ex) {
+          if (--max_retry > 0) {
+            sleep(1);
+          } else {
+            throw ex;
+          }
+        }
+      }
     } else {
+      // Open the existing region.
       shm_obj_ = std::make_unique<bi::shared_memory_object>(
           bi::open_only, shm_region_name.c_str(), bi::read_write);
     }

--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -43,25 +43,11 @@ SharedMemoryManager::SharedMemoryManager(
 
   try {
     if (create) {
-      // Remove (if any) and create the region. Truncate the shm region could
-      // occasionally fail, allow up to max_retry for stability.
-      int max_retry = 3;
-      while (true) {
-        try {
-          bi::shared_memory_object::remove(shm_region_name.c_str());
-          shm_obj_ = std::make_unique<bi::shared_memory_object>(
-              bi::create_only, shm_region_name.c_str(), bi::read_write);
-          shm_obj_->truncate(shm_size);
-          break;
-        }
-        catch (bi::interprocess_exception& ex) {
-          if (--max_retry > 0) {
-            sleep(1);
-          } else {
-            throw ex;
-          }
-        }
-      }
+      // Remove (if any) and create the region.
+      bi::shared_memory_object::remove(shm_region_name.c_str());
+      shm_obj_ = std::make_unique<bi::shared_memory_object>(
+          bi::create_only, shm_region_name.c_str(), bi::read_write);
+      shm_obj_->truncate(shm_size);
     } else {
       // Open the existing region.
       shm_obj_ = std::make_unique<bi::shared_memory_object>(

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -35,6 +35,7 @@
 #include <type_traits>
 #include <typeinfo>
 #include <vector>
+#include <functional>
 #include "pb_exception.h"
 
 namespace triton { namespace backend { namespace python {

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -62,12 +62,12 @@ StubLauncher::Initialize(ModelState* model_state)
   is_decoupled_ = model_state->IsDecoupled();
   model_repository_path_ = model_state->RepositoryPath();
 
-  // Increase the stub process count to avoid shared memory region name
-  // collision
-  model_state->StateForBackend()->number_of_instance_inits++;
+  // Atomically increase and read the stub process count to avoid shared memory
+  // region name collision
+  int num_init = ++model_state->StateForBackend()->number_of_instance_inits;
   shm_region_name_ =
       model_state->StateForBackend()->shared_memory_region_prefix +
-      std::to_string(model_state->StateForBackend()->number_of_instance_inits);
+      std::to_string(num_init);
 
   model_version_ = model_state->Version();
 


### PR DESCRIPTION
This PR involves two changes:

[Atomically increase and read stub process count](https://github.com/triton-inference-server/python_backend/pull/205/commits/626349b691e405be53306bb9754a8bbffa502463)
The stub process count needs to be increased and read atomically. Otherwise, during parallel model loading, the combination: 
```
thread 1:           count = 1
thread 1: increase; count = 2
thread 2: increase; count = 3
thread 1: read;     count = 3
thread 2: read;     count = 3
```
could happen resulting in shared memory name collision, which two or more stubs could be using the same region.

[Upgrade boost to 1.79.0](https://github.com/triton-inference-server/python_backend/pull/205/commits/ebca0c101d48cbbe15ce0d931318065471665d2a)
The current version of boost (1.76.0) has two bugs in the `shared_memory_object.truncate()`. The first bug is it does not correctly return the error from `posix_fallocate()` when it encounters error, as the function only returns the code but does not set `errno`, while boost checks for `errno` for the error. The second bug is if `posix_fallocate()` encounters `EINTR` error, it is safe to retry and should not throw the error back to the caller. The upgraded version 1.79.0 fixed both bugs.