### PR TITLE
Pass InferPayload pointer to callback function to fix reinterpret_cast issue on shared_ptr

### DIFF
--- a/src/python_be.h
+++ b/src/python_be.h
@@ -257,8 +257,6 @@ class ModelInstanceState : public BackendModelInstance {
 
   TRITONBACKEND_Model* triton_model_;
   std::unique_ptr<StubLauncher> model_instance_stub_;
-  std::vector<TRITONSERVER_InferenceResponse*> bls_inference_responses_;
-  std::mutex bls_responses_mutex_;
   std::vector<intptr_t> closed_requests_;
   std::mutex closed_requests_mutex_;
 


### PR DESCRIPTION
This PR fixed the value corrupted issue with the`std::shared_ptr<InferPayload>*` object.  `shared_ptr` is only thread safe when used by value (copied/moved). It's not thread safe when calling by reference. 