### PR TITLE
Add configuration for BLS to choose the device of output tensors

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -158,6 +158,7 @@ set(
   src/shm_manager.cc
   src/shm_manager.h
   src/pb_exception.h
+  src/pb_preferred_memory.h
 )
 
 set(

--- a/README.md
+++ b/README.md
@@ -892,12 +892,16 @@ class TritonPythonModel:
           inputs=[<pb_utils.Tensor object>])
 
       # `pb_utils.InferenceRequest` supports request_id, correlation_id,
-      # model version and timeout in addition to the arguments described above.
+      # model version timeout and  preferred_memory in addition to the
+      # arguments described above.
       # These arguments are optional. An example containing all the arguments:
       # inference_request = pb_utils.InferenceRequest(model_name='model_name',
       #   requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
       #   inputs=[<list of pb_utils.Tensor objects>],
-      #   request_id="1", correlation_id=4, model_version=1, flags=0, timeout=5)
+      #   request_id="1", correlation_id=4, model_version=1, flags=0, timeout=5,
+      #   preferred_memory=pb_utils.PreferredMemory(
+      #     pb_utils.PreferredMemory.GPU, # or pb_utils.PreferredMemory.CPU
+      #     0))
 
       # Execute the inference_request and wait for the response
       inference_response = inference_request.exec()
@@ -986,11 +990,22 @@ inference responses returned by a decoupled model. If the `decoupled` parameter
 is set to `False`, the `exec` and `async_exec` function will return a single
 response as shown in the example above.
 
