### PR TITLE
Enable parallel instance loading backend attribute

### DIFF
--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -2274,6 +2274,11 @@ TRITONBACKEND_GetBackendAttribute(
       backend_attributes, TRITONSERVER_INSTANCEGROUPKIND_CPU, 0, nullptr, 0));
 #endif
 
+  // This backend can safely handle parallel calls to
+  // TRITONBACKEND_ModelInstanceInitialize (thread-safe).
+  RETURN_IF_ERROR(TRITONBACKEND_BackendAttributeSetParallelModelInstanceLoading(
+      backend_attributes, true));
+
   return nullptr;
 }
 


### PR DESCRIPTION
As far as I can tell, the Python Backend is completely thread-safe on calls to [TRITONBACKEND_ModelInstanceInitialize](https://github.com/triton-inference-server/python_backend/blob/d9de83e7a6fb660dfa4af7773e07f9ff871075d8/src/python_be.cc#L2097-L2137)

All use of `model_state` (the problem area with instance initialization in current backends) appears to be read-only. 

It is passed to constructor for ModelInstanceState very [simply](https://github.com/triton-inference-server/python_backend/blob/d9de83e7a6fb660dfa4af7773e07f9ff871075d8/src/python_be.cc#L37-L59).

L0_backend_python has been hanging on BLS model load tests, but this is now happening on `main` branches too, so I don't believe this is due to any parallel instance changes.

--- 

Corresponding tests: https://github.com/triton-inference-server/server/pull/6126