### PR TITLE
Adding the support tracing of child models invoked from a BLS model

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -44,12 +44,13 @@ InferRequest::InferRequest(
     const std::string& model_name, const int64_t model_version,
     const std::string& parameters, const uint32_t flags, const int32_t timeout,
     const intptr_t response_factory_address, const intptr_t request_address,
-    const PreferredMemory& preferred_memory)
+    const PreferredMemory& preferred_memory, TRITONSERVER_InferenceTrace* trace)
     : request_id_(request_id), correlation_id_(correlation_id), inputs_(inputs),
       requested_output_names_(requested_output_names), model_name_(model_name),
       model_version_(model_version), parameters_(parameters), flags_(flags),
       timeout_(timeout), response_factory_address_(response_factory_address),
-      request_address_(request_address), preferred_memory_(preferred_memory)
+      request_address_(request_address), preferred_memory_(preferred_memory),
+      trace_(trace)
 {
   for (auto& input : inputs) {
     if (!input) {
@@ -164,6 +165,12 @@ PreferredMemory&
 InferRequest::GetPreferredMemory()
 {
   return preferred_memory_;
+}
+
+TRITONSERVER_InferenceTrace*
+InferRequest::Trace()
+{
+  return trace_;
 }
 
 void

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -173,6 +173,7 @@ InferRequest::Trace()
   return trace_;
 }
 
+
 void
 InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {
@@ -198,6 +199,7 @@ InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
   infer_request_shm_ptr_->is_decoupled = is_decoupled_;
   infer_request_shm_ptr_->timeout = timeout_;
   infer_request_shm_ptr_->preferred_memory = preferred_memory_;
+  infer_request_shm_ptr_->trace = trace_;
 
   output_names_handle_shm_ptr_ =
       reinterpret_cast<bi::managed_external_buffer::handle_t*>(
@@ -375,6 +377,7 @@ InferRequest::InferRequest(
   is_decoupled_ = infer_request_shm_ptr_->is_decoupled;
   timeout_ = infer_request_shm_ptr_->timeout;
   preferred_memory_ = infer_request_shm_ptr_->preferred_memory;
+  trace_ = infer_request_shm_ptr_->trace;
 
 #ifdef TRITON_PB_STUB
   response_sender_ = std::make_shared<ResponseSender>(

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -173,7 +173,6 @@ InferRequest::Trace()
   return trace_;
 }
 
-
 void
 InferRequest::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -44,7 +44,7 @@ InferRequest::InferRequest(
     const std::string& model_name, const int64_t model_version,
     const std::string& parameters, const uint32_t flags, const int32_t timeout,
     const intptr_t response_factory_address, const intptr_t request_address,
-    const PreferredMemory& preferred_memory, TRITONSERVER_InferenceTrace* trace)
+    const PreferredMemory& preferred_memory, const InferenceTrace& trace)
     : request_id_(request_id), correlation_id_(correlation_id), inputs_(inputs),
       requested_output_names_(requested_output_names), model_name_(model_name),
       model_version_(model_version), parameters_(parameters), flags_(flags),
@@ -167,7 +167,7 @@ InferRequest::GetPreferredMemory()
   return preferred_memory_;
 }
 
-TRITONSERVER_InferenceTrace*
+InferenceTrace&
 InferRequest::Trace()
 {
   return trace_;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -42,6 +42,17 @@ namespace triton { namespace backend { namespace python {
 class Stub;
 
 //
+// Inference Trace
+//
+struct InferenceTrace {
+#ifndef TRITON_PB_STUB
+  TRITONSERVER_InferenceTrace* triton_trace_;
+#else
+  void* triton_trace_;
+#endif
+};
+
+//
 // Inference Request
 //
 struct InferRequestShm {
@@ -55,7 +66,7 @@ struct InferRequestShm {
   bool is_decoupled;
   int32_t timeout;
   PreferredMemory preferred_memory;
-  TRITONSERVER_InferenceTrace* trace;
+  InferenceTrace trace;
 };
 
 class InferRequest {
@@ -70,7 +81,7 @@ class InferRequest {
       const intptr_t request_address = 0,
       const PreferredMemory& preferred_memory =
           PreferredMemory(PreferredMemory::DEFAULT, 0),
-      TRITONSERVER_InferenceTrace* trace = nullptr);
+      const InferenceTrace& trace = {.triton_trace_ = nullptr});
 
   const std::vector<std::shared_ptr<PbTensor>>& Inputs();
   const std::string& RequestId();
@@ -86,7 +97,7 @@ class InferRequest {
   bool IsDecoupled();
   void SetIsDecoupled(const bool is_decoupled);
   PreferredMemory& GetPreferredMemory();
-  TRITONSERVER_InferenceTrace* Trace();
+  InferenceTrace& Trace();
 
 #ifdef TRITON_PB_STUB
   std::shared_ptr<InferResponse> Exec(const bool is_decoupled);
@@ -142,7 +153,7 @@ class InferRequest {
   intptr_t request_address_;
   bool is_decoupled_;
   PreferredMemory preferred_memory_;
-  TRITONSERVER_InferenceTrace* trace_;
+  InferenceTrace trace_;
 
   // Shared Memory Data Structures
   AllocatedSharedMemory<char> infer_request_shm_;

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -55,6 +55,7 @@ struct InferRequestShm {
   bool is_decoupled;
   int32_t timeout;
   PreferredMemory preferred_memory;
+  TRITONSERVER_InferenceTrace* trace;
 };
 
 class InferRequest {
@@ -85,6 +86,9 @@ class InferRequest {
   bool IsDecoupled();
   void SetIsDecoupled(const bool is_decoupled);
   PreferredMemory& GetPreferredMemory();
+  TRITONSERVER_InferenceTrace* Trace();
+  uint32_t CustomTrace();
+
 
 #ifdef TRITON_PB_STUB
   std::shared_ptr<InferResponse> Exec(const bool is_decoupled);
@@ -118,8 +122,6 @@ class InferRequest {
   TRITONSERVER_Error* DeleteResponseFactory();
 #endif
 
-  TRITONSERVER_InferenceTrace* Trace();
-
  private:
   InferRequest(
       AllocatedSharedMemory<char>& infer_request_shm,
@@ -142,6 +144,7 @@ class InferRequest {
   intptr_t request_address_;
   bool is_decoupled_;
   PreferredMemory preferred_memory_;
+  TRITONSERVER_InferenceTrace* trace_;
 
   // Shared Memory Data Structures
   AllocatedSharedMemory<char> infer_request_shm_;
@@ -158,7 +161,5 @@ class InferRequest {
 #ifdef TRITON_PB_STUB
   std::shared_ptr<ResponseSender> response_sender_;
 #endif
-
-  TRITONSERVER_InferenceTrace* trace_;
 };
 }}};  // namespace triton::backend::python

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -87,8 +87,6 @@ class InferRequest {
   void SetIsDecoupled(const bool is_decoupled);
   PreferredMemory& GetPreferredMemory();
   TRITONSERVER_InferenceTrace* Trace();
-  uint32_t CustomTrace();
-
 
 #ifdef TRITON_PB_STUB
   std::shared_ptr<InferResponse> Exec(const bool is_decoupled);

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -68,7 +68,8 @@ class InferRequest {
       const int32_t timeout = 0, const intptr_t response_factory_address = 0,
       const intptr_t request_address = 0,
       const PreferredMemory& preferred_memory =
-          PreferredMemory(PreferredMemory::DEFAULT, 0));
+          PreferredMemory(PreferredMemory::DEFAULT, 0),
+      TRITONSERVER_InferenceTrace* trace = nullptr);
 
   const std::vector<std::shared_ptr<PbTensor>>& Inputs();
   const std::string& RequestId();
@@ -117,6 +118,8 @@ class InferRequest {
   TRITONSERVER_Error* DeleteResponseFactory();
 #endif
 
+  TRITONSERVER_InferenceTrace* Trace();
+
  private:
   InferRequest(
       AllocatedSharedMemory<char>& infer_request_shm,
@@ -155,5 +158,7 @@ class InferRequest {
 #ifdef TRITON_PB_STUB
   std::shared_ptr<ResponseSender> response_sender_;
 #endif
+
+  TRITONSERVER_InferenceTrace* trace_;
 };
 }}};  // namespace triton::backend::python

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1377,9 +1377,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
             for (auto& requested_output_name : requested_output_names) {
               requested_outputs.emplace(requested_output_name);
             }
-
             auto trace = (request != nullptr) ? request->Trace() : nullptr;
-
             // FIXME: InferenceRequest parameters are not supported in BLS now.
             return std::make_shared<InferRequest>(
                 request_id, correlation_id, inputs, requested_outputs,

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1371,17 +1371,21 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
                       const std::string& model_name,
                       const int64_t model_version, const uint32_t flags,
                       const int32_t timeout,
-                      const PreferredMemory& preferred_memory) {
+                      const PreferredMemory& preferred_memory,
+                      std::shared_ptr<InferRequest>& request) {
             std::set<std::string> requested_outputs;
             for (auto& requested_output_name : requested_output_names) {
               requested_outputs.emplace(requested_output_name);
             }
+
+            auto trace = (request != nullptr) ? request->Trace() : nullptr;
+
             // FIXME: InferenceRequest parameters are not supported in BLS now.
             return std::make_shared<InferRequest>(
                 request_id, correlation_id, inputs, requested_outputs,
                 model_name, model_version, "" /*parameters*/, flags, timeout,
                 0 /*response_factory_address*/, 0 /*request_address*/,
-                preferred_memory);
+                preferred_memory, trace);
           }),
           py::arg("request_id").none(false) = "",
           py::arg("correlation_id").none(false) = 0,
@@ -1391,7 +1395,8 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
           py::arg("model_version").none(false) = -1,
           py::arg("flags").none(false) = 0, py::arg("timeout").none(false) = 0,
           py::arg("preferred_memory").none(false) =
-              PreferredMemory(PreferredMemory::DEFAULT, 0))
+              PreferredMemory(PreferredMemory::DEFAULT, 0),
+          py::arg("request").none(false) = nullptr)
       .def(
           "inputs", &InferRequest::Inputs,
           py::return_value_policy::reference_internal)

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -382,7 +382,7 @@ ModelInstanceState::SaveRequestsToSharedMemory(
           id, correlation_id, pb_input_tensors, requested_output_names,
           model_state->Name(), model_state->Version(), parameters_string, flags,
           0 /* BLS request timeout*/, 0 /* response_factory_address */,
-          reinterpret_cast<intptr_t>(request), 
+          reinterpret_cast<intptr_t>(request),
           PreferredMemory(PreferredMemory::DEFAULT, 0), trace);
     }
 

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -375,7 +375,8 @@ ModelInstanceState::SaveRequestsToSharedMemory(
           id, correlation_id, pb_input_tensors, requested_output_names,
           model_state->Name(), model_state->Version(), parameters_string, flags,
           0 /* BLS request timeout*/, reinterpret_cast<intptr_t>(factory_ptr),
-          reinterpret_cast<intptr_t>(request));
+          reinterpret_cast<intptr_t>(request),
+          PreferredMemory(PreferredMemory::DEFAULT, 0), trace);
     } else {
       infer_request = std::make_unique<InferRequest>(
           id, correlation_id, pb_input_tensors, requested_output_names,

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -364,6 +364,9 @@ ModelInstanceState::SaveRequestsToSharedMemory(
     uint32_t flags;
     RETURN_IF_ERROR(TRITONBACKEND_RequestFlags(request, &flags));
 
+    TRITONSERVER_InferenceTrace* trace;
+    RETURN_IF_ERROR(TRITONBACKEND_RequestTrace(request, &trace));
+
     std::unique_ptr<InferRequest> infer_request;
     if (model_state->IsDecoupled()) {
       TRITONBACKEND_ResponseFactory* factory_ptr;
@@ -378,7 +381,8 @@ ModelInstanceState::SaveRequestsToSharedMemory(
           id, correlation_id, pb_input_tensors, requested_output_names,
           model_state->Name(), model_state->Version(), parameters_string, flags,
           0 /* BLS request timeout*/, 0 /* response_factory_address */,
-          reinterpret_cast<intptr_t>(request));
+          reinterpret_cast<intptr_t>(request), 
+          PreferredMemory(PreferredMemory::DEFAULT, 0), trace);
     }
 
     RETURN_IF_EXCEPTION(infer_request->SaveToSharedMemory(Stub()->ShmPool()));

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -364,8 +364,10 @@ ModelInstanceState::SaveRequestsToSharedMemory(
     uint32_t flags;
     RETURN_IF_ERROR(TRITONBACKEND_RequestFlags(request, &flags));
 
-    TRITONSERVER_InferenceTrace* trace;
-    RETURN_IF_ERROR(TRITONBACKEND_RequestTrace(request, &trace));
+    TRITONSERVER_InferenceTrace* triton_trace;
+    RETURN_IF_ERROR(TRITONBACKEND_RequestTrace(request, &triton_trace));
+
+    InferenceTrace trace = {triton_trace};
 
     std::unique_ptr<InferRequest> infer_request;
     if (model_state->IsDecoupled()) {

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -360,9 +360,9 @@ RequestExecutor::Infer(
         irequest, InferRequestComplete, nullptr /* request_release_userp */));
 
     TRITONSERVER_InferenceTrace* trace = nullptr;
-    if (infer_request->Trace() != nullptr) {
+    if (infer_request->Trace().triton_trace_ != nullptr) {
       THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceTraceSpawnChildTrace(
-          infer_request->Trace(), &trace));
+          infer_request->Trace().triton_trace_, &trace));
     }
 
     for (auto& infer_input : infer_request->Inputs()) {


### PR DESCRIPTION
To allow tracing for sub models, user must provide `request` when creating `InferenceRequest` object in python model.
Sample:
```
for request in requests:
           ...

            infer_request = pb_utils.InferenceRequest(
                model_name=model_name_string,
                requested_output_names=["OUTPUT0", "OUTPUT1"],
                inputs=[in_0, in_1],
                request=request)
```
This is necessary, because `request` has an access to the main trace. Open to the discussion on this.