### PR TITLE
Pin pybind11 version to v2.10.0 commit id to avoid unanticipated changes

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -78,7 +78,8 @@ FetchContent_MakeAvailable(repo-common repo-core repo-backend)
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY "https://github.com/pybind/pybind11"
-  GIT_TAG "v2.10"
+  # COMMIT ID for v2.10.0
+  GIT_TAG "aa304c9c7d725ffb9d10af08a3b34cb372307020"
   GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(pybind11)


### PR DESCRIPTION
Using a tag or branch in the GIT_TAG FetchContents CMake setting can introduce unwanted  changes. Thus pinning to a specific commit id is recommended.

https://cmake.org/cmake/help/latest/module/ExternalProject.html#command:externalproject_add

In particular - this change (merged into the v2.10 branch of pybind11)

https://github.com/pybind/pybind11/commit/88699849264150f513dafb98d9ec1bb31a7fa904

changed the behavior of locale setting in the python stub process. 

Alternately we can explicit configuration before initialization but in either case pinning the version of pybind is desireable.

Fixes https://github.com/triton-inference-server/server/issues/5321