### PR TITLE
Link properly with dlclose and dlopen libraries

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -240,7 +240,7 @@ target_link_libraries(
     dlpack
     Threads::Threads
     triton-backend-utils          # from repo-backend
-    -ldl                          # dlopen
+    ${CMAKE_DL_LIBS}              # dlopen and dlclose
     -lrt                          # shared memory 
     triton-core-serverstub        # from repo-core
     ZLIB::ZLIB
@@ -253,6 +253,7 @@ target_link_libraries(
    dlpack
    Threads::Threads
    triton-backend-utils           # from repo-backend
+   ${CMAKE_DL_LIBS}               # dlopen and dlclose
    pybind11::embed
    -lrt                           # shared memory 
    -larchive                      # libarchive


### PR DESCRIPTION
Fixes the following:

```
[ 98%] Linking CXX executable triton_python_backend_stub
/usr/bin/cmake -E cmake_link_script CMakeFiles/triton-python-backend-stub.dir/link.txt --verbose=1
/usr/bin/c++ -O3 -DNDEBUG "CMakeFiles/triton-python-backend-stub.dir/src/pb_stub_utils.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/response_sender.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/pb_stub.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/pb_response_iterator.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/infer_response.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/infer_request.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/ipc_message.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/pb_string.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/pb_map.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/scoped_defer.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/pb_error.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/pb_log.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/pb_memory.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/pb_tensor.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/pb_utils.cc.o" "CMakeFiles/triton-python-backend-stub.dir/src/shm_manager.cc.o" -o triton_python_backend_stub  -Wl,-rpath,/usr/local/cuda/lib64:/opt/conda/lib: _deps/repo-backend-build/libtritonbackendutils.a -lrt -larchive -lpthread _deps/repo-common-build/libtritonasyncworkqueue.a -pthread /usr/local/cuda/lib64/libcudart.so _deps/repo-backend-build/libkernel_library_new.a /usr/local/cuda/lib64/libcudart.so /opt/conda/lib/libpython3.8.so 
/usr/bin/ld: CMakeFiles/triton-python-backend-stub.dir/src/pb_utils.cc.o: undefined reference to symbol 'dlclose@@GLIBC_2.2.5'
/usr/bin/ld: /lib/x86_64-linux-gnu/libdl.so.2: error adding symbols: DSO missing from command line
```