### PR TITLE
Allow uncompressed conda execution enviroments

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,8 +62,8 @@ any C++ code.
   - [Running Multiple Instances of Triton Server](#running-multiple-instances-of-triton-server)
 - [Business Logic Scripting](#business-logic-scripting)
   - [Using BLS with Decoupled Models](#using-bls-with-decoupled-models)
-  - [Using BLS with Stateful Models](#using-bls-with-stateful-models)
   - [Model Loading API](#model-loading-api)
+  - [Using BLS with Stateful Models](#using-bls-with-stateful-models)
   - [Limitation](#limitation)
 - [Interoperability and GPU Support](#interoperability-and-gpu-support)
   - [`pb_utils.Tensor.to_dlpack() -> PyCapsule`](#pb_utilstensorto_dlpack---pycapsule)
@@ -706,9 +706,9 @@ If this variable is not exported and similar packages are installed outside your
 conda environment, your tar file may not contain all the dependencies required
 for an isolated Python environment.
 
-Alternatively, Triton also supports unpacked Conda execution environments, given
-it  points to an activation script to setup the Conda environment. Usually the
-Conda activation script is located in:
+Alternatively, Python backend also supports unpacked conda execution 
+environments, given it points to an activation script to setup the conda 
+environment. Usually the conda activation script is located in:
 ````$path_to_conda_pack/lib/python3.7/site-packages/conda_pack/scripts/posix/activate```
 This speeds up the server loading time for models.
 

--- a/README.md
+++ b/README.md
@@ -681,7 +681,7 @@ If you want to create a tar file that contains all your Python dependencies or
 you want to use different Python environments for each Python model you need to
 create a *Custom Execution Environment* in Python backend.
 Currently, Python backend supports
-[conda-pack](https://conda.github.io/conda-pack/) for this purpose. 
+[conda-pack](https://conda.github.io/conda-pack/) for this purpose.
 [conda-pack](https://conda.github.io/conda-pack/) ensures that your conda
 environment is portable. You can create a tar file for your conda environment
 using `conda-pack` command:
@@ -706,10 +706,10 @@ If this variable is not exported and similar packages are installed outside your
 conda environment, your tar file may not contain all the dependencies required
 for an isolated Python environment.
 
-Alternatively, Triton also supports unpacked Conda execution environments, given 
-it  points to an activation script to setup the Conda environment. Usually the 
+Alternatively, Triton also supports unpacked Conda execution environments, given
+it  points to an activation script to setup the Conda environment. Usually the
 Conda activation script is located in:
-````$path_to_conda_pack/lib/python3.7/site-packages/conda_pack/scripts/posix/activate``` 
+````$path_to_conda_pack/lib/python3.7/site-packages/conda_pack/scripts/posix/activate```
 This speeds up the server loading time for models.
 
 After creating the tar file from the conda environment or creating a conda
@@ -796,9 +796,9 @@ may use dependencies that are not available in the Triton container that you are
 using for deployment. For example, compiling the Python backend stub on an OS
 other than Ubuntu 22.04 can lead to unexpected errors.
 
-7. The custom execution environment needs to be compressed with the name 
-`*.tar.gz` for the Python Backend to unpack the package. Otherwise the 
-Python Backend will treat the environment as is. 
+7. The custom execution environment needs to be compressed with the name
+`*.tar.gz` for the Python Backend to unpack the package. Otherwise the
+Python Backend will treat the environment as is.
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -706,14 +706,14 @@ If this variable is not exported and similar packages are installed outside your
 conda environment, your tar file may not contain all the dependencies required
 for an isolated Python environment.
 
-Alternatively, Triton also supports unpacked Conda execution enviroments, given 
-it  points to an activation script to setup the Conda enviroment. Usually the 
+Alternatively, Triton also supports unpacked Conda execution environments, given 
+it  points to an activation script to setup the Conda environment. Usually the 
 Conda activation script is located in:
 ````$path_to_conda_pack/lib/python3.7/site-packages/conda_pack/scripts/posix/activate``` 
 This speeds up the server loading time for models.
 
 After creating the tar file from the conda environment or creating a conda
-enviroment with a custom activation script, you need to tell Python
+environment with a custom activation script, you need to tell Python
 backend to use that environment for your model. You can do this by adding the
 lines below to the `config.pbtxt` file:
 
@@ -796,9 +796,9 @@ may use dependencies that are not available in the Triton container that you are
 using for deployment. For example, compiling the Python backend stub on an OS
 other than Ubuntu 22.04 can lead to unexpected errors.
 
-7. The custom execution enviroment needs to be compressed with the name 
+7. The custom execution environment needs to be compressed with the name 
 `*.tar.gz` for the Python Backend to unpack the package. Otherwise the 
-Python Backend will treat the enviroment as is. 
+Python Backend will treat the environment as is. 
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ any C++ code.
     - [`initialize`](#initialize)
     - [`execute`](#execute)
       - [Default Mode](#default-mode)
-        - [Error Handling](#error-handling)
+      - [Error Handling](#error-handling)
       - [Decoupled mode](#decoupled-mode)
         - [Use Cases](#use-cases)
         - [Known Issues](#known-issues)
@@ -72,7 +72,9 @@ any C++ code.
   - [Input Tensor Device Placement](#input-tensor-device-placement)
 - [Frameworks](#frameworks)
   - [PyTorch](#pytorch)
+    - [PyTorch Determinism](#pytorch-determinism)
   - [TensorFlow](#tensorflow)
+    - [TensorFlow Determinism](#tensorflow-determinism)
 - [Custom Metrics](#custom-metrics)
 - [Examples](#examples)
   - [AddSub in NumPy](#addsub-in-numpy)
@@ -81,7 +83,8 @@ any C++ code.
   - [Business Logic Scripting](#business-logic-scripting-1)
   - [Preprocessing](#preprocessing)
   - [Decoupled Models](#decoupled-models)
-  - [Auto-complete Config](#auto-complete-config)
+  - [Model Instance Kind](#model-instance-kind)
+  - [Auto-complete config](#auto-complete-config)
   - [Custom Metrics](#custom-metrics-1)
 - [Running with Inferentia](#running-with-inferentia)
 - [Logging](#logging)
@@ -677,8 +680,8 @@ above.
 If you want to create a tar file that contains all your Python dependencies or
 you want to use different Python environments for each Python model you need to
 create a *Custom Execution Environment* in Python backend.
-Currently, Python backend only supports
-[conda-pack](https://conda.github.io/conda-pack/) for this purpose.
+Currently, Python backend supports
+[conda-pack](https://conda.github.io/conda-pack/) for this purpose. 
 [conda-pack](https://conda.github.io/conda-pack/) ensures that your conda
 environment is portable. You can create a tar file for your conda environment
 using `conda-pack` command:
@@ -703,7 +706,14 @@ If this variable is not exported and similar packages are installed outside your
 conda environment, your tar file may not contain all the dependencies required
 for an isolated Python environment.
 
-After creating the tar file from the conda environment, you need to tell Python
+Alternatively, Triton also supports unpacked Conda execution enviroments, given 
+it  points to an activation script to setup the Conda enviroment. Usually the 
+Conda activation script is located in:
+````$path_to_conda_pack/lib/python3.7/site-packages/conda_pack/scripts/posix/activate``` 
+This speeds up the server loading time for models.
+
+After creating the tar file from the conda environment or creating a conda
+enviroment with a custom activation script, you need to tell Python
 backend to use that environment for your model. You can do this by adding the
 lines below to the `config.pbtxt` file:
 
@@ -785,6 +795,10 @@ compile it in the official Triton NGC containers. Otherwise, your compiled stub
 may use dependencies that are not available in the Triton container that you are
 using for deployment. For example, compiling the Python backend stub on an OS
 other than Ubuntu 22.04 can lead to unexpected errors.
+
+7. The custom execution enviroment needs to be compressed with the name 
+`*.tar.gz` for the Python Backend to unpack the package. Otherwise the 
+Python Backend will treat the enviroment as is. 
 
 ## Error Handling
 

--- a/README.md
+++ b/README.md
@@ -706,13 +706,16 @@ If this variable is not exported and similar packages are installed outside your
 conda environment, your tar file may not contain all the dependencies required
 for an isolated Python environment.
 
-Alternatively, Python backend also supports unpacked conda execution 
-environments, given it points to an activation script to setup the conda 
-environment. Usually the conda activation script is located in:
-````$path_to_conda_pack/lib/python3.7/site-packages/conda_pack/scripts/posix/activate```
+Alternatively, Python backend also supports unpacked conda execution
+environments, given it points to an activation script to setup the conda
+environment. To do this, the execution environment can be first packed using
+[conda-pack](https://conda.github.io/conda-pack/) and then unpacked, or created
+using [conda create -p](https://docs.conda.io/projects/conda/en/latest/commands/create.html).
+In this case, the conda activation script is located in:
+```$path_to_conda_pack/lib/python<your.python.version>/site-packages/conda_pack/scripts/posix/activate```
 This speeds up the server loading time for models.
 
-After creating the tar file from the conda environment or creating a conda
+After creating the packed file from the conda environment or creating a conda
 environment with a custom activation script, you need to tell Python
 backend to use that environment for your model. You can do this by adding the
 lines below to the `config.pbtxt` file:
@@ -795,10 +798,6 @@ compile it in the official Triton NGC containers. Otherwise, your compiled stub
 may use dependencies that are not available in the Triton container that you are
 using for deployment. For example, compiling the Python backend stub on an OS
 other than Ubuntu 22.04 can lead to unexpected errors.
-
-7. The custom execution environment needs to be compressed with the name
-`*.tar.gz` for the Python Backend to unpack the package. Otherwise the
-Python Backend will treat the environment as is.
 
 ## Error Handling
 

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -251,11 +251,18 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
   time_t last_modified_time;
   LastModifiedTime(canonical_env_path, &last_modified_time);
 
-  bool env_extracted = false;  
+  bool env_extracted = false;
   bool re_extraction = false;
-  std::string subPath = canonical_env_path.substr(canonical_env_path.size() - 6);
-  std::cout << "subpath: " << subPath << " canonical env path" << canonical_env_path << std::endl;
-  if(subPath == "tar.gz") {
+
+  // If the path is not a conda-packed file, then bypass the extraction process
+  std::string subPath = env_path.substr(env_path.size() - 6);
+  if (subPath != "tar.gz") {
+    LOG_MESSAGE(
+        TRITONSERVER_LOG_VERBOSE,
+        (std::string("Returning canonical path since EXECUTION_ENV_PATH does "
+                     "not contain tar. Path: ") +
+         canonical_env_path)
+            .c_str());
     return canonical_env_path;
   }
   const auto env_itr = env_map_.find(canonical_env_path);
@@ -277,7 +284,7 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
   if (!env_extracted) {
     LOG_MESSAGE(
         TRITONSERVER_LOG_VERBOSE,
-        (std::string("Extracting Python execution env ") + "subpath: " + subPath + " canonical env path" + canonical_env_path)
+        (std::string("Extracting Python execution env ") + canonical_env_path)
             .c_str());
     std::string dst_env_path;
     if (re_extraction) {

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -30,6 +30,7 @@
 #include <archive_entry.h>
 #include <fts.h>
 
+#include <boost/algorithm/string/predicate.hpp>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -255,9 +256,7 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
   bool re_extraction = false;
 
   // If the path is not a conda-packed file, then bypass the extraction process
-  std::size_t subStrPos = env_path.size() > 6 ? env_path.size() - 6 : 0;
-  std::string subPath = env_path.substr(subStrPos);
-  if (subPath != "tar.gz") {
+  if (!boost::algorithm::ends_with(env_path, "tar.gz")) {
     LOG_MESSAGE(
         TRITONSERVER_LOG_VERBOSE,
         (std::string("Returning canonical path since EXECUTION_ENV_PATH does "

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -256,11 +256,11 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
   bool re_extraction = false;
 
   // If the path is not a conda-packed file, then bypass the extraction process
-  if (!boost::algorithm::ends_with(env_path, "tar.gz")) {
+  if (boost::filesystem::exists(env_path)) {
     LOG_MESSAGE(
         TRITONSERVER_LOG_VERBOSE,
         (std::string("Returning canonical path since EXECUTION_ENV_PATH does "
-                     "not contain tar. Path: ") +
+                     "not contain compressed path. Path: ") +
          canonical_env_path)
             .c_str());
     return canonical_env_path;

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -254,6 +254,7 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
   bool env_extracted = false;  
   bool re_extraction = false;
   std::string subPath = canonical_env_path.substr(canonical_env_path.size() - 6);
+  std::cout << "subpath: " << subPath << " canonical env path" << canonical_env_path << std::endl;
   if(subPath == "tar.gz") {
     return canonical_env_path;
   }
@@ -276,7 +277,7 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
   if (!env_extracted) {
     LOG_MESSAGE(
         TRITONSERVER_LOG_VERBOSE,
-        (std::string("Extracting Python execution env ") + canonical_env_path)
+        (std::string("Extracting Python execution env ") + "subpath: " + subPath + " canonical env path" + canonical_env_path)
             .c_str());
     std::string dst_env_path;
     if (re_extraction) {

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -255,7 +255,8 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
   bool re_extraction = false;
 
   // If the path is not a conda-packed file, then bypass the extraction process
-  std::string subPath = env_path.substr(env_path.size() - 6);
+  std::size_t subStrPos = env_path.size() > 6 ? env_path.size() - 6 : 0;
+  std::string subPath =  env_path.substr(subStrPos);
   if (subPath != "tar.gz") {
     LOG_MESSAGE(
         TRITONSERVER_LOG_VERBOSE,

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -30,7 +30,7 @@
 #include <archive_entry.h>
 #include <fts.h>
 
-#include <boost/algorithm/string/predicate.hpp>
+#include <sys/stat.h>
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -256,7 +256,8 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
   bool re_extraction = false;
 
   // If the path is not a conda-packed file, then bypass the extraction process
-  if (boost::filesystem::exists(env_path)) {
+  struct stat info;
+  if (stat(canonical_env_path, &info) == 0 && S_ISDIR(info.st_mode)) {
     LOG_MESSAGE(
         TRITONSERVER_LOG_VERBOSE,
         (std::string("Returning canonical path since EXECUTION_ENV_PATH does "

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -251,8 +251,12 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
   time_t last_modified_time;
   LastModifiedTime(canonical_env_path, &last_modified_time);
 
-  bool env_extracted = false;
+  bool env_extracted = false;  
   bool re_extraction = false;
+  std::string subPath = canonical_env_path.substr(canonical_env_path.size() - 6);
+  if(subPath == "tar.gz") {
+    return canonical_env_path;
+  }
   const auto env_itr = env_map_.find(canonical_env_path);
   if (env_itr != env_map_.end()) {
     // Check if the environment has been modified and would

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -29,8 +29,8 @@
 #include <archive.h>
 #include <archive_entry.h>
 #include <fts.h>
-
 #include <sys/stat.h>
+
 #include <cstdlib>
 #include <cstring>
 #include <iostream>
@@ -257,7 +257,10 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
 
   // If the path is not a conda-packed file, then bypass the extraction process
   struct stat info;
-  if (stat(canonical_env_path, &info) == 0 && S_ISDIR(info.st_mode)) {
+  if (stat(canonical_env_path, &info) != 0) {
+    throw PythonBackendException(
+        std::string("stat() of : ") + canonical_env_path + " returned error.");
+  } else if (S_ISDIR(info.st_mode)) {
     LOG_MESSAGE(
         TRITONSERVER_LOG_VERBOSE,
         (std::string("Returning canonical path since EXECUTION_ENV_PATH does "

--- a/src/pb_env.cc
+++ b/src/pb_env.cc
@@ -256,7 +256,7 @@ EnvironmentManager::ExtractIfNotExtracted(std::string env_path)
 
   // If the path is not a conda-packed file, then bypass the extraction process
   std::size_t subStrPos = env_path.size() > 6 ? env_path.size() - 6 : 0;
-  std::string subPath =  env_path.substr(subStrPos);
+  std::string subPath = env_path.substr(subStrPos);
   if (subPath != "tar.gz") {
     LOG_MESSAGE(
         TRITONSERVER_LOG_VERBOSE,

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1160,8 +1160,8 @@ ModelInstanceState::ResponseSendDecoupled(
     if (send_message_payload->flags == TRITONSERVER_RESPONSE_COMPLETE_FINAL) {
       std::unique_ptr<
           TRITONBACKEND_ResponseFactory, backend::ResponseFactoryDeleter>
-          response_factory(reinterpret_cast<TRITONBACKEND_ResponseFactory*>(
-              send_message_payload->response_factory_address));
+      response_factory(reinterpret_cast<TRITONBACKEND_ResponseFactory*>(
+          send_message_payload->response_factory_address));
     }
   }
 }

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1160,8 +1160,8 @@ ModelInstanceState::ResponseSendDecoupled(
     if (send_message_payload->flags == TRITONSERVER_RESPONSE_COMPLETE_FINAL) {
       std::unique_ptr<
           TRITONBACKEND_ResponseFactory, backend::ResponseFactoryDeleter>
-      response_factory(reinterpret_cast<TRITONBACKEND_ResponseFactory*>(
-          send_message_payload->response_factory_address));
+          response_factory(reinterpret_cast<TRITONBACKEND_ResponseFactory*>(
+              send_message_payload->response_factory_address));
     }
   }
 }


### PR DESCRIPTION
Allow uncompressed conda execution environments and add documentation for custom execution environments.
Test: https://github.com/triton-inference-server/server/pull/6005