### PR TITLE
Use constructor to define InferenceTrace default value

### DIFF
--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -47,9 +47,14 @@ class Stub;
 struct InferenceTrace {
 #ifndef TRITON_PB_STUB
   TRITONSERVER_InferenceTrace* triton_trace_;
+  InferenceTrace(TRITONSERVER_InferenceTrace* triton_trace)
+      : triton_trace_(triton_trace)
+  {
+  }
 #else
   void* triton_trace_;
 #endif
+  InferenceTrace() : triton_trace_(nullptr) {}
 };
 
 //
@@ -81,7 +86,7 @@ class InferRequest {
       const intptr_t request_address = 0,
       const PreferredMemory& preferred_memory =
           PreferredMemory(PreferredMemory::DEFAULT, 0),
-      const InferenceTrace& trace = {.triton_trace_ = nullptr});
+      const InferenceTrace& trace = InferenceTrace());
 
   const std::vector<std::shared_ptr<PbTensor>>& Inputs();
   const std::string& RequestId();

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1396,7 +1396,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
           py::arg("flags").none(false) = 0, py::arg("timeout").none(false) = 0,
           py::arg("preferred_memory").none(false) =
               PreferredMemory(PreferredMemory::DEFAULT, 0),
-          py::arg("trace").none(false) = nullptr)
+          py::arg("trace").none(false) = InferenceTrace())
       .def(
           "inputs", &InferRequest::Inputs,
           py::return_value_policy::reference_internal)

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -367,7 +367,7 @@ ModelInstanceState::SaveRequestsToSharedMemory(
     TRITONSERVER_InferenceTrace* triton_trace;
     RETURN_IF_ERROR(TRITONBACKEND_RequestTrace(request, &triton_trace));
 
-    InferenceTrace trace = {triton_trace};
+    InferenceTrace trace = InferenceTrace(triton_trace);
 
     std::unique_ptr<InferRequest> infer_request;
     if (model_state->IsDecoupled()) {


### PR DESCRIPTION
It seems like the L0_backend_python/io test is failing due to incompatible constructor arguments when creating `InferenceRequest` for BLS request:
```
======================================================================
FAIL: test_ensemble_io (__main__.IOTest)
----------------------------------------------------------------------
Traceback (most recent call last):
  File "/opt/tritonserver/qa/L0_backend_python/io/./io_test.py", line 108, in test_ensemble_io
    self._run_ensemble_test()
  File "/opt/tritonserver/qa/L0_backend_python/io/./io_test.py", line 92, in _run_ensemble_test
    self.assertTrue(False, result)
AssertionError: False is not true : in ensemble 'ensemble_io', Failed to process the request(s) for model instance 'dlpack_io_identity_2_0_0', message: TypeError: __init__(): incompatible constructor arguments. The following argument types are supported:
    1. c_python_backend_utils.InferenceRequest(request_id: str = '', correlation_id: int = 0, inputs: List[triton::backend::python::PbTensor], requested_output_names: List[str], model_name: str, model_version: int = -1, flags: int = 0, timeout: int = 0, preferred_memory: c_python_backend_utils.PreferredMemory = <c_python_backend_utils.PreferredMemory object at 0x7fb136b59a30>, trace: c_python_backend_utils.InferenceTrace = None)

Invoked with: kwargs: model_name='dlpack_io_identity_1', inputs=[<c_python_backend_utils.Tensor object at 0x7fb136b69830>, <c_python_backend_utils.Tensor object at 0x7fb1201eaff0>], requested_output_names=['OUTPUT0']

At:
  /opt/tritonserver/qa/L0_backend_python/io/models/dlpack_io_identity_2/1/model.py(71): execute


----------------------------------------------------------------------
```
If we add the trace argument [when creating InferenceRequest](https://github.com/triton-inference-server/server/blob/main/qa/python_models/dlpack_io_identity/model.py#L71-L78) then it's working fine:
```
infer_request = pb_utils.InferenceRequest(
                    model_name="dlpack_io_identity_1",
                    inputs=[
                        input0,
                        pb_utils.get_input_tensor_by_name(request, "GPU_OUTPUT"),
                    ],
                    requested_output_names=["OUTPUT0"],
                    trace=request.trace(),    # <---
                )
```

I suspect the use of [brace-enclosed initializer list](https://github.com/triton-inference-server/python_backend/blob/main/src/infer_request.h#L84) to define default value of `InfereceTrace` is not working well with Pybind. Using the constructor to set the default value seems to do the trick.