### PR TITLE
Fix the lifetime of InferPayload

### DIFF
--- a/src/infer_payload.cc
+++ b/src/infer_payload.cc
@@ -38,6 +38,7 @@ InferPayload::InferPayload(
 
 InferPayload::~InferPayload()
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   prev_promise_.reset();
 }
 
@@ -45,6 +46,7 @@ void
 InferPayload::SetValueForPrevPromise(
     std::unique_ptr<InferResponse> infer_response)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   prev_promise_->set_value(std::move(infer_response));
   prev_promise_.reset();
   is_promise_set_ = true;
@@ -54,6 +56,7 @@ void
 InferPayload::SetFuture(
     std::future<std::unique_ptr<InferResponse>>& response_future)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   response_future = prev_promise_->get_future();
 }
 
@@ -79,6 +82,7 @@ void
 InferPayload::SetResponseAllocUserp(
     const ResponseAllocatorUserp& response_alloc_userp)
 {
+  std::lock_guard<std::mutex> lock(mutex_);
   response_alloc_userp_ =
       std::make_shared<ResponseAllocatorUserp>(response_alloc_userp);
 }

--- a/src/infer_payload.cc
+++ b/src/infer_payload.cc
@@ -42,10 +42,9 @@ InferPayload::SetValue(std::unique_ptr<InferResponse> infer_response)
   // Only set value to the promise with the first response. Call the callback
   // function to send decoupled response to the stub.
   {
-    std::unique_lock<std::mutex> lock(mutex_);
+    std::lock_guard<std::mutex> lock(mutex_);
     if (!is_promise_set_) {
       is_promise_set_ = true;
-      lock.unlock();
       promise_->set_value(std::move(infer_response));
       return;
     }

--- a/src/infer_payload.cc
+++ b/src/infer_payload.cc
@@ -39,12 +39,17 @@ InferPayload::InferPayload(
 InferPayload::~InferPayload() {}
 
 void
-InferPayload::SetValueForPrevPromise(
-    std::unique_ptr<InferResponse> infer_response)
+InferPayload::SetValue(std::unique_ptr<InferResponse> infer_response)
 {
+  // Only set value to the promise with the first response. Call the callback
+  // function to send decoupled response to the stub.
   std::lock_guard<std::mutex> lock(mutex_);
-  promise_->set_value(std::move(infer_response));
-  is_promise_set_ = true;
+  if (!is_promise_set_) {
+    is_promise_set_ = true;
+    promise_->set_value(std::move(infer_response));
+  } else {
+    Callback(std::move(infer_response));
+  }
 }
 
 void

--- a/src/infer_payload.cc
+++ b/src/infer_payload.cc
@@ -36,8 +36,6 @@ InferPayload::InferPayload(
   promise_.reset(new std::promise<std::unique_ptr<InferResponse>>());
 }
 
-InferPayload::~InferPayload() {}
-
 void
 InferPayload::SetValue(std::unique_ptr<InferResponse> infer_response)
 {

--- a/src/infer_payload.cc
+++ b/src/infer_payload.cc
@@ -39,15 +39,17 @@ InferPayload::InferPayload(
 void
 InferPayload::SetValue(std::unique_ptr<InferResponse> infer_response)
 {
-  // Only set value to the promise with the first response. Call the callback
-  // function to send decoupled response to the stub.
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (!is_promise_set_) {
-    is_promise_set_ = true;
-    promise_->set_value(std::move(infer_response));
-  } else {
-    Callback(std::move(infer_response));
+  {
+    // Only set value to the promise with the first response. Call the callback
+    // function to send decoupled response to the stub.
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!is_promise_set_) {
+      is_promise_set_ = true;
+      promise_->set_value(std::move(infer_response));
+      return;
+    }
   }
+  Callback(std::move(infer_response));
 }
 
 void

--- a/src/infer_payload.cc
+++ b/src/infer_payload.cc
@@ -42,9 +42,10 @@ InferPayload::SetValue(std::unique_ptr<InferResponse> infer_response)
   // Only set value to the promise with the first response. Call the callback
   // function to send decoupled response to the stub.
   {
-    std::lock_guard<std::mutex> lock(mutex_);
+    std::unique_lock<std::mutex> lock(mutex_);
     if (!is_promise_set_) {
       is_promise_set_ = true;
+      lock.unlock();
       promise_->set_value(std::move(infer_response));
       return;
     }

--- a/src/infer_payload.cc
+++ b/src/infer_payload.cc
@@ -41,15 +41,13 @@ InferPayload::SetValue(std::unique_ptr<InferResponse> infer_response)
 {
   // Only set value to the promise with the first response. Call the callback
   // function to send decoupled response to the stub.
-  {
-    std::lock_guard<std::mutex> lock(mutex_);
-    if (!is_promise_set_) {
-      is_promise_set_ = true;
-      promise_->set_value(std::move(infer_response));
-      return;
-    }
+  std::lock_guard<std::mutex> lock(mutex_);
+  if (!is_promise_set_) {
+    is_promise_set_ = true;
+    promise_->set_value(std::move(infer_response));
+  } else {
+    Callback(std::move(infer_response));
   }
-  Callback(std::move(infer_response));
 }
 
 void

--- a/src/infer_payload.cc
+++ b/src/infer_payload.cc
@@ -41,13 +41,15 @@ InferPayload::SetValue(std::unique_ptr<InferResponse> infer_response)
 {
   // Only set value to the promise with the first response. Call the callback
   // function to send decoupled response to the stub.
-  std::lock_guard<std::mutex> lock(mutex_);
-  if (!is_promise_set_) {
-    is_promise_set_ = true;
-    promise_->set_value(std::move(infer_response));
-  } else {
-    Callback(std::move(infer_response));
+  {
+    std::lock_guard<std::mutex> lock(mutex_);
+    if (!is_promise_set_) {
+      is_promise_set_ = true;
+      promise_->set_value(std::move(infer_response));
+      return;
+    }
   }
+  Callback(std::move(infer_response));
 }
 
 void

--- a/src/infer_payload.h
+++ b/src/infer_payload.h
@@ -48,7 +48,6 @@ class InferPayload {
   InferPayload(
       const bool is_decouple,
       std::function<void(std::unique_ptr<InferResponse>)> callback);
-  ~InferPayload();
 
   void SetValue(std::unique_ptr<InferResponse> infer_response);
   void SetFuture(std::future<std::unique_ptr<InferResponse>>& response_future);

--- a/src/infer_payload.h
+++ b/src/infer_payload.h
@@ -43,12 +43,13 @@ struct ResponseAllocatorUserp {
   PreferredMemory preferred_memory;
 };
 
-class InferPayload {
+class InferPayload : public std::enable_shared_from_this<InferPayload> {
  public:
   InferPayload(
       const bool is_decouple,
       std::function<void(std::unique_ptr<InferResponse>)> callback);
 
+  std::shared_ptr<InferPayload> GetPtr() { return shared_from_this(); }
   void SetValue(std::unique_ptr<InferResponse> infer_response);
   void SetFuture(std::future<std::unique_ptr<InferResponse>>& response_future);
   bool IsDecoupled();

--- a/src/infer_payload.h
+++ b/src/infer_payload.h
@@ -61,9 +61,9 @@ class InferPayload {
 
  private:
   // Need to use mutex to make sure InferPayload is thread-safe in
-  // `InferResponseComplete` callback function.
+  // `InferResponseComplete` callback function for decoupled case.
   std::mutex mutex_;
-  std::unique_ptr<std::promise<std::unique_ptr<InferResponse>>> prev_promise_;
+  std::unique_ptr<std::promise<std::unique_ptr<InferResponse>>> promise_;
   bool is_decoupled_;
   bool is_promise_set_;
   std::function<void(std::unique_ptr<InferResponse>)> callback_;

--- a/src/infer_payload.h
+++ b/src/infer_payload.h
@@ -49,6 +49,9 @@ class InferPayload : public std::enable_shared_from_this<InferPayload> {
       const bool is_decouple,
       std::function<void(std::unique_ptr<InferResponse>)> callback);
 
+  /// GetPtr should be only called when the InferPayload object is constructed
+  /// using a shared pointer. Calling this function in any other circumstance
+  /// is undefined behaviour until C++17.
   std::shared_ptr<InferPayload> GetPtr() { return shared_from_this(); }
   void SetValue(std::unique_ptr<InferResponse> infer_response);
   void SetFuture(std::future<std::unique_ptr<InferResponse>>& response_future);

--- a/src/infer_payload.h
+++ b/src/infer_payload.h
@@ -50,7 +50,7 @@ class InferPayload {
       std::function<void(std::unique_ptr<InferResponse>)> callback);
   ~InferPayload();
 
-  void SetValueForPrevPromise(std::unique_ptr<InferResponse> infer_response);
+  void SetValue(std::unique_ptr<InferResponse> infer_response);
   void SetFuture(std::future<std::unique_ptr<InferResponse>>& response_future);
   bool IsDecoupled();
   bool IsPromiseSet();
@@ -60,11 +60,9 @@ class InferPayload {
   std::shared_ptr<ResponseAllocatorUserp> ResponseAllocUserp();
 
  private:
-  // Need to use mutex to make sure InferPayload is thread-safe in
-  // `InferResponseComplete` callback function for decoupled case.
-  std::mutex mutex_;
   std::unique_ptr<std::promise<std::unique_ptr<InferResponse>>> promise_;
   bool is_decoupled_;
+  std::mutex mutex_;
   bool is_promise_set_;
   std::function<void(std::unique_ptr<InferResponse>)> callback_;
   std::shared_ptr<ResponseAllocatorUserp> response_alloc_userp_;

--- a/src/infer_payload.h
+++ b/src/infer_payload.h
@@ -60,6 +60,9 @@ class InferPayload {
   std::shared_ptr<ResponseAllocatorUserp> ResponseAllocUserp();
 
  private:
+  // Need to use mutex to make sure InferPayload is thread-safe in
+  // `InferResponseComplete` callback function.
+  std::mutex mutex_;
   std::unique_ptr<std::promise<std::unique_ptr<InferResponse>>> prev_promise_;
   bool is_decoupled_;
   bool is_promise_set_;

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -77,8 +77,8 @@ void
 InferResponseComplete(
     TRITONSERVER_InferenceResponse* response, const uint32_t flags, void* userp)
 {
-  auto linfer_payload = reinterpret_cast<std::shared_ptr<InferPayload>*>(userp);
-  std::unique_ptr<std::shared_ptr<InferPayload>> infer_payload(linfer_payload);
+  auto linfer_payload = reinterpret_cast<InferPayload*>(userp);
+  std::shared_ptr<InferPayload> infer_payload = linfer_payload->GetPtr();
   std::unique_ptr<InferResponse> infer_response;
   std::vector<std::shared_ptr<PbTensor>> output_tensors;
   std::shared_ptr<PbError> pb_error;
@@ -147,7 +147,7 @@ InferResponseComplete(
       output_tensors.clear();
     }
 
-    if (!(*infer_payload)->IsDecoupled()) {
+    if (!infer_payload->IsDecoupled()) {
       infer_response = std::make_unique<InferResponse>(
           output_tensors, pb_error, true /* is_last_response */);
     } else {
@@ -168,7 +168,7 @@ InferResponseComplete(
         TRITONSERVER_InferenceResponseDelete(response),
         "Failed to release BLS inference response.");
   } else if (
-      (*infer_payload)->IsDecoupled() &&
+      (infer_payload)->IsDecoupled() &&
       (flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) != 0) {
     // An empty response may be the last reponse for decoupled models.
     infer_response = std::make_unique<InferResponse>(
@@ -179,7 +179,7 @@ InferResponseComplete(
         output_tensors, pb_error, true /* is_last_response */, userp /* id */);
   }
 
-  (*infer_payload)->SetValue(std::move(infer_response));
+  infer_payload->SetValue(std::move(infer_response));
 }
 
 TRITONSERVER_Error*
@@ -381,13 +381,11 @@ RequestExecutor::Infer(
       ResponseAllocatorUserp response_allocator_userp(
           shm_pool_.get(), infer_request->GetPreferredMemory());
       infer_payload->SetResponseAllocUserp(response_allocator_userp);
-      std::shared_ptr<InferPayload>* infer_payload_p =
-          new std::shared_ptr<InferPayload>(infer_payload);
 
       THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceRequestSetResponseCallback(
           irequest, response_allocator_,
           reinterpret_cast<void*>(infer_payload->ResponseAllocUserp().get()),
-          InferResponseComplete, reinterpret_cast<void*>(infer_payload_p)));
+          InferResponseComplete, reinterpret_cast<void*>(infer_payload.get())));
 
       THROW_IF_TRITON_ERROR(TRITONSERVER_ServerInferAsync(
           server_, irequest, nullptr /* trace */));

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -177,13 +177,7 @@ InferResponseComplete(
         output_tensors, pb_error, true /* is_last_response */, userp /* id */);
   }
 
-  // Only set value to the promise with the first response. Call the callback
-  // function to send decoupled response to the stub.
-  if (p->IsPromiseSet()) {
-    p->Callback(std::move(infer_response));
-  } else {
-    p->SetValueForPrevPromise(std::move(infer_response));
-  }
+  p->SetValue(std::move(infer_response));
 }
 
 TRITONSERVER_Error*


### PR DESCRIPTION
For the BLS non-decoupled case, there is a race condtion:

In Thread 1 ExecuteBLSRequest:
The line [infer_response = response_future.get()](https://github.com/triton-inference-server/python_backend/blob/r23.04/src/python_be.cc#L712) is wait on Thread 2 to complete the future's promise.

In Thread 2 InferResponseComplete:
When the line [p->SetValueForPrevPromise(std::move(infer_response));](https://github.com/triton-inference-server/python_backend/blob/r23.04/src/request_executor.cc#L185) is reached, the promise is completed inside the function at [p->SetValueForPrevPromise(std::move(infer_response));](https://github.com/triton-inference-server/python_backend/blob/r23.04/src/infer_payload.cc#L48). At this moment, Thread 1 is unblocked, and `infer_payload` will be destroyed at the end of the block scope in Thread 1. This makes it possible that [the following objects](https://github.com/triton-inference-server/python_backend/blob/r23.04/src/infer_payload.cc#L49-L50) in Thread 2 might be used after `infer_payload` being destroyed, which causes segfaults.

```
Thread 1 ExecuteBLSRequest:
{
std::shared_ptr<InferPayload> infer_payload = ...;
auto response_future = request_executor_->Infer(infer_request, infer_payload);
infer_response = response_future.get(); // Waits on Thread 2 to complete the future's promise
}

Thread 2 InferResponseComplete:
auto p = reinterpret_cast<InferPayload*>(userp); // here p is same infer_payload as in Thread 1
p->SetValueForPrevPromise(std::move(infer_response)):
   prev_promise_->set_value(std::move(infer_response)); // Unblocks Thread 1
   prev_promise_.reset(); // Use after free race with Thread 1 destroying infer_payload
   is_promise_set_ = true; // Use after free race with Thread 1 destroying infer_payload

Order of execution for lifetime race:
Thread 1 blocks on promise future
Thread 2 completes promise and unblocks Thread 1
Thread 1 destroys infer_payload at the end of the block scope
Thread 2 accesses infer_payload after it was destroyed
```

This PR fixed the lifetime of `InferPayload` to avoid the race condition.