### PR TITLE
Fix L0_backend_python timeout issue

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -553,11 +553,11 @@ InferRequest::Exec(const bool is_decoupled)
 
   if (responses_is_set) {
     auto& memory_manager_message_queue = stub->MemoryManagerQueue();
-    std::unique_ptr<InferResponse> error_response =
+    std::unique_ptr<InferResponse> return_response =
         InferResponse::LoadFromSharedMemory(
             shm_pool, *response_handle, true /* open cuda handle */);
 
-    for (auto& output_tensor : error_response->OutputTensors()) {
+    for (auto& output_tensor : return_response->OutputTensors()) {
       if (!output_tensor->IsCPU()) {
         uint64_t memory_release_id = output_tensor->Memory()->MemoryReleaseId();
         output_tensor->Memory()->SetMemoryReleaseCallback(
@@ -567,7 +567,7 @@ InferRequest::Exec(const bool is_decoupled)
       }
     }
 
-    return error_response;
+    return return_response;
   } else {
     auto error_response = std::make_unique<InferResponse>(
         std::vector<std::shared_ptr<PbTensor>>{},

--- a/src/pb_response_iterator.cc
+++ b/src/pb_response_iterator.cc
@@ -144,19 +144,19 @@ ResponseIterator::Clear()
   is_cleared_ = true;
 }
 
-std::shared_ptr<InferResponse>
-ResponseIterator::Pop()
+std::vector<std::shared_ptr<InferResponse>>
+ResponseIterator::GetExistingResponses()
 {
+  std::vector<std::shared_ptr<InferResponse>> responses;
   std::unique_lock<std::mutex> lock{mu_};
-  if (!response_buffer_.empty()) {
-    auto response = response_buffer_.front();
+  while (!response_buffer_.empty()) {
+    responses.push_back(response_buffer_.front());
     response_buffer_.pop();
-    return response;
-  } else {
-    is_finished_ = true;
-    is_cleared_ = true;
-    throw py::stop_iteration("Iteration is done for the responses.");
   }
+  is_finished_ = true;
+  is_cleared_ = true;
+
+  return responses;
 }
 
 }}}  // namespace triton::backend::python

--- a/src/pb_response_iterator.h
+++ b/src/pb_response_iterator.h
@@ -38,9 +38,10 @@ class ResponseIterator {
 
   std::shared_ptr<InferResponse> Next();
   py::iterator Iter();
-  void EnqueueResponse(std::unique_ptr<InferResponse> infer_response);
+  void EnqueueResponse(std::shared_ptr<InferResponse> infer_response);
   void* Id();
   void Clear();
+  std::shared_ptr<InferResponse> Pop();
 
  private:
   std::vector<std::shared_ptr<InferResponse>> responses_;

--- a/src/pb_response_iterator.h
+++ b/src/pb_response_iterator.h
@@ -41,7 +41,7 @@ class ResponseIterator {
   void EnqueueResponse(std::shared_ptr<InferResponse> infer_response);
   void* Id();
   void Clear();
-  std::shared_ptr<InferResponse> Pop();
+  std::vector<std::shared_ptr<InferResponse>> GetExistingResponses();
 
  private:
   std::vector<std::shared_ptr<InferResponse>> responses_;

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -919,6 +919,7 @@ Stub::ServiceStubToParentRequests()
       } else {
         bls_response_cleanup_buffer_.pop();
         SendCleanupId(id);
+        std::lock_guard<std::mutex> lock(response_iterator_map_mu_);
         response_iterator_map_.erase(id);
       }
     }

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1132,17 +1132,12 @@ Stub::GetResponseIterator(std::shared_ptr<InferResponse> infer_response)
     // 'response_iterator_map_' to make sure the 'ResponseIterator' object has
     // the correct first response.
     auto response_iterator = std::make_shared<ResponseIterator>(infer_response);
-    bool done = false;
-    while (!done) {
-      try {
-        std::shared_ptr<InferResponse> next_response =
-            response_iterator_map_[infer_response->Id()]->Pop();
-        response_iterator->EnqueueResponse(next_response);
-      }
-      catch (const py::stop_iteration& exception) {
-        done = true;
-      }
+    std::vector<std::shared_ptr<InferResponse>> existing_responses =
+        response_iterator_map_[infer_response->Id()]->GetExistingResponses();
+    for (auto& response : existing_responses) {
+      response_iterator->EnqueueResponse(response);
     }
+
     response_iterator_map_[infer_response->Id()] = response_iterator;
   } else {
     auto response_iterator = std::make_shared<ResponseIterator>(infer_response);

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -246,9 +246,9 @@ class Stub {
   /// Thread process
   void ParentToStubMQMonitor();
 
-  /// Keep track of the ResponseIterator object
-  void SaveResponseIterator(
-      std::shared_ptr<ResponseIterator> response_iterator);
+  /// Get the ResponseIterator object associated with the infer response
+  std::shared_ptr<ResponseIterator> GetResponseIterator(
+      std::shared_ptr<InferResponse> infer_response);
 
   /// Send the id to the python backend for object cleanup
   void SendCleanupId(void* id);


### PR DESCRIPTION
When python backend sending BLS decoupled responses to the stub process, in some cases the stub process gets the following response before getting the first response, causing the `ResponseIterator` stop receiving the responses. For example, if a square model generates two responses, and the last response is placed before the actual first response, the `ResponseIterator` will think all the responses are fetched and stop receiving other responses.

This PR addresses the issue to make sure that the `ResponseIterator` object has the correct order of the first response.