### PR TITLE
Fallback to CPU tensors if cuInit call fails

### DIFF
--- a/src/pb_utils.cc
+++ b/src/pb_utils.cc
@@ -104,11 +104,12 @@ CUDAHandler::CUDAHandler()
     if (cuda_err != CUDA_SUCCESS) {
       const char* error_string;
       (*cu_get_error_string_fn_)(cuda_err, &error_string);
-      throw PythonBackendException(
-          std::string(
-              "failed to get cuda pointer device attribute: " +
-              std::string(error_string))
-              .c_str());
+      error_str_ = std::string("failed to call cuInit: ") + error_string;
+      int status = dlclose(dl_open_handle_);
+      if (status != 0) {
+        throw PythonBackendException("Failed to close the libcuda handle.");
+      }
+      dl_open_handle_ = nullptr;
     }
   }
 }

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -247,6 +247,7 @@ class CUDAHandler {
  private:
   std::mutex mu_;
   void* dl_open_handle_ = nullptr;
+  std::string error_str_;
   CUresult (*cu_pointer_get_attribute_fn_)(
       CUdeviceptr*, CUpointer_attribute, CUdeviceptr) = nullptr;
   CUresult (*cu_get_error_string_fn_)(CUresult, const char**) = nullptr;
@@ -263,6 +264,8 @@ class CUDAHandler {
   CUDAHandler(CUDAHandler const&) = delete;
   void operator=(CUDAHandler const&) = delete;
   bool IsAvailable();
+  const std::string& GetErrorString() const { return error_str_; }
+  void ClearErrorString() { return error_str_.clear(); }
   void PointerGetAttribute(
       CUdeviceptr* start_address, CUpointer_attribute attr,
       CUdeviceptr device_ptr);

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -462,7 +462,7 @@ ModelInstanceState::GetInputTensor(
   CUDAHandler& cuda_handler = CUDAHandler::getInstance();
   // If CUDA driver API is not available, the input tensors will be moved to
   // CPU.
-  if (!cuda_handler.IsAvailable()) {
+  if (!cuda_handler.IsAvailable() && !cpu_only_tensors) {
     if (!cuda_handler.GetErrorString().empty()) {
       LOG_MESSAGE(
           TRITONSERVER_LOG_WARN, (std::string(

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -463,6 +463,14 @@ ModelInstanceState::GetInputTensor(
   // If CUDA driver API is not available, the input tensors will be moved to
   // CPU.
   if (!cuda_handler.IsAvailable()) {
+    if (!cuda_handler.GetErrorString().empty()) {
+      LOG_MESSAGE(
+          TRITONSERVER_LOG_WARN, (std::string(
+                                      "Forcing CPU only input tensors: " +
+                                      cuda_handler.GetErrorString()))
+                                     .c_str());
+    }
+    cuda_handler.ClearErrorString();
     cpu_only_tensors = true;
   }
 #endif


### PR DESCRIPTION
cuInit can fail if there are no GPUs are available in the system.

### Before

```
terminate called after throwing an instance of 'triton::backend::python::PythonBackendException'
  what():  failed to get cuda pointer device attribute: no CUDA-capable device is detected

Thread 41 "tritonserver" received signal SIGABRT, Aborted.
```

### After

The model loading and inference runs successfully.

Test for these changes are part of the TF platflorm handler test changes.

