### PR TITLE
Fix cuda synchronization

### DIFF
--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -165,10 +165,12 @@ PbMemory::CopyBuffer(
     err = cudaStreamSynchronize(0);
     if (err != cudaSuccess) {
       throw PythonBackendException(
-          std::string("failed to synchronize the default CUDA stream").c_str());
+          std::string(
+              "failed to synchronize the default CUDA stream. error: " +
+              std::string(cudaGetErrorString(err)))
+              .c_str());
     }
   }
-
 #endif
 }
 

--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -142,8 +142,7 @@ PbMemory::CopyBuffer(
   }
 
   cudaError_t err;
-  if ((src->MemoryType() == TRITONSERVER_MEMORY_GPU &&
-       dst->MemoryType() == TRITONSERVER_MEMORY_GPU) &&
+  if ((kind == cudaMemcpyDeviceToDevice) &&
       (src->MemoryTypeId() != dst->MemoryTypeId())) {
     err = cudaMemcpyPeer(
         dst->DataPtr(), dst->MemoryTypeId(), src->DataPtr(),
@@ -160,8 +159,7 @@ PbMemory::CopyBuffer(
             .c_str());
   }
 
-  if ((src->MemoryType() == TRITONSERVER_MEMORY_GPU &&
-       dst->MemoryType() == TRITONSERVER_MEMORY_GPU)) {
+  if (kind == cudaMemcpyDeviceToDevice) {
     // Synchronize the default stream for d2d copies.
     // https://docs.nvidia.com/cuda/cuda-runtime-api/api-sync-behavior.html#api-sync-behavior__memcpy-sync
     err = cudaStreamSynchronize(0);


### PR DESCRIPTION
Closes https://github.com/triton-inference-server/server/issues/5733

After:
```
Number of threads: 3, number of inferences: 1000
Number of failures: [0, 0, 0]
Total: 0
```

Before:
```
Number of threads: 3, number of inferences: 1000
Number of failures: [396, 405, 402]
Total: 1203
```