### PR TITLE
Add TF determinism section, fix TF32 typo, remove PyTorch 2.0 note

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ any C++ code.
   - [Input Tensor Device Placement](#input-tensor-device-placement)
 - [Frameworks](#frameworks)
   - [PyTorch](#pytorch)
+  - [TensorFlow](#tensorflow)
 - [Examples](#examples)
   - [AddSub in NumPy](#addsub-in-numpy)
   - [AddSubNet in PyTorch](#addsubnet-in-pytorch)
@@ -1270,7 +1271,7 @@ this workflow.
 For a simple example of using PyTorch in a Python Backend model, see the
 [AddSubNet PyTorch example](#addsubnet-in-pytorch).
 
-### Determinism and Reproducibility
+### PyTorch Determinism 
 
 When running PyTorch code, you may notice slight differences in output values
 across runs or across servers depending on hardware, system load, driver, or even
@@ -1301,12 +1302,13 @@ Python backend route instead.
 
 ## TensorFlow
 
-### Determinism and Reproducibility
+### TensorFlow Determinism
 
-Similar to the PyTorch section above, TensorFlow can have slight differences 
-in outputs based on various factors like hardware, system configurations, or
-batch sizes due to the library's internal CUDA kernel selection process. For
-more information on improving the determinism of outputs in TensorFlow, see
+Similar to the PyTorch determinism section above, TensorFlow can have slight 
+differences in outputs based on various factors like hardware, system
+configurations, or batch sizes due to the library's internal CUDA kernel
+selection process. For more information on improving the determinism of outputs
+in TensorFlow, see
 [here](https://www.tensorflow.org/api_docs/python/tf/config/experimental/enable_op_determinism).
 
 # Examples

--- a/README.md
+++ b/README.md
@@ -1306,7 +1306,7 @@ Python backend route instead.
 Similar to the PyTorch section above, TensorFlow can have slight differences 
 in outputs based on various factors like hardware, system configurations, or
 batch sizes due to the library's internal CUDA kernel selection process. For
-more information on improving the determinism of these values in TensorFlow, see
+more information on improving the determinism of outputs in TensorFlow, see
 [here](https://www.tensorflow.org/api_docs/python/tf/config/experimental/enable_op_determinism).
 
 # Examples

--- a/README.md
+++ b/README.md
@@ -1291,15 +1291,6 @@ model predictions. For more info on TF32 in PyTorch and how to enable/disable
 it as needed, see 
 [here](https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices).
 
-### PyTorch 2.0
-
-Currently, the
-[PyTorch Backend](https://github.com/triton-inference-server/pytorch_backend)
-relies on LibTorch/TorchScript (C++) which has been deprecated from
-[PyTorch 2.0](https://pytorch.org/get-started/pytorch-2.0/). 
-So, users interested in new features introduced in PyTorch 2.0 should try the
-Python backend route instead.
-
 ## TensorFlow
 
 ### TensorFlow Determinism

--- a/README.md
+++ b/README.md
@@ -1273,16 +1273,21 @@ For a simple example of using PyTorch in a Python Backend model, see the
 ### Determinism and Reproducibility
 
 When running PyTorch code, you may notice slight differences in output values
-across runs or across servers depending on hardware, system load, driver, etc. 
+across runs or across servers depending on hardware, system load, driver, or even
+batch size. These differences are generally related to the selection of CUDA
+kernels used to execute the operations, based on the factors mentioned.
+
 For most intents and purposes, these differences aren't large enough to affect
 a model's final prediction. However, to understand where these differences come 
 from, see this [doc](https://pytorch.org/docs/stable/notes/randomness.html).
 
 On Ampere devices and later, there is an optimization related to
-FP32 operations called TensorFlow32 (TF32). Typically this optimization will
-improve overall performance at the cost of minor precision loss, but similarly
-this precision loss is acceptable for most model predictions. For more info on
-TF32 in PyTorch and how to enable/disable it as needed, see 
+FP32 operations called 
+[TensorFloat32 (TF32)](https://blogs.nvidia.com/blog/2020/05/14/tensorfloat-32-precision-format/).
+Typically this optimization will improve overall performance at the cost of
+minor precision loss, but similarly this precision loss is acceptable for most
+model predictions. For more info on TF32 in PyTorch and how to enable/disable
+it as needed, see 
 [here](https://pytorch.org/docs/stable/notes/cuda.html#tensorfloat-32-tf32-on-ampere-devices).
 
 ### PyTorch 2.0
@@ -1293,6 +1298,16 @@ relies on LibTorch/TorchScript (C++) which has been deprecated from
 [PyTorch 2.0](https://pytorch.org/get-started/pytorch-2.0/). 
 So, users interested in new features introduced in PyTorch 2.0 should try the
 Python backend route instead.
+
+## TensorFlow
+
+### Determinism and Reproducibility
+
+Similar to the PyTorch section above, TensorFlow can have slight differences 
+in outputs based on various factors like hardware, system configurations, or
+batch sizes due to the library's internal CUDA kernel selection process. For
+more information on improving the determinism of these values in TensorFlow, see
+[here](https://www.tensorflow.org/api_docs/python/tf/config/experimental/enable_op_determinism).
 
 # Examples
 


### PR DESCRIPTION
Adding similar TF determinism section based on https://github.com/triton-inference-server/server/issues/5640#issuecomment-1512608861