-Besides, you can set the timeout via the parameter 'timeout' in microseconds
-within the constructor of `InferenceRequest`. If the request times out, the
-request will respond with an error. The default of 'timeout' is 0 which
-indicates that the request has no timeout. Example below shows how to use this
-feature:
+Additionally, starting from the 23.04 release, you have the flexibility to
+select a specific device to receive output tensors from BLS calls. This
+can be achieved by setting the optional `preferred_memory` parameter within the
+`InferenceRequest` constructor. To do this, you can create a `PreferredMemory`
+object and specify the `preferred_memory_type` as either `PreferredMemory.GPU`
+or `PreferredMemory.CPU`, as well as the `preferred_device_id` as an integer to
+indicate the memory type and device ID on which you wish to receive output
+tensors. In the event that the `preferred_memory_type` is set to
+`PreferredMemory.GPU` but the device with the specified `preferred_device_id`
+is unavailable for output allocation, the Python backend will attempt to
+allocate output tensors on other available devices and only return an error if
+none of the devices are available. If you do not specify the `preferred_memory`
+parameter, the output tensors will be allocated on the same device where the
+output tensors were received from the model to which the BLS call is made.
+
+Example below shows how to use this feature:
 
 ```python
 import triton_python_backend_utils as pb_utils
@@ -1011,12 +1026,16 @@ class TritonPythonModel:
           inputs=[<pb_utils.Tensor object>])
 
       # `pb_utils.InferenceRequest` supports request_id, correlation_id,
-      # model version and timeout in addition to the arguments described above.
+      # model version timeout and  preferred_memory in addition to the
+      # arguments described above.
       # These arguments are optional. An example containing all the arguments:
       # inference_request = pb_utils.InferenceRequest(model_name='model_name',
       #   requested_output_names=['REQUESTED_OUTPUT_1', 'REQUESTED_OUTPUT_2'],
       #   inputs=[<list of pb_utils.Tensor objects>],
-      #   request_id="1", correlation_id=4, model_version=1, flags=0, timeout=5)
+      #   request_id="1", correlation_id=4, model_version=1, flags=0, timeout=5,
+      #   preferred_memory=pb_utils.PreferredMemory(
+      #     pb_utils.PreferredMemory.GPU, # or pb_utils.PreferredMemory.CPU
+      #     0))
 
       # Execute the inference_request and wait for the response. Here we are
       # running a BLS request on a decoupled model, hence setting the parameter

--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@ class TritonPythonModel:
       #   inputs=[<list of pb_utils.Tensor objects>],
       #   request_id="1", correlation_id=4, model_version=1, flags=0, timeout=5,
       #   preferred_memory=pb_utils.PreferredMemory(
-      #     pb_utils.GPU, # or pb_utils.CPU
+      #     pb_utils.TRITONSERVER_MEMORY_GPU, # or pb_utils.TRITONSERVER_MEMORY_CPU
       #     0))
 
       # Execute the inference_request and wait for the response
@@ -998,10 +998,11 @@ Additionally, starting from the 23.04 release, you have the flexibility to
 select a specific device to receive output tensors from BLS calls. This
 can be achieved by setting the optional `preferred_memory` parameter within the
 `InferenceRequest` constructor. To do this, you can create a `PreferredMemory`
-object and specify the `preferred_memory_type` as either `GPU` or `CPU`, as
-well as the `preferred_device_id` as an integer to indicate the memory type and
-device ID on which you wish to receive output tensors. If you do not specify
-the `preferred_memory` parameter, the output tensors will be allocated on the
+object and specify the `preferred_memory_type` as either
+`TRITONSERVER_MEMORY_GPU` or `TRITONSERVER_MEMORY_CPU`, as well as the
+`preferred_device_id` as an integer to indicate the memory type and device ID
+on which you wish to receive output tensors. If you do not specify the
+`preferred_memory` parameter, the output tensors will be allocated on the
 same device where the output tensors were received from the model to which the
 BLS call is made.
 
@@ -1034,7 +1035,7 @@ class TritonPythonModel:
       #   inputs=[<list of pb_utils.Tensor objects>],
       #   request_id="1", correlation_id=4, model_version=1, flags=0, timeout=5,
       #   preferred_memory=pb_utils.PreferredMemory(
-      #     pb_utils.GPU, # or pb_utils.CPU
+      #     pb_utils.TRITONSERVER_MEMORY_GPU, # or pb_utils.TRITONSERVER_MEMORY_CPU
       #     0))
 
       # Execute the inference_request and wait for the response. Here we are

--- a/README.md
+++ b/README.md
@@ -892,7 +892,7 @@ class TritonPythonModel:
           inputs=[<pb_utils.Tensor object>])
 
       # `pb_utils.InferenceRequest` supports request_id, correlation_id,
-      # model version timeout and  preferred_memory in addition to the
+      # model version, timeout and preferred_memory in addition to the
       # arguments described above.
       # These arguments are optional. An example containing all the arguments:
       # inference_request = pb_utils.InferenceRequest(model_name='model_name',
@@ -988,7 +988,11 @@ models in both [default mode](#default-mode) and
 [iterator](https://docs.python.org/3/glossary.html#term-iterator) of
 inference responses returned by a decoupled model. If the `decoupled` parameter
 is set to `False`, the `exec` and `async_exec` function will return a single
-response as shown in the example above.
+response as shown in the example above. Besides, you can set the timeout via
+the parameter 'timeout' in microseconds within the constructor of
+`InferenceRequest`. If the request times out, the request will respond with an
+error. The default of 'timeout' is 0 which indicates that the request has no
+timeout.
 
 Additionally, starting from the 23.04 release, you have the flexibility to
 select a specific device to receive output tensors from BLS calls. This
@@ -996,7 +1000,10 @@ can be achieved by setting the optional `preferred_memory` parameter within the
 `InferenceRequest` constructor. To do this, you can create a `PreferredMemory`
 object and specify the `preferred_memory_type` as either `GPU` or `CPU`, as
 well as the `preferred_device_id` as an integer to indicate the memory type and
-device ID on which you wish to receive output tensors.
+device ID on which you wish to receive output tensors. If you do not specify
+the `preferred_memory` parameter, the output tensors will be allocated on the
+same device where the output tensors were received from the model to which the
+BLS call is made.
 
 Example below shows how to use this feature:
 
@@ -1019,7 +1026,7 @@ class TritonPythonModel:
           inputs=[<pb_utils.Tensor object>])
 
       # `pb_utils.InferenceRequest` supports request_id, correlation_id,
-      # model version timeout and  preferred_memory in addition to the
+      # model version, timeout and preferred_memory in addition to the
       # arguments described above.
       # These arguments are optional. An example containing all the arguments:
       # inference_request = pb_utils.InferenceRequest(model_name='model_name',

--- a/README.md
+++ b/README.md
@@ -900,7 +900,7 @@ class TritonPythonModel:
       #   inputs=[<list of pb_utils.Tensor objects>],
       #   request_id="1", correlation_id=4, model_version=1, flags=0, timeout=5,
       #   preferred_memory=pb_utils.PreferredMemory(
-      #     pb_utils.PreferredMemory.GPU, # or pb_utils.PreferredMemory.CPU
+      #     pb_utils.GPU, # or pb_utils.CPU
       #     0))
 
       # Execute the inference_request and wait for the response
@@ -994,16 +994,9 @@ Additionally, starting from the 23.04 release, you have the flexibility to
 select a specific device to receive output tensors from BLS calls. This
 can be achieved by setting the optional `preferred_memory` parameter within the
 `InferenceRequest` constructor. To do this, you can create a `PreferredMemory`
-object and specify the `preferred_memory_type` as either `PreferredMemory.GPU`
-or `PreferredMemory.CPU`, as well as the `preferred_device_id` as an integer to
-indicate the memory type and device ID on which you wish to receive output
-tensors. In the event that the `preferred_memory_type` is set to
-`PreferredMemory.GPU` but the device with the specified `preferred_device_id`
-is unavailable for output allocation, the Python backend will attempt to
-allocate output tensors on other available devices and only return an error if
-none of the devices are available. If you do not specify the `preferred_memory`
-parameter, the output tensors will be allocated on the same device where the
-output tensors were received from the model to which the BLS call is made.
+object and specify the `preferred_memory_type` as either `GPU` or `CPU`, as
+well as the `preferred_device_id` as an integer to indicate the memory type and
+device ID on which you wish to receive output tensors.
 
 Example below shows how to use this feature:
 
@@ -1034,7 +1027,7 @@ class TritonPythonModel:
       #   inputs=[<list of pb_utils.Tensor objects>],
       #   request_id="1", correlation_id=4, model_version=1, flags=0, timeout=5,
       #   preferred_memory=pb_utils.PreferredMemory(
-      #     pb_utils.PreferredMemory.GPU, # or pb_utils.PreferredMemory.CPU
+      #     pb_utils.GPU, # or pb_utils.CPU
       #     0))
 
       # Execute the inference_request and wait for the response. Here we are

--- a/src/infer_payload.cc
+++ b/src/infer_payload.cc
@@ -75,4 +75,18 @@ InferPayload::Callback(std::unique_ptr<InferResponse> infer_response)
   return callback_(std::move(infer_response));
 }
 
+void
+InferPayload::SetResponseAllocUserp(
+    const ResponseAllocatorUserp& response_alloc_userp)
+{
+  response_alloc_userp_ =
+      std::make_shared<ResponseAllocatorUserp>(response_alloc_userp);
+}
+
+std::shared_ptr<ResponseAllocatorUserp>
+InferPayload::ResponseAllocUserp()
+{
+  return response_alloc_userp_;
+}
+
 }}}  // namespace triton::backend::python

--- a/src/infer_payload.h
+++ b/src/infer_payload.h
@@ -29,8 +29,19 @@
 #include <functional>
 #include <queue>
 #include "infer_response.h"
+#include "pb_preferred_memory.h"
 
 namespace triton { namespace backend { namespace python {
+
+struct ResponseAllocatorUserp {
+  ResponseAllocatorUserp(
+      void* shm_pool, const PreferredMemory& preferred_memory)
+      : shm_pool(shm_pool), preferred_memory(preferred_memory)
+  {
+  }
+  void* shm_pool;
+  PreferredMemory preferred_memory;
+};
 
 class InferPayload {
  public:
@@ -44,12 +55,16 @@ class InferPayload {
   bool IsDecoupled();
   bool IsPromiseSet();
   void Callback(std::unique_ptr<InferResponse> infer_response);
+  void SetResponseAllocUserp(
+      const ResponseAllocatorUserp& response_alloc_userp);
+  std::shared_ptr<ResponseAllocatorUserp> ResponseAllocUserp();
 
  private:
   std::unique_ptr<std::promise<std::unique_ptr<InferResponse>>> prev_promise_;
   bool is_decoupled_;
   bool is_promise_set_;
   std::function<void(std::unique_ptr<InferResponse>)> callback_;
+  std::shared_ptr<ResponseAllocatorUserp> response_alloc_userp_;
 };
 
 }}}  // namespace triton::backend::python

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -42,12 +42,13 @@ InferRequest::InferRequest(
     const std::set<std::string>& requested_output_names,
     const std::string& model_name, const int64_t model_version,
     const std::string& parameters, const uint32_t flags, const int32_t timeout,
-    const intptr_t response_factory_address, const intptr_t request_address)
+    const intptr_t response_factory_address, const intptr_t request_address,
+    const PreferredMemory& preferred_memory)
     : request_id_(request_id), correlation_id_(correlation_id), inputs_(inputs),
       requested_output_names_(requested_output_names), model_name_(model_name),
       model_version_(model_version), parameters_(parameters), flags_(flags),
       timeout_(timeout), response_factory_address_(response_factory_address),
-      request_address_(request_address)
+      request_address_(request_address), preferred_memory_(preferred_memory)
 {
   for (auto& input : inputs) {
     if (!input) {
@@ -158,6 +159,12 @@ InferRequest::IsDecoupled()
   return is_decoupled_;
 }
 
+PreferredMemory&
+InferRequest::GetPreferredMemory()
+{
+  return preferred_memory_;
+}
+
 void
 InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {
@@ -182,6 +189,7 @@ InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
   infer_request_shm_ptr_->response_factory_address = response_factory_address_;
   infer_request_shm_ptr_->is_decoupled = is_decoupled_;
   infer_request_shm_ptr_->timeout = timeout_;
+  infer_request_shm_ptr_->preferred_memory = preferred_memory_;
 
   output_names_handle_shm_ptr_ =
       reinterpret_cast<bi::managed_external_buffer::handle_t*>(
@@ -358,6 +366,7 @@ InferRequest::InferRequest(
   response_factory_address_ = infer_request_shm_ptr_->response_factory_address;
   is_decoupled_ = infer_request_shm_ptr_->is_decoupled;
   timeout_ = infer_request_shm_ptr_->timeout;
+  preferred_memory_ = infer_request_shm_ptr_->preferred_memory;
 
 #ifdef TRITON_PB_STUB
   response_sender_ = std::make_shared<ResponseSender>(

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -29,6 +29,7 @@
 #include <future>
 #include <string>
 #include "infer_response.h"
+#include "pb_preferred_memory.h"
 #include "pb_tensor.h"
 
 #ifdef TRITON_PB_STUB
@@ -52,6 +53,7 @@ struct InferRequestShm {
   intptr_t response_factory_address;
   bool is_decoupled;
   int32_t timeout;
+  PreferredMemory preferred_memory;
 };
 
 class InferRequest {
@@ -63,7 +65,9 @@ class InferRequest {
       const std::string& model_name, const int64_t model_version,
       const std::string& parameters, const uint32_t flags = 0,
       const int32_t timeout = 0, const intptr_t response_factory_address = 0,
-      const intptr_t request_address = 0);
+      const intptr_t request_address = 0,
+      const PreferredMemory& preferred_memory =
+          PreferredMemory(PreferredMemory::DEFAULT, 0));
 
   const std::vector<std::shared_ptr<PbTensor>>& Inputs();
   const std::string& RequestId();
@@ -78,6 +82,7 @@ class InferRequest {
   int32_t Timeout();
   bool IsDecoupled();
   void SetIsDecoupled(const bool is_decoupled);
+  PreferredMemory& GetPreferredMemory();
 
 #ifdef TRITON_PB_STUB
   std::shared_ptr<InferResponse> Exec(const bool is_decoupled);
@@ -132,6 +137,7 @@ class InferRequest {
   intptr_t response_factory_address_;
   intptr_t request_address_;
   bool is_decoupled_;
+  PreferredMemory preferred_memory_;
 
   // Shared Memory Data Structures
   AllocatedSharedMemory<char> infer_request_shm_;

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -422,8 +422,12 @@ Stub::StubSetup()
   py::setattr(
       python_backend_utils, "PreferredMemory",
       c_python_backend_utils.attr("PreferredMemory"));
-  py::setattr(python_backend_utils, "GPU", c_python_backend_utils.attr("GPU"));
-  py::setattr(python_backend_utils, "CPU", c_python_backend_utils.attr("CPU"));
+  py::setattr(
+      python_backend_utils, "TRITONSERVER_MEMORY_GPU",
+      c_python_backend_utils.attr("TRITONSERVER_MEMORY_GPU"));
+  py::setattr(
+      python_backend_utils, "TRITONSERVER_MEMORY_CPU",
+      c_python_backend_utils.attr("TRITONSERVER_MEMORY_CPU"));
 
   c_python_backend_utils.attr("shared_memory") = py::cast(shm_pool_.get());
 
@@ -1300,8 +1304,8 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
           py::arg("preferred_device_id").none(false) = 0);
 
   py::enum_<PreferredMemory::MemoryType>(module, "MemoryType")
-      .value("GPU", PreferredMemory::MemoryType::GPU)
-      .value("CPU", PreferredMemory::MemoryType::CPU)
+      .value("TRITONSERVER_MEMORY_GPU", PreferredMemory::MemoryType::GPU)
+      .value("TRITONSERVER_MEMORY_CPU", PreferredMemory::MemoryType::CPU)
       .export_values();
 
   py::class_<InferRequest, std::shared_ptr<InferRequest>>(

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -422,6 +422,8 @@ Stub::StubSetup()
   py::setattr(
       python_backend_utils, "PreferredMemory",
       c_python_backend_utils.attr("PreferredMemory"));
+  py::setattr(python_backend_utils, "GPU", c_python_backend_utils.attr("GPU"));
+  py::setattr(python_backend_utils, "CPU", c_python_backend_utils.attr("CPU"));
 
   c_python_backend_utils.attr("shared_memory") = py::cast(shm_pool_.get());
 
@@ -1290,13 +1292,14 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
       .def(py::init<std::string>())
       .def("message", &PbError::Message);
 
-  py::class_<PreferredMemory, std::shared_ptr<PreferredMemory>>
-      preferred_memory(module, "PreferredMemory");
-  preferred_memory.def(
-      py::init<const PreferredMemory::MemoryType&, const int64_t&>(),
-      py::arg("preferred_memory_type").none(false),
-      py::arg("preferred_device_id").none(false) = 0);
-  py::enum_<PreferredMemory::MemoryType>(preferred_memory, "MemoryType")
+  py::class_<PreferredMemory, std::shared_ptr<PreferredMemory>>(
+      module, "PreferredMemory")
+      .def(
+          py::init<const PreferredMemory::MemoryType&, const int64_t&>(),
+          py::arg("preferred_memory_type").none(false),
+          py::arg("preferred_device_id").none(false) = 0);
+
+  py::enum_<PreferredMemory::MemoryType>(module, "MemoryType")
       .value("GPU", PreferredMemory::MemoryType::GPU)
       .value("CPU", PreferredMemory::MemoryType::CPU)
       .export_values();

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -222,7 +222,7 @@ ResponseAlloc(
     void** buffer_userp, TRITONSERVER_MemoryType* actual_memory_type,
     int64_t* actual_memory_type_id)
 {
-  auto p = reinterpret_cast<RequestExecutor::ResponseAllocatorUserp*>(userp);
+  auto p = reinterpret_cast<ResponseAllocatorUserp*>(userp);
   std::unique_ptr<SharedMemoryManager> shm_pool(
       reinterpret_cast<SharedMemoryManager*>(p->shm_pool));
 
@@ -423,10 +423,11 @@ RequestExecutor::Infer(
 
       ResponseAllocatorUserp response_allocator_userp(
           shm_pool_.get(), infer_request->GetPreferredMemory());
+      infer_payload->SetResponseAllocUserp(response_allocator_userp);
 
       THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetResponseCallback(
           irequest, response_allocator_,
-          reinterpret_cast<void*>(&response_allocator_userp),
+          reinterpret_cast<void*>(infer_payload->ResponseAllocUserp().get()),
           InferResponseComplete, reinterpret_cast<void*>(infer_payload.get())));
 
       THROW_IF_TRITON_ERROR(TRITONSERVER_ServerInferAsync(

--- a/src/request_executor.h
+++ b/src/request_executor.h
@@ -30,7 +30,6 @@
 #include "infer_payload.h"
 #include "infer_request.h"
 #include "infer_response.h"
-#include "pb_preferred_memory.h"
 
 namespace triton { namespace backend { namespace python {
 
@@ -52,15 +51,5 @@ class RequestExecutor {
       TRITONSERVER_Server* server);
 
   ~RequestExecutor();
-
-  struct ResponseAllocatorUserp {
-    ResponseAllocatorUserp(
-        void* shm_pool, const PreferredMemory& preferred_memory)
-        : shm_pool(shm_pool), preferred_memory(preferred_memory)
-    {
-    }
-    void* shm_pool;
-    PreferredMemory preferred_memory;
-  };
 };
 }}}  // namespace triton::backend::python


### PR DESCRIPTION
This PR adds a new configuration to explicitly choose a device for receiving output tensors from BLS calls. The preferred memory can be set within the constructor of `InferenceRequest` with a new objcect `PreferredMemory` using parameters `preferred_memory_type` and `preferred_device_id`.

Added testing: https://github.com/triton-inference-server/server/pull/5580