### PR TITLE
Reduce the default required shm size to 1MB

### DIFF
--- a/README.md
+++ b/README.md
@@ -852,8 +852,8 @@ Starting from 21.04 release, Python backend uses shared memory to connect
 user's code to Triton. Note that this change is completely transparent and
 does not require any change to the existing user's model code.
 
-Python backend, by default, allocates 64 MBs for each model instance. Then,
-it will grow the shared memory region by 64 MBs whenever an increase is
+Python backend, by default, allocates 1 MB for each model instance. Then,
+it will grow the shared memory region by 1 MB chunks whenever an increase is
 required. You can configure the default shared memory used by each model
 instance using the `shm-default-byte-size` flag. The amount of shared memory
 growth can be configured using the `shm-growth-byte-size`.

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1901,8 +1901,8 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
 
   std::unique_ptr<BackendState> backend_state(new BackendState());
   triton::common::TritonJson::Value cmdline;
-  backend_state->shm_default_byte_size = 1 * 1024 * 1024;  // 1 MBs
-  backend_state->shm_growth_byte_size = 1 * 1024 * 1024;   // 1 MBs
+  backend_state->shm_default_byte_size = 1 * 1024 * 1024;  // 1 MB
+  backend_state->shm_growth_byte_size = 1 * 1024 * 1024;   // 1 MB
   backend_state->stub_timeout_seconds = 30;
   backend_state->shm_message_queue_size = 1000;
   backend_state->number_of_instance_inits = 0;
@@ -1936,7 +1936,7 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
       RETURN_IF_ERROR(shm_default_size.AsString(&shm_default_byte_size));
       try {
         backend_state->shm_default_byte_size = std::stol(shm_default_byte_size);
-        // Shared memory default byte size can't be less than 1 MBs.
+        // Shared memory default byte size can't be less than 1 MB.
         if (backend_state->shm_default_byte_size < 1 * 1024 * 1024) {
           return TRITONSERVER_ErrorNew(
               TRITONSERVER_ERROR_INVALID_ARG,

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1901,8 +1901,8 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
 
   std::unique_ptr<BackendState> backend_state(new BackendState());
   triton::common::TritonJson::Value cmdline;
-  backend_state->shm_default_byte_size = 64 * 1024 * 1024;  // 64 MBs
-  backend_state->shm_growth_byte_size = 64 * 1024 * 1024;   // 64 MBs
+  backend_state->shm_default_byte_size = 1 * 1024 * 1024;  // 1 MBs
+  backend_state->shm_growth_byte_size = 1 * 1024 * 1024;   // 1 MBs
   backend_state->stub_timeout_seconds = 30;
   backend_state->shm_message_queue_size = 1000;
   backend_state->number_of_instance_inits = 0;
@@ -1936,8 +1936,8 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
       RETURN_IF_ERROR(shm_default_size.AsString(&shm_default_byte_size));
       try {
         backend_state->shm_default_byte_size = std::stol(shm_default_byte_size);
-        // Shared memory default byte size can't be less than 4 MBs.
-        if (backend_state->shm_default_byte_size < 4 * 1024 * 1024) {
+        // Shared memory default byte size can't be less than 1 MBs.
+        if (backend_state->shm_default_byte_size < 1 * 1024 * 1024) {
           return TRITONSERVER_ErrorNew(
               TRITONSERVER_ERROR_INVALID_ARG,
               (std::string("shm-default-byte-size") +

--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -76,7 +76,7 @@ SharedMemoryManager::SharedMemoryManager(
          "' to requested size (" + std::to_string(shm_size) +
          " bytes). If you are running Triton inside docker, use '--shm-size' "
          "flag to control the shared memory region size. Each Python backend "
-         "model instance requires at least 64MBs of shared memory. Error: " +
+         "model instance requires at least 1 MB of shared memory. Error: " +
          ex.what());
     // Remove the shared memory region if there was an error.
     bi::shared_memory_object::remove(shm_region_name.c_str());


### PR DESCRIPTION
There has been a lot of requests to reduce the default share memory size to avoid running into issues when using Docker.
Since Python backend automatically adjusts the shm size, I think it should be safe to decrease the default to 1MB.
