### PR TITLE
Update neuron readme and setup

### DIFF
--- a/inferentia/README.md
+++ b/inferentia/README.md
@@ -321,10 +321,12 @@ opt/
         └── sg00
   ├── config.pbtxt
 ```
+
 3. Add the following imports (e.g., for OPT model). The import will differ as per the model you're trying to run.
 ```
 from transformers_neuronx.opt.model import OPTForSampling
 ```
+
 4. Add the following lines in `initialize()` function. Set the `batch_size`, `tp_degree`, `n_positions`, `amp` and `unroll` args as per your requirement. `tp_degree` should typically match the number of neuron cores available on inf2 instance.
 ```
 batch_size = 1
@@ -338,9 +340,11 @@ self.model_neuron.to_neuron()
 self.model_neuron.num_workers = num_threads
 ```
 You may also chose to add the `batch_size` etc. arguments to config.pbtxt as parameters and read them in the `initialize()` function similar to `--compiled-model`.
-5. Finally, in the `excute()` function, use the following API to run the inference:
+
+5. Finally, in the `execute()` function, use the following API to run the inference:
 ```
 batched_results = self.model_neuron.sample(batched_tensor, 2048)
 ```
 Above, `2048` is a sufficiently-long output token. It may also be passed in as one of the inputs if you wanto specify it as part of the payload.
+
 6. Proceed to load the model, and submit the inference payload similar to any other triton model.

--- a/inferentia/scripts/setup.sh
+++ b/inferentia/scripts/setup.sh
@@ -91,6 +91,7 @@ for OPTS; do
         ;;
         -inf1|--inf1-setup)
         INSTALL_INF1=1
+        INSTALL_INF2=0
         echo "Installing framework and tools for inf1."
         shift 1
         ;;

--- a/inferentia/scripts/setup.sh
+++ b/inferentia/scripts/setup.sh
@@ -96,11 +96,13 @@ for OPTS; do
         ;;
         -inf2|--inf2-setup)
         INSTALL_INF2=1
+        INSTALL_INF1=0
         echo "Installing framework and tools for inf2"
         shift 1
         ;;
         -trn1|--trn1-setup)
         INSTALL_INF2=1 # same frameworks are used for inf2 and trn1
+        INSTALL_INF1=0
         echo "Installing framework and tools for trn1/inf2"
         shift 1
         ;;


### PR DESCRIPTION
In previous update to setup.sh making `inf1` default caused a break in `inf2` installation in pytorch. Fixing that.