### PR TITLE
Model loading API for Python BLS

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -166,6 +166,8 @@ set(
   src/metric_family.cc
   src/gpu_buffers.cc
   src/gpu_buffers.h
+  src/model_loader.h
+  src/model_loader.cc
 )
 
 set(

--- a/README.md
+++ b/README.md
@@ -1211,7 +1211,8 @@ Additionally, the model loading API should only be used after the server has
 been running, which means that the BLS model should not be loaded during server
 startup. You can use different
 [client endpoints](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_model_repository.md)
-to load the model after the server has been started.
+to load the model after the server has been started. The model loading API is
+currently not supported during the `finalize` phase.
 
 ## Using BLS with Stateful Models
 

--- a/src/ipc_message.h
+++ b/src/ipc_message.h
@@ -59,7 +59,10 @@ typedef enum PYTHONSTUB_commandtype_enum {
   PYTHONSTUB_MetricRequestDelete,
   PYTHONSTUB_MetricRequestValue,
   PYTHONSTUB_MetricRequestIncrement,
-  PYTHONSTUB_MetricRequestSet
+  PYTHONSTUB_MetricRequestSet,
+  PYTHONSTUB_LoadModelRequest,
+  PYTHONSTUB_UnloadModelRequest,
+  PYTHONSTUB_ModelReadinessRequest
 } PYTHONSTUB_CommandType;
 
 ///

--- a/src/metric.cc
+++ b/src/metric.cc
@@ -144,16 +144,12 @@ void
 Metric::SendSetValueRequest(const double& value)
 {
   try {
-<<<<<<< HEAD
     CheckIfCleared();
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     operation_value_ = value;
     SaveToSharedMemory(stub->ShmPool());
     CustomMetricsMessage* custom_metrics_msg = nullptr;
-    stub->SendCustomMetricsMessage(
-=======
     stub->SendMessage<CustomMetricsMessage>(
->>>>>>> Use template functions for custom metrics
         &custom_metrics_msg, PYTHONSTUB_MetricRequestSet, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
@@ -167,14 +163,10 @@ Metric::SendGetValueRequest()
 {
   CustomMetricsMessage* custom_metrics_msg = nullptr;
   try {
-<<<<<<< HEAD
     CheckIfCleared();
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     SaveToSharedMemory(stub->ShmPool());
-    stub->SendCustomMetricsMessage(
-=======
     stub->SendMessage<CustomMetricsMessage>(
->>>>>>> Use template functions for custom metrics
         &custom_metrics_msg, PYTHONSTUB_MetricRequestValue, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {

--- a/src/metric.cc
+++ b/src/metric.cc
@@ -65,7 +65,7 @@ Metric::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
   // Save the references to shared memory.
   custom_metric_shm_ = std::move(custom_metric_shm);
   labels_shm_ = std::move(labels_shm);
-  shm_handle_ = custom_metric_shm.handle_;
+  shm_handle_ = custom_metric_shm_.handle_;
 }
 
 std::unique_ptr<Metric>
@@ -111,7 +111,7 @@ Metric::SendCreateMetricRequest()
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
   try {
-    stub->SendCustomMetricsMessage(
+    stub->SendMessage<CustomMetricsMessage>(
         &custom_metrics_msg, PYTHONSTUB_MetricRequestNew, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
@@ -130,7 +130,7 @@ Metric::SendIncrementRequest(const double& value)
     operation_value_ = value;
     SaveToSharedMemory(stub->ShmPool());
     CustomMetricsMessage* custom_metrics_msg = nullptr;
-    stub->SendCustomMetricsMessage(
+    stub->SendMessage<CustomMetricsMessage>(
         &custom_metrics_msg, PYTHONSTUB_MetricRequestIncrement, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
@@ -144,12 +144,16 @@ void
 Metric::SendSetValueRequest(const double& value)
 {
   try {
+<<<<<<< HEAD
     CheckIfCleared();
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     operation_value_ = value;
     SaveToSharedMemory(stub->ShmPool());
     CustomMetricsMessage* custom_metrics_msg = nullptr;
     stub->SendCustomMetricsMessage(
+=======
+    stub->SendMessage<CustomMetricsMessage>(
+>>>>>>> Use template functions for custom metrics
         &custom_metrics_msg, PYTHONSTUB_MetricRequestSet, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
@@ -163,10 +167,14 @@ Metric::SendGetValueRequest()
 {
   CustomMetricsMessage* custom_metrics_msg = nullptr;
   try {
+<<<<<<< HEAD
     CheckIfCleared();
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     SaveToSharedMemory(stub->ShmPool());
     stub->SendCustomMetricsMessage(
+=======
+    stub->SendMessage<CustomMetricsMessage>(
+>>>>>>> Use template functions for custom metrics
         &custom_metrics_msg, PYTHONSTUB_MetricRequestValue, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
@@ -190,7 +198,7 @@ Metric::Clear()
     SaveToSharedMemory(stub->ShmPool());
     CustomMetricsMessage* custom_metrics_msg = nullptr;
     try {
-      stub->SendCustomMetricsMessage(
+      stub->SendMessage<CustomMetricsMessage>(
           &custom_metrics_msg, PYTHONSTUB_MetricRequestDelete, shm_handle_);
     }
     catch (const PythonBackendException& pb_exception) {

--- a/src/metric.cc
+++ b/src/metric.cc
@@ -110,9 +110,11 @@ Metric::SendCreateMetricRequest()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
+  std::unique_ptr<IPCMessage> ipc_message;
   try {
     stub->SendMessage<CustomMetricsMessage>(
-        &custom_metrics_msg, PYTHONSTUB_MetricRequestNew, shm_handle_);
+        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricRequestNew,
+        shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -130,8 +132,10 @@ Metric::SendIncrementRequest(const double& value)
     operation_value_ = value;
     SaveToSharedMemory(stub->ShmPool());
     CustomMetricsMessage* custom_metrics_msg = nullptr;
+    std::unique_ptr<IPCMessage> ipc_message;
     stub->SendMessage<CustomMetricsMessage>(
-        &custom_metrics_msg, PYTHONSTUB_MetricRequestIncrement, shm_handle_);
+        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricRequestIncrement,
+        shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -149,8 +153,10 @@ Metric::SendSetValueRequest(const double& value)
     operation_value_ = value;
     SaveToSharedMemory(stub->ShmPool());
     CustomMetricsMessage* custom_metrics_msg = nullptr;
+    std::unique_ptr<IPCMessage> ipc_message;
     stub->SendMessage<CustomMetricsMessage>(
-        &custom_metrics_msg, PYTHONSTUB_MetricRequestSet, shm_handle_);
+        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricRequestSet,
+        shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -162,12 +168,14 @@ double
 Metric::SendGetValueRequest()
 {
   CustomMetricsMessage* custom_metrics_msg = nullptr;
+  std::unique_ptr<IPCMessage> ipc_message;
   try {
     CheckIfCleared();
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     SaveToSharedMemory(stub->ShmPool());
     stub->SendMessage<CustomMetricsMessage>(
-        &custom_metrics_msg, PYTHONSTUB_MetricRequestValue, shm_handle_);
+        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricRequestValue,
+        shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -189,9 +197,11 @@ Metric::Clear()
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     SaveToSharedMemory(stub->ShmPool());
     CustomMetricsMessage* custom_metrics_msg = nullptr;
+    std::unique_ptr<IPCMessage> ipc_message;
     try {
       stub->SendMessage<CustomMetricsMessage>(
-          &custom_metrics_msg, PYTHONSTUB_MetricRequestDelete, shm_handle_);
+          ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricRequestDelete,
+          shm_handle_);
     }
     catch (const PythonBackendException& pb_exception) {
       std::cerr << "Error when deleting Metric: " << pb_exception.what()

--- a/src/metric.cc
+++ b/src/metric.cc
@@ -111,17 +111,16 @@ Metric::SendCreateMetricRequest()
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
   AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
-  std::unique_ptr<IPCMessage> ipc_message;
-
   try {
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, custom_metrics_shm,
-        PYTHONSTUB_MetricRequestNew, shm_handle_);
+        custom_metrics_shm, PYTHONSTUB_MetricRequestNew, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
         "Error when creating Metric: " + std::string(pb_exception.what()));
   }
+
+  custom_metrics_msg = custom_metrics_shm.data_.get();
   metric_address_ = custom_metrics_msg->address;
 }
 
@@ -133,13 +132,9 @@ Metric::SendIncrementRequest(const double& value)
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     operation_value_ = value;
     SaveToSharedMemory(stub->ShmPool());
-    CustomMetricsMessage* custom_metrics_msg = nullptr;
     AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
-    std::unique_ptr<IPCMessage> ipc_message;
-
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, custom_metrics_shm,
-        PYTHONSTUB_MetricRequestIncrement, shm_handle_);
+        custom_metrics_shm, PYTHONSTUB_MetricRequestIncrement, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -156,13 +151,9 @@ Metric::SendSetValueRequest(const double& value)
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     operation_value_ = value;
     SaveToSharedMemory(stub->ShmPool());
-    CustomMetricsMessage* custom_metrics_msg = nullptr;
     AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
-    std::unique_ptr<IPCMessage> ipc_message;
-
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, custom_metrics_shm,
-        PYTHONSTUB_MetricRequestSet, shm_handle_);
+        custom_metrics_shm, PYTHONSTUB_MetricRequestSet, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -175,20 +166,19 @@ Metric::SendGetValueRequest()
 {
   CustomMetricsMessage* custom_metrics_msg = nullptr;
   AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
-  std::unique_ptr<IPCMessage> ipc_message;
   try {
     CheckIfCleared();
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     SaveToSharedMemory(stub->ShmPool());
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, custom_metrics_shm,
-        PYTHONSTUB_MetricRequestValue, shm_handle_);
+        custom_metrics_shm, PYTHONSTUB_MetricRequestValue, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
         "Failed to get metric value: " + std::string(pb_exception.what()));
   }
 
+  custom_metrics_msg = custom_metrics_shm.data_.get();
   return custom_metrics_msg->value;
 }
 
@@ -203,14 +193,10 @@ Metric::Clear()
     is_cleared_ = true;
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     SaveToSharedMemory(stub->ShmPool());
-    CustomMetricsMessage* custom_metrics_msg = nullptr;
     AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
-    std::unique_ptr<IPCMessage> ipc_message;
-
     try {
       stub->SendMessage<CustomMetricsMessage>(
-          ipc_message, &custom_metrics_msg, custom_metrics_shm,
-          PYTHONSTUB_MetricRequestDelete, shm_handle_);
+          custom_metrics_shm, PYTHONSTUB_MetricRequestDelete, shm_handle_);
     }
     catch (const PythonBackendException& pb_exception) {
       std::cerr << "Error when deleting Metric: " << pb_exception.what()

--- a/src/metric.cc
+++ b/src/metric.cc
@@ -110,11 +110,13 @@ Metric::SendCreateMetricRequest()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
+  AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
   std::unique_ptr<IPCMessage> ipc_message;
+
   try {
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricRequestNew,
-        shm_handle_);
+        ipc_message, &custom_metrics_msg, custom_metrics_shm,
+        PYTHONSTUB_MetricRequestNew, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -132,10 +134,12 @@ Metric::SendIncrementRequest(const double& value)
     operation_value_ = value;
     SaveToSharedMemory(stub->ShmPool());
     CustomMetricsMessage* custom_metrics_msg = nullptr;
+    AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
     std::unique_ptr<IPCMessage> ipc_message;
+
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricRequestIncrement,
-        shm_handle_);
+        ipc_message, &custom_metrics_msg, custom_metrics_shm,
+        PYTHONSTUB_MetricRequestIncrement, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -153,10 +157,12 @@ Metric::SendSetValueRequest(const double& value)
     operation_value_ = value;
     SaveToSharedMemory(stub->ShmPool());
     CustomMetricsMessage* custom_metrics_msg = nullptr;
+    AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
     std::unique_ptr<IPCMessage> ipc_message;
+
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricRequestSet,
-        shm_handle_);
+        ipc_message, &custom_metrics_msg, custom_metrics_shm,
+        PYTHONSTUB_MetricRequestSet, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -168,14 +174,15 @@ double
 Metric::SendGetValueRequest()
 {
   CustomMetricsMessage* custom_metrics_msg = nullptr;
+  AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
   std::unique_ptr<IPCMessage> ipc_message;
   try {
     CheckIfCleared();
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     SaveToSharedMemory(stub->ShmPool());
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricRequestValue,
-        shm_handle_);
+        ipc_message, &custom_metrics_msg, custom_metrics_shm,
+        PYTHONSTUB_MetricRequestValue, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -197,11 +204,13 @@ Metric::Clear()
     std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
     SaveToSharedMemory(stub->ShmPool());
     CustomMetricsMessage* custom_metrics_msg = nullptr;
+    AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
     std::unique_ptr<IPCMessage> ipc_message;
+
     try {
       stub->SendMessage<CustomMetricsMessage>(
-          ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricRequestDelete,
-          shm_handle_);
+          ipc_message, &custom_metrics_msg, custom_metrics_shm,
+          PYTHONSTUB_MetricRequestDelete, shm_handle_);
     }
     catch (const PythonBackendException& pb_exception) {
       std::cerr << "Error when deleting Metric: " << pb_exception.what()

--- a/src/metric_family.cc
+++ b/src/metric_family.cc
@@ -59,7 +59,7 @@ MetricFamily::~MetricFamily()
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
   try {
-    stub->SendCustomMetricsMessage(
+    stub->SendMessage<CustomMetricsMessage>(
         &custom_metrics_msg, PYTHONSTUB_MetricFamilyRequestDelete, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
@@ -90,7 +90,7 @@ MetricFamily::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
   custom_metric_family_shm_ = std::move(custom_metric_family_shm);
   name_shm_ = std::move(name_shm);
   description_shm_ = std::move(description_shm);
-  shm_handle_ = custom_metric_family_shm.handle_;
+  shm_handle_ = custom_metric_family_shm_.handle_;
 }
 
 std::unique_ptr<MetricFamily>
@@ -151,7 +151,7 @@ MetricFamily::SendCreateMetricFamilyRequest()
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
   try {
-    stub->SendCustomMetricsMessage(
+    stub->SendMessage<CustomMetricsMessage>(
         &custom_metrics_msg, PYTHONSTUB_MetricFamilyRequestNew, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {

--- a/src/metric_family.cc
+++ b/src/metric_family.cc
@@ -58,11 +58,13 @@ MetricFamily::~MetricFamily()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
+  AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
   std::unique_ptr<IPCMessage> ipc_message;
+
   try {
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricFamilyRequestDelete,
-        shm_handle_);
+        ipc_message, &custom_metrics_msg, custom_metrics_shm,
+        PYTHONSTUB_MetricFamilyRequestDelete, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     std::cerr << "Error when deleting MetricFamily: " << pb_exception.what()
@@ -152,11 +154,13 @@ MetricFamily::SendCreateMetricFamilyRequest()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
+  AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
   std::unique_ptr<IPCMessage> ipc_message;
+
   try {
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricFamilyRequestNew,
-        shm_handle_);
+        ipc_message, &custom_metrics_msg, custom_metrics_shm,
+        PYTHONSTUB_MetricFamilyRequestNew, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(

--- a/src/metric_family.cc
+++ b/src/metric_family.cc
@@ -58,9 +58,11 @@ MetricFamily::~MetricFamily()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
+  std::unique_ptr<IPCMessage> ipc_message;
   try {
     stub->SendMessage<CustomMetricsMessage>(
-        &custom_metrics_msg, PYTHONSTUB_MetricFamilyRequestDelete, shm_handle_);
+        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricFamilyRequestDelete,
+        shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     std::cerr << "Error when deleting MetricFamily: " << pb_exception.what()
@@ -150,9 +152,11 @@ MetricFamily::SendCreateMetricFamilyRequest()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
+  std::unique_ptr<IPCMessage> ipc_message;
   try {
     stub->SendMessage<CustomMetricsMessage>(
-        &custom_metrics_msg, PYTHONSTUB_MetricFamilyRequestNew, shm_handle_);
+        ipc_message, &custom_metrics_msg, PYTHONSTUB_MetricFamilyRequestNew,
+        shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(

--- a/src/metric_family.cc
+++ b/src/metric_family.cc
@@ -163,8 +163,16 @@ MetricFamily::SendCreateMetricFamilyRequest()
 }
 
 std::shared_ptr<Metric>
-MetricFamily::CreateMetric(py::dict labels)
+MetricFamily::CreateMetric(const py::object& labels)
 {
+  if (!labels.is_none()) {
+    if (!py::isinstance<py::dict>(labels)) {
+      throw PythonBackendException(
+          "Failed to create metric. Labels must be a "
+          "dictionary.");
+    }
+  }
+
   py::module json = py::module_::import("json");
   std::string labels_str = std::string(py::str(json.attr("dumps")(labels)));
   auto metric = std::make_shared<Metric>(labels_str, metric_family_address_);

--- a/src/metric_family.cc
+++ b/src/metric_family.cc
@@ -57,14 +57,10 @@ MetricFamily::~MetricFamily()
   // Send the request to delete the MetricFamily to the parent process
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
-  CustomMetricsMessage* custom_metrics_msg = nullptr;
   AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
-  std::unique_ptr<IPCMessage> ipc_message;
-
   try {
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, custom_metrics_shm,
-        PYTHONSTUB_MetricFamilyRequestDelete, shm_handle_);
+        custom_metrics_shm, PYTHONSTUB_MetricFamilyRequestDelete, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     std::cerr << "Error when deleting MetricFamily: " << pb_exception.what()
@@ -155,18 +151,17 @@ MetricFamily::SendCreateMetricFamilyRequest()
   SaveToSharedMemory(stub->ShmPool());
   CustomMetricsMessage* custom_metrics_msg = nullptr;
   AllocatedSharedMemory<CustomMetricsMessage> custom_metrics_shm;
-  std::unique_ptr<IPCMessage> ipc_message;
-
   try {
     stub->SendMessage<CustomMetricsMessage>(
-        ipc_message, &custom_metrics_msg, custom_metrics_shm,
-        PYTHONSTUB_MetricFamilyRequestNew, shm_handle_);
+        custom_metrics_shm, PYTHONSTUB_MetricFamilyRequestNew, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
         "Error when creating MetricFamily: " +
         std::string(pb_exception.what()));
   }
+
+  custom_metrics_msg = custom_metrics_shm.data_.get();
   metric_family_address_ = custom_metrics_msg->address;
 }
 

--- a/src/metric_family.h
+++ b/src/metric_family.h
@@ -98,7 +98,7 @@ class MetricFamily {
   /// Create a metric from the metric family and store it in the metric map.
   /// \param labels The labels of the metric.
   /// \return Returns the shared pointer to the created metric.
-  std::shared_ptr<Metric> CreateMetric(py::dict labels);
+  std::shared_ptr<Metric> CreateMetric(const py::object& labels);
 #else
   /// Initialize the TRITONSERVER_MetricFamily object.
   /// \return Returns the address of the TRITONSERVER_MetricFamily object.

--- a/src/model_loader.cc
+++ b/src/model_loader.cc
@@ -25,9 +25,6 @@
 // OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 #include "model_loader.h"
 
-#include <fstream>
-#include <list>
-
 #ifdef TRITON_PB_STUB
 #include "pb_stub.h"
 #endif

--- a/src/model_loader.cc
+++ b/src/model_loader.cc
@@ -1,0 +1,256 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+#include "model_loader.h"
+
+#include <fstream>
+#include <list>
+
+#ifdef TRITON_PB_STUB
+#include "pb_stub.h"
+#endif
+
+namespace triton { namespace backend { namespace python {
+
+void
+ModelLoader::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
+{
+  AllocatedSharedMemory<ModelLoaderRequestShm> model_loader_req_shm =
+      shm_pool->Construct<ModelLoaderRequestShm>();
+  model_loader_req_shm_ptr_ = model_loader_req_shm.data_.get();
+
+  std::unique_ptr<PbString> name_shm = PbString::Create(shm_pool, name_);
+  std::unique_ptr<PbString> version_shm = PbString::Create(shm_pool, version_);
+  std::unique_ptr<PbString> config_shm = PbString::Create(shm_pool, config_);
+  std::unique_ptr<PbMap> files_shm = PbMap::Create(shm_pool, files_);
+
+  model_loader_req_shm_ptr_->name_shm_handle = name_shm->ShmHandle();
+  model_loader_req_shm_ptr_->version_shm_handle = version_shm->ShmHandle();
+  model_loader_req_shm_ptr_->config_shm_handle = config_shm->ShmHandle();
+  model_loader_req_shm_ptr_->files_shm_handle = files_shm->ShmHandle();
+  model_loader_req_shm_ptr_->unload_dependents = unload_dependents_;
+
+  // Save the references to shared memory.
+  model_loader_req_shm_ = std::move(model_loader_req_shm);
+  name_shm_ = std::move(name_shm);
+  version_shm_ = std::move(version_shm);
+  config_shm_ = std::move(config_shm);
+  files_shm_ = std::move(files_shm);
+
+  shm_handle_ = model_loader_req_shm_.handle_;
+}
+
+std::unique_ptr<ModelLoader>
+ModelLoader::LoadFromSharedMemory(
+    std::unique_ptr<SharedMemoryManager>& shm_pool,
+    bi::managed_external_buffer::handle_t handle)
+{
+  AllocatedSharedMemory<ModelLoaderRequestShm> model_loader_req_shm =
+      shm_pool->Load<ModelLoaderRequestShm>(handle);
+  ModelLoaderRequestShm* model_loader_req_shm_ptr =
+      model_loader_req_shm.data_.get();
+
+  std::unique_ptr<PbString> name_shm = PbString::LoadFromSharedMemory(
+      shm_pool, model_loader_req_shm_ptr->name_shm_handle);
+  std::unique_ptr<PbString> version_shm = PbString::LoadFromSharedMemory(
+      shm_pool, model_loader_req_shm_ptr->version_shm_handle);
+  std::unique_ptr<PbString> config_shm = PbString::LoadFromSharedMemory(
+      shm_pool, model_loader_req_shm_ptr->config_shm_handle);
+  std::unique_ptr<PbMap> files_shm = PbMap::LoadFromSharedMemory(
+      shm_pool, model_loader_req_shm_ptr->files_shm_handle);
+
+  return std::unique_ptr<ModelLoader>(new ModelLoader(
+      model_loader_req_shm, name_shm, version_shm, config_shm, files_shm));
+}
+
+ModelLoader::ModelLoader(
+    AllocatedSharedMemory<ModelLoaderRequestShm>& model_loader_req_shm,
+    std::unique_ptr<PbString>& name_shm, std::unique_ptr<PbString>& version_shm,
+    std::unique_ptr<PbString>& config_shm, std::unique_ptr<PbMap>& files_shm)
+    : model_loader_req_shm_(std::move(model_loader_req_shm)),
+      name_shm_(std::move(name_shm)), version_shm_(std::move(version_shm)),
+      config_shm_(std::move(config_shm)), files_shm_(std::move(files_shm))
+{
+  model_loader_req_shm_ptr_ = model_loader_req_shm_.data_.get();
+  name_ = name_shm_->String();
+  version_ = version_shm_->String();
+  config_ = config_shm_->String();
+  files_ = files_shm_->UnorderedMap();
+  unload_dependents_ = model_loader_req_shm_ptr_->unload_dependents;
+}
+#ifdef TRITON_PB_STUB
+void
+ModelLoader::SendLoadModelRequest()
+{
+  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
+  SaveToSharedMemory(stub->ShmPool());
+  ModelLoaderMessage* model_loader_msg = nullptr;
+  try {
+    stub->SendMessage<ModelLoaderMessage>(
+        &model_loader_msg, PYTHONSTUB_LoadModelRequest, shm_handle_);
+  }
+  catch (const PythonBackendException& pb_exception) {
+    throw PythonBackendException(
+        "Failed to load model: " + std::string(pb_exception.what()));
+  }
+}
+
+void
+ModelLoader::SendUnloadModelRequest()
+{
+  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
+  SaveToSharedMemory(stub->ShmPool());
+  ModelLoaderMessage* model_loader_msg = nullptr;
+  try {
+    stub->SendMessage<ModelLoaderMessage>(
+        &model_loader_msg, PYTHONSTUB_UnloadModelRequest, shm_handle_);
+  }
+  catch (const PythonBackendException& pb_exception) {
+    throw PythonBackendException(
+        "Failed to unload model: " + std::string(pb_exception.what()));
+  }
+}
+
+bool
+ModelLoader::SendModelReadinessRequest()
+{
+  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
+  SaveToSharedMemory(stub->ShmPool());
+  ModelLoaderMessage* model_loader_msg = nullptr;
+  try {
+    stub->SendMessage<ModelLoaderMessage>(
+        &model_loader_msg, PYTHONSTUB_ModelReadinessRequest, shm_handle_);
+  }
+  catch (const PythonBackendException& pb_exception) {
+    throw PythonBackendException(
+        "Failed to check model readiness: " + std::string(pb_exception.what()));
+  }
+  return model_loader_msg->is_model_ready;
+}
+
+void
+LoadModel(
+    const std::string& name, const std::string& config, const py::dict& files)
+{
+  std::unordered_map<std::string, std::string> files_map;
+
+  for (const auto& item : files) {
+    std::string key = py::cast<std::string>(item.first);
+    py::bytes value = py::cast<py::bytes>(item.second);
+    std::string content(value);
+    files_map[key] = content;
+  }
+  ModelLoader model_loader(name, config, files_map);
+  model_loader.SendLoadModelRequest();
+}
+
+void
+UnloadModel(const std::string& name, const bool unload_dependents)
+{
+  ModelLoader model_loader(name, unload_dependents);
+  model_loader.SendUnloadModelRequest();
+}
+
+bool
+IsModelReady(const std::string& name, const std::string& version)
+{
+  ModelLoader model_loader(name, version);
+  return model_loader.SendModelReadinessRequest();
+}
+#else
+void
+ModelLoader::LoadModel(TRITONSERVER_Server* server)
+{
+  std::string path = "";
+  std::string file_content = "";
+  std::vector<const TRITONSERVER_Parameter*> const_params;
+  if (!config_.empty()) {
+    const_params.emplace_back(TRITONSERVER_ParameterNew(
+        "config", TRITONSERVER_PARAMETER_STRING, config_.c_str()));
+  }
+  if (!files_.empty()) {
+    for (auto& file : files_) {
+      path = file.first;
+      file_content = file.second;
+      const_params.emplace_back(TRITONSERVER_ParameterBytesNew(
+          path.c_str(), file_content.data(), file_content.size()));
+    }
+  }
+
+  THROW_IF_TRITON_ERROR(TRITONSERVER_ServerLoadModelWithParameters(
+      server, name_.c_str(), const_params.data(), const_params.size()));
+
+  for (const auto param : const_params) {
+    TRITONSERVER_ParameterDelete(const_cast<TRITONSERVER_Parameter*>(param));
+  }
+}
+
+void
+ModelLoader::UnloadModel(TRITONSERVER_Server* server)
+{
+  if (unload_dependents_) {
+    THROW_IF_TRITON_ERROR(
+        TRITONSERVER_ServerUnloadModelAndDependents(server, name_.c_str()));
+  } else {
+    THROW_IF_TRITON_ERROR(
+        TRITONSERVER_ServerUnloadModel(server, name_.c_str()));
+  }
+}
+
+bool
+ModelLoader::IsModelReady(TRITONSERVER_Server* server)
+{
+  bool is_ready = false;
+  int64_t model_version = GetModelVersionFromString(version_);
+  THROW_IF_TRITON_ERROR(TRITONSERVER_ServerModelIsReady(
+      server, name_.c_str(), model_version, &is_ready));
+  return is_ready;
+}
+
+int64_t
+ModelLoader::GetModelVersionFromString(const std::string& version_string)
+{
+  int64_t version = -1;
+  if (!version_string.empty()) {
+    try {
+      version = std::stol(version_string);
+    }
+    catch (std::exception& e) {
+      throw PythonBackendException(
+          "failed to get model version from specified version string '" +
+          version_string + "' (details: " + e.what() +
+          "), version should be an integral value > 0");
+    }
+
+    if (version < 0) {
+      throw PythonBackendException(
+          "failed to get model version from specified version string '" +
+          version_string + "', version should be an integral value > 0");
+    }
+  }
+  return version;
+}
+#endif
+}}}  // namespace triton::backend::python

--- a/src/model_loader.cc
+++ b/src/model_loader.cc
@@ -103,14 +103,11 @@ ModelLoader::SendLoadModelRequest()
 {
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
-  ModelLoaderMessage* model_loader_msg = nullptr;
   AllocatedSharedMemory<ModelLoaderMessage> model_loader_msg_shm;
-  std::unique_ptr<IPCMessage> ipc_message;
 
   try {
     stub->SendMessage<ModelLoaderMessage>(
-        ipc_message, &model_loader_msg, model_loader_msg_shm,
-        PYTHONSTUB_LoadModelRequest, shm_handle_);
+        model_loader_msg_shm, PYTHONSTUB_LoadModelRequest, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -123,14 +120,10 @@ ModelLoader::SendUnloadModelRequest()
 {
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
-  ModelLoaderMessage* model_loader_msg = nullptr;
   AllocatedSharedMemory<ModelLoaderMessage> model_loader_msg_shm;
-  std::unique_ptr<IPCMessage> ipc_message;
-
   try {
     stub->SendMessage<ModelLoaderMessage>(
-        ipc_message, &model_loader_msg, model_loader_msg_shm,
-        PYTHONSTUB_UnloadModelRequest, shm_handle_);
+        model_loader_msg_shm, PYTHONSTUB_UnloadModelRequest, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -145,17 +138,16 @@ ModelLoader::SendModelReadinessRequest()
   SaveToSharedMemory(stub->ShmPool());
   ModelLoaderMessage* model_loader_msg = nullptr;
   AllocatedSharedMemory<ModelLoaderMessage> model_loader_msg_shm;
-  std::unique_ptr<IPCMessage> ipc_message;
-
   try {
     stub->SendMessage<ModelLoaderMessage>(
-        ipc_message, &model_loader_msg, model_loader_msg_shm,
-        PYTHONSTUB_ModelReadinessRequest, shm_handle_);
+        model_loader_msg_shm, PYTHONSTUB_ModelReadinessRequest, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
         "Failed to check model readiness: " + std::string(pb_exception.what()));
   }
+
+  model_loader_msg = model_loader_msg_shm.data_.get();
   return model_loader_msg->is_model_ready;
 }
 

--- a/src/model_loader.cc
+++ b/src/model_loader.cc
@@ -104,9 +104,11 @@ ModelLoader::SendLoadModelRequest()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   ModelLoaderMessage* model_loader_msg = nullptr;
+  std::unique_ptr<IPCMessage> ipc_message;
   try {
     stub->SendMessage<ModelLoaderMessage>(
-        &model_loader_msg, PYTHONSTUB_LoadModelRequest, shm_handle_);
+        ipc_message, &model_loader_msg, PYTHONSTUB_LoadModelRequest,
+        shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -120,9 +122,11 @@ ModelLoader::SendUnloadModelRequest()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   ModelLoaderMessage* model_loader_msg = nullptr;
+  std::unique_ptr<IPCMessage> ipc_message;
   try {
     stub->SendMessage<ModelLoaderMessage>(
-        &model_loader_msg, PYTHONSTUB_UnloadModelRequest, shm_handle_);
+        ipc_message, &model_loader_msg, PYTHONSTUB_UnloadModelRequest,
+        shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -136,9 +140,11 @@ ModelLoader::SendModelReadinessRequest()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   ModelLoaderMessage* model_loader_msg = nullptr;
+  std::unique_ptr<IPCMessage> ipc_message;
   try {
     stub->SendMessage<ModelLoaderMessage>(
-        &model_loader_msg, PYTHONSTUB_ModelReadinessRequest, shm_handle_);
+        ipc_message, &model_loader_msg, PYTHONSTUB_ModelReadinessRequest,
+        shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(

--- a/src/model_loader.cc
+++ b/src/model_loader.cc
@@ -104,11 +104,13 @@ ModelLoader::SendLoadModelRequest()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   ModelLoaderMessage* model_loader_msg = nullptr;
+  AllocatedSharedMemory<ModelLoaderMessage> model_loader_msg_shm;
   std::unique_ptr<IPCMessage> ipc_message;
+
   try {
     stub->SendMessage<ModelLoaderMessage>(
-        ipc_message, &model_loader_msg, PYTHONSTUB_LoadModelRequest,
-        shm_handle_);
+        ipc_message, &model_loader_msg, model_loader_msg_shm,
+        PYTHONSTUB_LoadModelRequest, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -122,11 +124,13 @@ ModelLoader::SendUnloadModelRequest()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   ModelLoaderMessage* model_loader_msg = nullptr;
+  AllocatedSharedMemory<ModelLoaderMessage> model_loader_msg_shm;
   std::unique_ptr<IPCMessage> ipc_message;
+
   try {
     stub->SendMessage<ModelLoaderMessage>(
-        ipc_message, &model_loader_msg, PYTHONSTUB_UnloadModelRequest,
-        shm_handle_);
+        ipc_message, &model_loader_msg, model_loader_msg_shm,
+        PYTHONSTUB_UnloadModelRequest, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(
@@ -140,11 +144,13 @@ ModelLoader::SendModelReadinessRequest()
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
   SaveToSharedMemory(stub->ShmPool());
   ModelLoaderMessage* model_loader_msg = nullptr;
+  AllocatedSharedMemory<ModelLoaderMessage> model_loader_msg_shm;
   std::unique_ptr<IPCMessage> ipc_message;
+
   try {
     stub->SendMessage<ModelLoaderMessage>(
-        ipc_message, &model_loader_msg, PYTHONSTUB_ModelReadinessRequest,
-        shm_handle_);
+        ipc_message, &model_loader_msg, model_loader_msg_shm,
+        PYTHONSTUB_ModelReadinessRequest, shm_handle_);
   }
   catch (const PythonBackendException& pb_exception) {
     throw PythonBackendException(

--- a/src/model_loader.h
+++ b/src/model_loader.h
@@ -1,0 +1,159 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <string>
+#include <unordered_map>
+
+#include "ipc_message.h"
+#include "pb_map.h"
+#include "pb_string.h"
+#include "pb_utils.h"
+
+#ifdef TRITON_PB_STUB
+#include <pybind11/embed.h>
+namespace py = pybind11;
+#else
+#include "triton/core/tritonserver.h"
+#endif
+
+namespace triton { namespace backend { namespace python {
+
+// The 'ModelLoaderRequestShm' struct is utilized by the 'ModelLoader' class for
+// saving the essential data to shared memory and for loading the data from
+// shared memory in order to reconstruct the 'ModelLoader' object.
+struct ModelLoaderRequestShm {
+  // The shared memory handle of the model name in PbString format.
+  bi::managed_external_buffer::handle_t name_shm_handle;
+  // The shared memory handle of the model version in PbString format.
+  bi::managed_external_buffer::handle_t version_shm_handle;
+  // The flag to unload the dependent models.
+  bool unload_dependents;
+  // The shared memory handle of the config in PbString format.
+  bi::managed_external_buffer::handle_t config_shm_handle;
+  // The shared memory handle of the files in PbMap format.
+  bi::managed_external_buffer::handle_t files_shm_handle;
+};
+
+class ModelLoader {
+ public:
+  ModelLoader(
+      const std::string& name, const std::string& config,
+      const std::unordered_map<std::string, std::string>& files)
+      : name_(name), version_(""), config_(config), files_(files),
+        unload_dependents_(false)
+  {
+  }
+
+  ModelLoader(const std::string& name, const bool unload_dependents)
+      : name_(name), version_(""), config_(""), files_({}),
+        unload_dependents_(unload_dependents)
+  {
+  }
+
+  ModelLoader(const std::string& name, const std::string& version)
+      : name_(name), version_(version), config_(""), files_({}),
+        unload_dependents_(false)
+  {
+  }
+
+  /// Save ModelLoader object to shared memory.
+  /// \param shm_pool Shared memory pool to save the ModelLoader object.
+  void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
+
+  /// Create a ModelLoader object from shared memory.
+  /// \param shm_pool Shared memory pool
+  /// \param handle Shared memory handle of the ModelLoader.
+  /// \return Returns the ModelLoaders in the specified request_handle
+  /// location.
+  static std::unique_ptr<ModelLoader> LoadFromSharedMemory(
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      bi::managed_external_buffer::handle_t handle);
+#ifdef TRITON_PB_STUB
+  /// Send a request to load the model.
+  void SendLoadModelRequest();
+  /// Send a request to unload the model.
+  void SendUnloadModelRequest();
+  /// Send a request to check if the model is ready.
+  bool SendModelReadinessRequest();
+#else
+  /// Use Triton C API to load the model.
+  /// \param server The Triton server object.
+  void LoadModel(TRITONSERVER_Server* server);
+  /// Use Triton C API to unload the model.
+  /// \param server The Triton server object.
+  void UnloadModel(TRITONSERVER_Server* server);
+  /// Use Triton C API to check if the model is ready.
+  /// \param server The Triton server object.
+  /// \return Returns true if the model is ready.
+  bool IsModelReady(TRITONSERVER_Server* server);
+  /// Get the model version from the version string.
+  /// \param version_string The version string.
+  /// \return Returns the model version in uint64_t.
+  int64_t GetModelVersionFromString(const std::string& version_string);
+#endif
+  /// Disallow copying the ModelLoader object.
+  DISALLOW_COPY_AND_ASSIGN(ModelLoader);
+
+ private:
+  // The private constructor for creating a Metric object from shared memory.
+  ModelLoader(
+      AllocatedSharedMemory<ModelLoaderRequestShm>& model_loader_req_shm,
+      std::unique_ptr<PbString>& name_shm,
+      std::unique_ptr<PbString>& version_shm,
+      std::unique_ptr<PbString>& config_shm, std::unique_ptr<PbMap>& files_shm);
+
+  // The name of the model.
+  std::string name_;
+  // The version of the model.
+  std::string version_;
+  // The configuration of the model.
+  std::string config_;
+  // The files of the model.
+  std::unordered_map<std::string, std::string> files_;
+  // The flag to unload the dependent models.
+  bool unload_dependents_;
+
+  // // Shared Memory Data Structures
+  AllocatedSharedMemory<ModelLoaderRequestShm> model_loader_req_shm_;
+  ModelLoaderRequestShm* model_loader_req_shm_ptr_;
+  bi::managed_external_buffer::handle_t shm_handle_;
+  std::unique_ptr<PbString> name_shm_;
+  std::unique_ptr<PbString> version_shm_;
+  std::unique_ptr<PbString> config_shm_;
+  std::unique_ptr<PbMap> files_shm_;
+};
+
+#ifdef TRITON_PB_STUB
+// The binding functions for the Python stub.
+void LoadModel(
+    const std::string& name, const std::string& config, const py::dict& files);
+void UnloadModel(const std::string& name, const bool unload_dependents);
+bool IsModelReady(const std::string& name, const std::string& version);
+#endif
+
+}}};  // namespace triton::backend::python

--- a/src/model_loader.h
+++ b/src/model_loader.h
@@ -84,7 +84,6 @@ class ModelLoader {
   /// Save ModelLoader object to shared memory.
   /// \param shm_pool Shared memory pool to save the ModelLoader object.
   void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
-
   /// Create a ModelLoader object from shared memory.
   /// \param shm_pool Shared memory pool
   /// \param handle Shared memory handle of the ModelLoader.

--- a/src/model_loader.h
+++ b/src/model_loader.h
@@ -84,6 +84,7 @@ class ModelLoader {
   /// Save ModelLoader object to shared memory.
   /// \param shm_pool Shared memory pool to save the ModelLoader object.
   void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
+
   /// Create a ModelLoader object from shared memory.
   /// \param shm_pool Shared memory pool
   /// \param handle Shared memory handle of the ModelLoader.
@@ -95,21 +96,26 @@ class ModelLoader {
 #ifdef TRITON_PB_STUB
   /// Send a request to load the model.
   void SendLoadModelRequest();
+
   /// Send a request to unload the model.
   void SendUnloadModelRequest();
+
   /// Send a request to check if the model is ready.
   bool SendModelReadinessRequest();
 #else
   /// Use Triton C API to load the model.
   /// \param server The Triton server object.
   void LoadModel(TRITONSERVER_Server* server);
+
   /// Use Triton C API to unload the model.
   /// \param server The Triton server object.
   void UnloadModel(TRITONSERVER_Server* server);
+
   /// Use Triton C API to check if the model is ready.
   /// \param server The Triton server object.
   /// \return Returns true if the model is ready.
   bool IsModelReady(TRITONSERVER_Server* server);
+
   /// Get the model version from the version string.
   /// \param version_string The version string.
   /// \return Returns the model version in uint64_t.

--- a/src/model_loader.h
+++ b/src/model_loader.h
@@ -156,7 +156,8 @@ class ModelLoader {
 #ifdef TRITON_PB_STUB
 // The binding functions for the Python stub.
 void LoadModel(
-    const std::string& name, const std::string& config, const py::dict& files);
+    const std::string& name, const std::string& config,
+    const py::object& files = py::none());
 void UnloadModel(const std::string& name, const bool unload_dependents);
 bool IsModelReady(const std::string& name, const std::string& version);
 #endif

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1542,14 +1542,14 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
           py::arg("kind").none(false))
       .def(
           "Metric", &MetricFamily::CreateMetric,
-          py::arg("labels").none(false) = py::dict());
+          py::arg("labels").none(true) = py::none());
   module.attr("MetricFamily").attr("COUNTER") = MetricKind::COUNTER;
   module.attr("MetricFamily").attr("GAUGE") = MetricKind::GAUGE;
 
   module.def(
       "load_model", &LoadModel, py::arg("model_name").none(false),
       py::arg("config").none(false) = "",
-      py::arg("files").none(false) = py::dict());
+      py::arg("files").none(true) = py::none());
   module.def(
       "unload_model", &UnloadModel, py::arg("model_name").none(false),
       py::arg("unload_dependents").none(false) = false);

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -293,14 +293,11 @@ class Stub {
       std::unique_ptr<UtilsMessagePayload> utils_msg_payload);
 
   /// Send the message to the python backend. MessageType should be either
-  // 'MetricFamilyMessage', 'MetricMessage' or 'ModelLoaderMessage'. In some
-  // cases, the 'msg' object will hold the return value from the parent process,
-  // so we need to pass the 'ipc_message' from the caller function to make sure
-  // the 'msg' object is not deallocated along with the 'ipc_message' object
-  // before the stub process retrieves the return value.
+  // 'MetricFamilyMessage', 'MetricMessage' or 'ModelLoaderMessage'.
   template <typename MessageType>
   void SendMessage(
       std::unique_ptr<IPCMessage>& ipc_message, MessageType** msg,
+      AllocatedSharedMemory<MessageType>& msg_shm,
       PYTHONSTUB_CommandType command_type,
       bi::managed_external_buffer::handle_t handle);
 
@@ -374,12 +371,11 @@ template <typename MessageType>
 void
 Stub::SendMessage(
     std::unique_ptr<IPCMessage>& ipc_message, MessageType** msg,
+    AllocatedSharedMemory<MessageType>& msg_shm,
     PYTHONSTUB_CommandType command_type,
     bi::managed_external_buffer::handle_t handle)
 {
-  AllocatedSharedMemory<MessageType> msg_shm;
   PrepareMessage(msg_shm, msg);
-
   (*msg)->message = handle;
 
   ipc_message = IPCMessage::Create(shm_pool_, false /* inline_response */);

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -200,6 +200,14 @@ struct CustomMetricsMessage : SendMessageBase {
   void* address;
 };
 
+struct ModelLoaderMessage : SendMessageBase {
+  bi::managed_external_buffer::handle_t message;
+  bool has_error;
+  bool is_error_set;
+  bi::managed_external_buffer::handle_t error;
+  bool is_model_ready;
+};
+
 struct ResponseSenderBase {
   bi::interprocess_mutex mu;
   bi::interprocess_condition cv;

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -390,18 +390,22 @@ class ModelInstanceState : public BackendModelInstance {
   // Process the bls decoupled cleanup request
   void ProcessBLSCleanupRequest(const std::unique_ptr<IPCMessage>& message);
 
-  // Process a custom metrics request. The function 'request_handler' is invoked
-  // to handle the request. T should be either 'MetricFamily' or 'Metric'.
-  template <typename T>
-  void ProcessCustomMetricsRequest(
+  // Process a message. The function 'request_handler' is invoked
+  // to handle the request. T should be either 'MetricFamily', 'Metric' or
+  // 'ModelLoader', and MessageType should be either 'MetricFamilyMessage',
+  // 'MetricMessage' or 'ModelLoaderMessage'.
+  template <typename T, typename MessageType>
+  void ProcessMessage(
       const std::unique_ptr<IPCMessage>& message,
-      std::function<void(std::unique_ptr<T>&, CustomMetricsMessage*)>
-          request_handler);
+      std::function<void(std::unique_ptr<T>&, MessageType*)> request_handler);
 
   // Process a metric family request
   void ProcessMetricFamilyRequest(const std::unique_ptr<IPCMessage>& message);
 
   // Process a metric request
   void ProcessMetricRequest(const std::unique_ptr<IPCMessage>& message);
+
+  // Process a model control request
+  void ProcessModelControlRequest(const std::unique_ptr<IPCMessage>& message);
 };
 }}}  // namespace triton::backend::python


### PR DESCRIPTION
This PR adds support for the model loading API in Python BLS. It enables users to load the required model during the initialization of their BLS model.

Closes: https://github.com/triton-inference-server/server/issues/4366
Testing: https://github.com/triton-inference-server/server/pull/5980