### PR TITLE
Update dlpack implementation for PbTensor

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -89,7 +89,7 @@ FetchContent_MakeAvailable(pybind11)
 FetchContent_Declare(
   dlpack
   GIT_REPOSITORY "https://github.com/dmlc/dlpack"
-  GIT_TAG "v0.7"
+  GIT_TAG "v0.8"
   GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(dlpack)

--- a/README.md
+++ b/README.md
@@ -1223,7 +1223,7 @@ class TritonPythonModel:
     # tensor.
     input0 = pb_utils.Tensor.from_dlpack("INPUT0", to_dlpack(pytorch_tensor))
 ```
-Starting from 23.04 release, Python backend allows tensors implementing
+Python backend allows tensors implementing
 [`__dlpack__`](https://data-apis.org/array-api/2022.12/API_specification/generated/array_api.array.__dlpack__.html) 
 and [`__dlpack_device__`](https://data-apis.org/array-api/2022.12/API_specification/generated/array_api.array.__dlpack_device__.html) 
 [interface](https://dmlc.github.io/dlpack/latest/python_spec.html) 

--- a/README.md
+++ b/README.md
@@ -1223,6 +1223,15 @@ class TritonPythonModel:
     # tensor.
     input0 = pb_utils.Tensor.from_dlpack("INPUT0", to_dlpack(pytorch_tensor))
 ```
+Starting from 23.04 release, Python backend allows tensors implementing
+[`__dlpack__`](https://data-apis.org/array-api/2022.12/API_specification/generated/array_api.array.__dlpack__.html) 
+and [`__dlpack_device__`](https://data-apis.org/array-api/2022.12/API_specification/generated/array_api.array.__dlpack_device__.html) 
+[interface](https://dmlc.github.io/dlpack/latest/python_spec.html) 
+to be converted to Python backend tensors. For instance:
+
+```python
+input0 = pb_utils.Tensor.from_dlpack("INPUT0", pytorch_tensor)
+```
 
 This method only supports contiguous Tensors that are in C-order. If the tensor
 is not C-order contiguous an exception will be raised.

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1414,7 +1414,9 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
       .def("to_dlpack", &PbTensor::ToDLPack)
       .def("is_cpu", &PbTensor::IsCPU)
       .def("shape", &PbTensor::Dims)
-      .def("from_dlpack", &PbTensor::FromDLPack);
+      .def("from_dlpack", &PbTensor::FromDLPack)
+      .def("__dlpack__", &PbTensor::DLPack, py::arg("stream") = py::none())
+      .def("__dlpack_device__", &PbTensor::DLPackDevice);
 
   py::class_<InferResponse, std::shared_ptr<InferResponse>>(
       module, "InferenceResponse")

--- a/src/pb_stub_utils.cc
+++ b/src/pb_stub_utils.cc
@@ -189,8 +189,8 @@ triton_to_dlpack_type(TRITONSERVER_DataType triton_dtype)
   dl_dtype.lanes = 1;
   switch (triton_dtype) {
     case TRITONSERVER_TYPE_BOOL:
-      dl_code = DLDataTypeCode::kDLInt;
-      dt_size = 1;
+      dl_code = DLDataTypeCode::kDLBool;
+      dt_size = 8;
       break;
     case TRITONSERVER_TYPE_UINT8:
       dl_code = DLDataTypeCode::kDLUInt;
@@ -279,8 +279,6 @@ dlpack_to_triton_type(const DLDataType& data_type)
       return TRITONSERVER_TYPE_INT32;
     } else if (data_type.bits == 64) {
       return TRITONSERVER_TYPE_INT64;
-    } else if (data_type.bits == 1) {
-      return TRITONSERVER_TYPE_BOOL;
     }
   }
 
@@ -293,6 +291,12 @@ dlpack_to_triton_type(const DLDataType& data_type)
       return TRITONSERVER_TYPE_UINT32;
     } else if (data_type.bits == 64) {
       return TRITONSERVER_TYPE_UINT64;
+    }
+  }
+
+  if (data_type.code == DLDataTypeCode::kDLBool){
+    if (data_type.bits == 8){
+      return TRITONSERVER_TYPE_BOOL;
     }
   }
 

--- a/src/pb_stub_utils.cc
+++ b/src/pb_stub_utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -294,8 +294,8 @@ dlpack_to_triton_type(const DLDataType& data_type)
     }
   }
 
