### PR TITLE
adding proxy CUDA streams for dlpack synchronization

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -830,16 +830,14 @@ Stub::Finalize()
 #ifdef TRITON_ENABLE_GPU
   // We also need to destroy created proxy CUDA streams for dlpack, if any
   std::lock_guard<std::mutex> lock(dlpack_proxy_stream_pool_mu_);
-  if (!dlpack_proxy_stream_pool_.empty()) {
-    for (auto& entry : dlpack_proxy_stream_pool_) {
-      // We don't need to switch device to destroy a stream
-      // https://stackoverflow.com/questions/64663943/how-to-destroy-a-stream-that-was-created-on-a-specific-device
-      cudaError_t err = cudaStreamDestroy(entry.second);
-      if (err != cudaSuccess) {
-        LOG_INFO
-            << "Failed to destroy dlpack CUDA proxy stream on device with id " +
-                   std::to_string(entry.first);
-      }
+  for (auto& entry : dlpack_proxy_stream_pool_) {
+    // We don't need to switch device to destroy a stream
+    // https://stackoverflow.com/questions/64663943/how-to-destroy-a-stream-that-was-created-on-a-specific-device
+    cudaError_t err = cudaStreamDestroy(entry.second);
+    if (err != cudaSuccess) {
+      LOG_ERROR
+          << "Failed to destroy dlpack CUDA proxy stream on device with id " +
+                 std::to_string(entry.first);
     }
   }
 #endif

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -56,6 +56,10 @@ namespace bi = boost::interprocess;
 namespace py = pybind11;
 using namespace pybind11::literals;
 
+#ifndef TRITON_ENABLE_GPU
+using cudaStream_t = void*;
+#endif
+
 namespace triton { namespace backend { namespace python {
 
 #define LOG_IF_EXCEPTION(X)                              \
@@ -297,6 +301,10 @@ class Stub {
       AllocatedSharedMemory<CustomMetricsMessage>& custom_metrics_msg_shm,
       CustomMetricsMessage** custom_metrics_msg);
 
+  /// Helper function to retrieve a proxy stream for dlpack synchronization
+  /// for provided device
+  cudaStream_t GetProxyStream(const int& device_id);
+
  private:
   bi::interprocess_mutex* stub_mutex_;
   bi::interprocess_condition* stub_cond_;
@@ -335,5 +343,6 @@ class Stub {
   std::mutex response_iterator_map_mu_;
   std::unordered_map<void*, std::shared_ptr<ResponseIterator>>
       response_iterator_map_;
+  std::unordered_map<int, cudaStream_t> dlpack_proxy_stream_pool_;
 };
 }}}  // namespace triton::backend::python

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -343,6 +343,7 @@ class Stub {
   std::mutex response_iterator_map_mu_;
   std::unordered_map<void*, std::shared_ptr<ResponseIterator>>
       response_iterator_map_;
+  std::mutex dlpack_proxy_stream_pool_mu_;
   std::unordered_map<int, cudaStream_t> dlpack_proxy_stream_pool_;
 };
 }}}  // namespace triton::backend::python

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -384,11 +384,8 @@ PbTensor::FromDLPack(const std::string& name, const py::object& tensor)
     // In case there is a pending job on the data, where this capsule
     // is pointing to, we need to wait for it to finish before returning
     // capsule.
-    // We synchronize on the default stream explicitly since that what we
-    // pass to external tensor's `__dlpack__` method and in case when memory
-    // is allocated on GPU, PbTensor should be on the default stream.
-    // If external tensor's `__dlpack__` method for some reason does not make
-    // default stream wait for when the capsule is ready, this sync will help.
+    // We synchronize on the proxy stream explicitly since that what we
+    // pass to external tensor's `__dlpack__` method.
     err = cudaStreamSynchronize(proxy_stream);
     if (err != cudaSuccess) {
       throw PythonBackendException(


### PR DESCRIPTION
A follow up to the recent PR. I am making `cudaStreamSynchronize(0)` for all `from_dlpack` calls, since we need to be sure that all work is done on the external tensor and not count on external implementation of `__dlpack__` method.