### PR TITLE
Typo in class variable declaration on preprocessing example

### DIFF
--- a/examples/preprocessing/model.py
+++ b/examples/preprocessing/model.py
@@ -63,11 +63,11 @@ class TritonPythonModel:
         """
 
         # You must parse model_config. JSON string is not parsed here
-        self.model_config = model_config = json.loads(args['model_config'])
+        self.model_config = json.loads(args['model_config'])
 
         # Get OUTPUT0 configuration
         output0_config = pb_utils.get_output_config_by_name(
-            model_config, "OUTPUT_0")
+            self.model_config, "OUTPUT_0")
 
         # Convert Triton types to numpy types
         self.output0_dtype = pb_utils.triton_string_to_numpy(


### PR DESCRIPTION
`model_config` is declared twice: once as a class variable (`self.model_config`) and once as a local variable (`model_config`) in the same statement. I think it is better to declare it only once as class variable.

I have updated the only line where it is used with the new name.