-  if (data_type.code == DLDataTypeCode::kDLBool){
-    if (data_type.bits == 8){
+  if (data_type.code == DLDataTypeCode::kDLBool) {
+    if (data_type.bits == 8) {
       return TRITONSERVER_TYPE_BOOL;
     }
   }

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -338,79 +338,76 @@ PbTensor::FromDLPack(const std::string& name, const py::object& tensor)
   }
   if (py::isinstance<py::capsule>(tensor)) {
     return FromDLPackCapsule(name, tensor);
-  } else if (py::hasattr(tensor, "__dlpack__")) {
-    // Array API requirements for the stream argument:
-    // stream = None, producer must assume the legacy default stream,
-    // stream = -1 is a signal for the producer not to perform any
-    //          synchronization
-    // stream = 1 the legacy default stream (in this case should synchronize
-    //          on CUDA stream 0)
-    // Python backend does not support async executions on PbTensor objects,
-    // thus we can count on the default `stream=None` argument.
-    // For CPU, `stream=None` is the only accepted argument
-    // according to array API. For GPU, when `stream=None`  producer must
-    // assume the legacy default stream.
-    // Reference:
-    // https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html
-    if (py::hasattr(tensor, "__dlpack_device__")) {
-      std::pair<int32_t, int64_t> capsule_device_info =
-          tensor.attr("__dlpack_device__")()
-              .cast<std::pair<int32_t, int64_t>>();
-      if (capsule_device_info.first == DLDeviceType::kDLCUDA) {
+  }
+
+  if (!py::hasattr(tensor, "__dlpack__") ||
+      !py::hasattr(tensor, "__dlpack_device__")) {
+    throw PythonBackendException(
+        "Provided tensor is not supported. Tensor must be a DLPack capsule \
+        or have `__dlpack__` and `__dlpack_device__` attributes");
+  }
+
+  auto capsule_device_info =
+      tensor.attr("__dlpack_device__")().cast<std::pair<int32_t, int64_t>>();
+  if (capsule_device_info.first == DLDeviceType::kDLCUDA) {
 #ifdef TRITON_ENABLE_GPU
-        auto current_device = 0;
-        cudaError_t err = cudaGetDevice(&current_device);
-        if (err == cudaSuccess) {
-          err = (current_device == capsule_device_info.second)
-                    ? cudaSetDevice(capsule_device_info.second)
-                    : cudaSuccess;
-          if (err == cudaSuccess) {
-            // In case there is a pending job on the data, where this capsule
-            // is pointing to, we need to wait ffor it before consuming.
-            // This is important for when data is located in different
-            // context (GPU) or work is done on a non-blocking stream
-            err = cudaDeviceSynchronize();
-            auto ptr_to_pbtensor = FromDLPackCapsule(
-                name,
-                tensor.attr("__dlpack__")(py::arg("stream") = py::int_(1)));
-            err = (current_device == capsule_device_info.second)
-                      ? cudaSetDevice(current_device)
-                      : cudaSuccess;
-            if (err == cudaSuccess) {
-              return ptr_to_pbtensor;
-            } else {
-              throw PythonBackendException(
-                  "Failed to set CUDA device back to initial compute device "
-                  "with id " +
-                  std::to_string(current_device));
-            }
-          } else {
-            throw PythonBackendException(
-                "Failed to set CUDA device to device with id " +
-                std::to_string(capsule_device_info.second));
-          }
-        } else {
-          throw PythonBackendException("Failed to get current CUDA device id.");
-        }
+    int current_device;
+    cudaError_t err = cudaGetDevice(&current_device);
+    if (err != cudaSuccess) {
+      throw PythonBackendException("Failed to get current CUDA device id.");
+    }
+
+    bool overridden = (current_device != capsule_device_info.second);
+    err = overridden ? cudaSetDevice(capsule_device_info.second) : cudaSuccess;
+    if (err != cudaSuccess) {
+      throw PythonBackendException(
+          "Failed to set CUDA device to device with id " +
+          std::to_string(capsule_device_info.second));
+    }
+    // In case there is a pending job on the data, where this capsule
+    // is pointing to, we need to wait for it before consuming.
+    // This is important for when data is located in different
+    // context (GPU) or work is done on non-blocking streams.
+    err = cudaDeviceSynchronize();
+    if (err != cudaSuccess) {
+      throw PythonBackendException(
+          "Failed to synchronize CUDA device with id " +
+          std::to_string(
+              overridden ? capsule_device_info.second : current_device));
+    }
+
+    // Array API requirements for the stream argument:
+    // stream = 1 the legacy default stream (in this case should
+    // synchronize on CUDA stream 0)
+    // For CPU, `stream=None` is the only accepted argument
+    // according to array API. For GPU, when `stream=None`  producer
+    // must assume the legacy default stream. Reference:
+    // https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html
+    auto ptr_to_tensor = FromDLPackCapsule(
+        name, tensor.attr("__dlpack__")(py::arg("stream") = py::int_(1)));
+
+    err = overridden ? cudaSetDevice(current_device) : cudaSuccess;
+    if (err != cudaSuccess) {
+      throw PythonBackendException(
+          "Failed to set CUDA device back to initial compute device "
+          "with id " +
+          std::to_string(current_device));
+    }
+    return ptr_to_tensor;
 #else
-        throw PythonBackendException(
-            "DLPack capsule passed pointer to memory allocated on GPU device, \
+    throw PythonBackendException(
+        "DLPack capsule passed pointer to memory allocated on GPU device, \
           when GPU is not available");
 #endif
-      } else {
-        return FromDLPackCapsule(
-            name, tensor.attr("__dlpack__")(py::arg("stream") = py::none()));
-      }
-    } else {
-      throw PythonBackendException(
-          "Provided tensor is not supported.\
-      Tensor must be a DLPack capsule or have a `__dlpack_device__` attribute");
-    }
-  } else {
-    throw PythonBackendException(
-        "Provided tensor is not supported.\
-      Tensor must be a DLPack capsule or have a `__dlpack__` attribute");
   }
+
+  // If data is located on CPU, `stream=None` is the only accepted argument
+  // according to array API. For GPU, when `stream=None`  producer must
+  // assume the legacy default stream.
+  // Reference:
+  // https://data-apis.org/array-api/latest/API_specification/generated/array_api.array.__dlpack__.html
+  return FromDLPackCapsule(
+      name, tensor.attr("__dlpack__")(py::arg("stream") = py::none()));
 }
 
 std::shared_ptr<PbTensor>

