### PR TITLE
Skip dimension of size 1 in contiguous checks.

### DIFF
--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -433,7 +433,7 @@ PbTensor::FromDLPackCapsule(
     int64_t calculated_stride{1};
     bool is_contiguous_c_order = true;
     for (size_t i = 1; i < dims.size(); i++) {
-      if (dims[ndim-i] != 1) {
+      if (dims[ndim - i] != 1) {
         if (strides[ndim - i] != calculated_stride) {
           is_contiguous_c_order = false;
           break;

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -433,12 +433,14 @@ PbTensor::FromDLPackCapsule(
     int64_t calculated_stride{1};
     bool is_contiguous_c_order = true;
     for (size_t i = 1; i < dims.size(); i++) {
-      if (strides[ndim - i] != calculated_stride) {
-        is_contiguous_c_order = false;
-        break;
-      }
+      if (dims[ndim-i] != 1) {
+        if (strides[ndim - i] != calculated_stride) {
+          is_contiguous_c_order = false;
+          break;
+        }
 
-      calculated_stride *= dims[ndim - i];
+        calculated_stride *= dims[ndim - i];
+      }
     }
 
     if (!is_contiguous_c_order) {


### PR DESCRIPTION
Since PyTorch 1.13 dimension of size 1 have normalised strides in PyTorch which fail here when using DLPack. This was done to conform the torch stride representation and the one from numpy. Unfortunately this means we are stuck with PyTorch 1.12.0 in python models.

Here is the [related issue on the server side](https://github.com/triton-inference-server/server/issues/6102). 

I haven't found any contributing guidelines as to what format Pull Requests should take for the `python_backend` will be happy to apply any changes you deem necessary. 

**Description of the Torch Issue since PyTorch 1.13.0**
PyTorch updated the way they handle strides for dimensions of size 1. 

In Pytorch 1.12 : 

```
import torch
from torch.utils.dlpack import to_dlpack, from_dlpack

x = torch.randn((1, 1, 768,768)).cuda()

y = from_dlpack(to_dlpack(x))

print(x.stride()) # (589824, 589824, 768, 1)
print(y.stride()) # (589824, 589824, 768, 1)
```

In PyTorch `>=` 1.13: 

```
import torch
from torch.utils.dlpack import to_dlpack, from_dlpack

x = torch.randn((1, 1, 768,768)).cuda()

y = from_dlpack(to_dlpack(x))

print(x.stride()) # (589824, 589824, 768, 1)
print(y.stride()) # (1, 1, 768, 1)
```

Closes: https://github.com/triton-inference-server/server/issues/6102