### PR TITLE
Fix shared_ptr thread-safe issue for InferResponseComplete callback (…

### DIFF
--- a/src/python_be.h
+++ b/src/python_be.h
@@ -257,8 +257,6 @@ class ModelInstanceState : public BackendModelInstance {
 
   TRITONBACKEND_Model* triton_model_;
   std::unique_ptr<StubLauncher> model_instance_stub_;
-  std::vector<TRITONSERVER_InferenceResponse*> bls_inference_responses_;
-  std::mutex bls_responses_mutex_;
   std::vector<intptr_t> closed_requests_;
   std::mutex closed_requests_mutex_;
 


### PR DESCRIPTION
…#215)

* Remove unused variables

* Pass InferPayload pointer as userp instead of shared_ptr