--- a/src/pb_tensor.h
+++ b/src/pb_tensor.h
@@ -114,9 +114,11 @@ class PbTensor {
 #ifdef TRITON_PB_STUB
   /// Construct a Python backend tensor using a DLPack
   /// capsule.
+  static std::shared_ptr<PbTensor> FromDLPack(
+      const std::string& name, const py::object& dlpack);
   /// \param dlpack source dlpack tensor
   /// \param name name of the tensor
-  static std::shared_ptr<PbTensor> FromDLPack(
+  static std::shared_ptr<PbTensor> FromDLPackCapsule(
       const std::string& name, const py::capsule& dlpack);
 
   /// Construct a Python backend tensor using a NumPy object.
@@ -125,9 +127,14 @@ class PbTensor {
   static std::shared_ptr<PbTensor> FromNumpy(
       const std::string& name, py::array& numpy_array);
 
+  
+  
+  DLDeviceType DeviceType();
+  py::capsule DLPack(const py::object& stream);
   /// Get a PyCapsule object containing the DLPack representation of the tensor.
   /// \return Capsule object containing pointer to a DLPack object.
   py::capsule ToDLPack();
+  std::pair<int32_t, int64_t> DLPackDevice();
 #endif
 
   /// Get the name of the tensor

--- a/src/pb_tensor.h
+++ b/src/pb_tensor.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -112,12 +112,15 @@ class PbTensor {
   DISALLOW_COPY_AND_ASSIGN(PbTensor);
 
 #ifdef TRITON_PB_STUB
-  /// Construct a Python backend tensor using a DLPack
-  /// capsule.
-  static std::shared_ptr<PbTensor> FromDLPack(
-      const std::string& name, const py::object& dlpack);
+  /// Construct a Python backend tensor from an
+  /// external tensor.
   /// \param dlpack source dlpack tensor
   /// \param name name of the tensor
+  static std::shared_ptr<PbTensor> FromDLPack(
+      const std::string& name, const py::object& dlpack);
+
+  /// Construct a Python backend tensor using a DLPack
+  /// capsule.
   static std::shared_ptr<PbTensor> FromDLPackCapsule(
       const std::string& name, const py::capsule& dlpack);
 
@@ -127,13 +130,22 @@ class PbTensor {
   static std::shared_ptr<PbTensor> FromNumpy(
       const std::string& name, py::array& numpy_array);
 
-  
-  
+  /// Get device type in DLPack format.
   DLDeviceType DeviceType();
+
+  /// Exports tensor for consumption by `from_dlpack()` as a DLPack capsule.
+  /// \param stream  a Python integer representing a pointer to a stream,
+  ///                on devices that support streams
+  /// \return Capsule object containing pointer to a DLPack object.
   py::capsule DLPack(const py::object& stream);
+
   /// Get a PyCapsule object containing the DLPack representation of the tensor.
   /// \return Capsule object containing pointer to a DLPack object.
   py::capsule ToDLPack();
+
+  /// Returns device type and device ID.
+  /// Meant for use within `from_dlpack()`.
+  /// \return a pair (device_type, device_id).
   std::pair<int32_t, int64_t> DLPackDevice();
 #endif
 


### PR DESCRIPTION
This PR updates DLPack implementation for PbTensor according to Array API and DLPack v0.8 requirements.

Major changes:
 - Added `__dlpack__` and `__dlpack_device__` implementations according to Array API standard
   + [Python Specification for DLPack](https://dmlc.github.io/dlpack/latest/python_spec.html#python-specification-for-dlpack)
   + [Array API specification] (https://data-apis.org/array-api/latest/API_specification/index.html)
 -  Current implementation is backward-compatible, i.e. `PbTensor.from_dlpack()` accepts PyCapsule (as before) and external tensor directly. `PbTensor::FromDLPack` takes care of that. Former `PbTensor::FromDLPack` -> `PbTensor::FromDLPackCapsule`
 -  `PbTensor::DLPack`, which is bind to `__dlpack__(self, Optional[Union[int, Any]] stream)` make sure to synchronize streams, if needed (passed stream is not a default stream, not -1, and not a legacy stream). Since PbTensor does not support async execution, if `DLPack` receives default stream, sync is not needed.
 - I've implemented some refactoring, i.e. separated `switch` into `PbTensor::DeviceType`, because I realized I need this for `DLPackDevice` 
 - `DLPackDevice` has returned type `std::pair<int32_t, int64_t>` with the following in mind. [This](https://github.com/pybind/pybind11/issues/3858) isn't finished yet. When it is done, a more elegant type description can be put instead. For now I used types, which are indicated in the code. Open to any suggestions/alternatives
 - Added bool support

Fixes issue: [3944](https://github.com/triton-inference-server/server/issues/3944)