### PR TITLE
[WIP] updated inferentia build

### DIFF
--- a/inferentia/scripts/setup-pre-container.sh
+++ b/inferentia/scripts/setup-pre-container.sh
@@ -39,6 +39,6 @@ sudo wget -qO - https://apt.repos.neuron.amazonaws.com/GPG-PUB-KEY-AMAZON-AWS-NE
 sudo apt-get update &&          \
     sudo apt-get install -y        \
         linux-headers-$(uname -r)  \
-        aws-neuron-dkms            \
-        aws-neuron-tools
+        aws-neuronx-dkms            \
+        aws-neuronx-tools
 

--- a/inferentia/scripts/setup.sh
+++ b/inferentia/scripts/setup.sh
@@ -153,23 +153,36 @@ make triton-python-backend-stub -j16
 pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
 conda config --env --add channels https://conda.repos.neuron.amazonaws.com
 
+# Install Python and Python venv 
+add-apt-repository ppa:deadsnakes/ppa
+apt-get install python3.7
+apt-get install -y python3.7-venv g++ 
+# Create Python venv
+python3.7 -m venv aws_neuron_venv
+# Activate Python venv 
+source aws_neuron_venv/bin/activate 
+python -m pip install -U pip
+# Set pip repository pointing to the Neuron repository 
+python -m pip config set global.extra-index-url https://pip.repos.neuron.amazonaws.com
 if [ $USE_TENSORFLOW -eq 1 ]; then
-    conda install tensorflow-neuron pillow -y
-    # Update Neuron TensorBoard
-    pip install --upgrade tensorboard-plugin-neuron
     # Update Neuron TensorFlow
     if [ $TENSORFLOW_VERSION -eq 1 ]; then
-        pip install --upgrade tensorflow-neuron==1.15.5.* neuron-cc "protobuf<4"
+        # Install TensorFlow Neuron
+        python -m pip install tensorflow-neuron[cc]==1.15.5.* "protobuf"
+        # Install Tensorflow Neuron model server
+        apt-get install tensorflow-model-server-neuronx=1.15.0.2.6.5.0 -y
     else
-        pip install --upgrade tensorflow-neuron[cc] "protobuf<4"
+        # Install TensorFlow Neuron
+        python -m pip install tensorflow-neuron[cc] "protobuf"
+        Install Tensorflow Neuron model server
+        apt-get install tensorflow-model-server-neuronx=2.10.1.2.6.5.0 -y
     fi
 fi
 
 if [ $USE_PYTORCH -eq 1 ]
 then
-    conda install torch-neuron torchvision -y
-    # Upgrade torch-neuron and install transformers
-    pip install --upgrade torch-neuron neuron-cc[tensorflow] "protobuf<4" torchvision "transformers==4.6.0"
+    # Install PyTorch Neuron
+    python -m pip install torch-neuron neuron-cc[tensorflow] "protobuf" torchvision
 fi
 
 # Upgrade the python backend stub, rules and sockets

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -164,8 +164,8 @@ def get_output_tensor_by_name(inference_response, name):
             return output_tensor
 
     return None
-
-
+    
+    
 def get_input_config_by_name(model_config, name):
     """Get input properties corresponding to the input
     with given `name`


### PR DESCRIPTION
Addresses [5520](https://github.com/triton-inference-server/server/issues/5520)
1. Update setup to use inf1 with `neuronx-dkms` and `aws-neuronx-tools`
2. Update build process to use python venv instead of conda using [neuron build instructions(https://awsdocs-neuron.readthedocs-hosted.com/en/latest/frameworks/torch/torch-neuron/setup/prev-releases/neuron-2.5.0-pytorch-install.html?highlight=aws-neuronx-dkms)

Todo:
1. Update tutorial to use latest Deeplearning machine (pytorch neuron 20.04 Ubuntu).
2. Figure if we can update to latest version of neuron sdk
3. Figure if we should change to inf2, or add inf2 build to our process
4. Run tests manually and make sure they work
