### PR TITLE
Add error checking for the case where MetricFamily is deleted before …

### DIFF
--- a/README.md
+++ b/README.md
@@ -1326,7 +1326,10 @@ Starting from 23.05, you can utlize Custom Metrics API to register and collect
 custom metrics in the `initialize`, `execute`, and `finalize` functions of your
 Python model. The Custom Metrics API is the Python equivalent of the
 [TRITON C API custom metrics](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/metrics.md#custom-metrics)
-support.
+support. You will need to take the ownership of the custom metrics created
+through the APIs and must manage their lifetime. Note that a `MetricFamily`
+object should be deleted only after all the `Metric` objects under it are
+deleted if you'd like to explicitly delete the custom metrics objects.
 
 Example below shows how to use this feature:
 

--- a/src/metric.cc
+++ b/src/metric.cc
@@ -124,11 +124,12 @@ Metric::SendCreateMetricRequest()
 void
 Metric::SendIncrementRequest(const double& value)
 {
-  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
-  operation_value_ = value;
-  SaveToSharedMemory(stub->ShmPool());
-  CustomMetricsMessage* custom_metrics_msg = nullptr;
   try {
+    CheckIfCleared();
+    std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
+    operation_value_ = value;
+    SaveToSharedMemory(stub->ShmPool());
+    CustomMetricsMessage* custom_metrics_msg = nullptr;
     stub->SendCustomMetricsMessage(
         &custom_metrics_msg, PYTHONSTUB_MetricRequestIncrement, shm_handle_);
   }
@@ -142,11 +143,12 @@ Metric::SendIncrementRequest(const double& value)
 void
 Metric::SendSetValueRequest(const double& value)
 {
-  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
-  operation_value_ = value;
-  SaveToSharedMemory(stub->ShmPool());
-  CustomMetricsMessage* custom_metrics_msg = nullptr;
   try {
+    CheckIfCleared();
+    std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
+    operation_value_ = value;
+    SaveToSharedMemory(stub->ShmPool());
+    CustomMetricsMessage* custom_metrics_msg = nullptr;
     stub->SendCustomMetricsMessage(
         &custom_metrics_msg, PYTHONSTUB_MetricRequestSet, shm_handle_);
   }
@@ -159,10 +161,11 @@ Metric::SendSetValueRequest(const double& value)
 double
 Metric::SendGetValueRequest()
 {
-  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
-  SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
   try {
+    CheckIfCleared();
+    std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
+    SaveToSharedMemory(stub->ShmPool());
     stub->SendCustomMetricsMessage(
         &custom_metrics_msg, PYTHONSTUB_MetricRequestValue, shm_handle_);
   }
@@ -194,6 +197,17 @@ Metric::Clear()
       std::cerr << "Error when deleting Metric: " << pb_exception.what()
                 << "\n";
     }
+  }
+}
+
+void
+Metric::CheckIfCleared()
+{
+  if (is_cleared_) {
+    throw PythonBackendException(
+        "Invalid metric operation as the corresponding 'MetricFamily' has been "
+        "deleted. The 'MetricFamily' object should be deleted AFTER its "
+        "corresponding 'Metric' objects have been deleted.");
   }
 }
 

--- a/src/metric.h
+++ b/src/metric.h
@@ -99,6 +99,11 @@ class Metric {
   /// Send the request to the parent process to get the value of the metric.
   /// \return Returns the value of the metric.
   double SendGetValueRequest();
+
+  /// Throws an exception if the metric has been cleared. This check is to avoid
+  /// the user error where the corresponding metric family has been deleted
+  /// before the metric is deleted.
+  void CheckIfCleared();
 #else
   // Initialize the TRITONSERVER_Metric object.
   /// \return Returns the address of the TRITONSERVER_Metric object.


### PR DESCRIPTION
…deleting Metric. Update documentation.

When the `MetricFamily` is deleted before the corresponding `Metric` objects are deleted, although the `TRITONSERVER_MetricFamily` and `TRITONSERVER_Metric` will be cleaned up properly in the Python backend side, users will still be able to use the `Metric` object for metric operation in the model. This PR added a check and throw an exception when having this kind of user error.

Added testing: https://github.com/triton-inference-server/server/pull/5915
Resolves: https://github.com/triton-inference-server/server/issues/5901