### PR TITLE
Add healthiness check to avoid hanging during model initialization

### DIFF
--- a/src/python_be.h
+++ b/src/python_be.h
@@ -365,10 +365,10 @@ class ModelInstanceState : public BackendModelInstance {
   // Model instance stub
   std::unique_ptr<StubLauncher>& Stub() { return model_instance_stub_; }
 
-  // Stop the log monitor threads
+  // Stop the stub_to_parent_queue_monitor thread
   void TerminateMonitor();
 
-  // Start the log monitor threads
+  // Start the stub_to_parent_queue_monitor thread
   void StartMonitor();
 
   // Send bls decoupled response to the stub process

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -290,9 +290,6 @@ class ModelInstanceState : public BackendModelInstance {
   bool IsStubProcessAlive();
 
   // Get a message from the stub process
-  TRITONSERVER_Error* ReceiveMessageFromStub(off_t& message);
-
-  // Get a message from the stub process
   void SendMessageAndReceiveResponse(
       off_t message, off_t& response, bool& restart,
       std::shared_ptr<std::vector<TRITONBACKEND_Response*>>& responses,

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -145,6 +145,9 @@ class StubLauncher {
   // Kill stub process
   void KillStubProcess();
 
+  // Get a message from the stub process
+  TRITONSERVER_Error* ReceiveMessageFromStub(off_t& message);
+
  private:
   pid_t parent_pid_;
   pid_t stub_pid_;

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -146,7 +146,8 @@ class StubLauncher {
   void KillStubProcess();
 
   // Get a message from the stub process
-  TRITONSERVER_Error* ReceiveMessageFromStub(off_t& message);
+  TRITONSERVER_Error* ReceiveMessageFromStub(
+      bi::managed_external_buffer::handle_t& message);
 
  private:
   pid_t parent_pid_;


### PR DESCRIPTION
This PR adds healthiness check to fix the hanging issue when the stub process gets killed during function `initialize`.
Added test case: https://github.com/triton-inference-server/server/pull/5554
Fixes: https://github.com/triton-inference-server/server/issues/5381