### PR TITLE
Enable Python execute() to return Triton error code

### DIFF
--- a/src/infer_response.cc
+++ b/src/infer_response.cc
@@ -243,8 +243,8 @@ InferResponse::Send(
   });
 
   if (HasError()) {
-    *response_error = TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INTERNAL, Error()->Message().c_str());
+    *response_error =
+        TRITONSERVER_ErrorNew(Error()->Code(), Error()->Message().c_str());
     return;
   }
 

--- a/src/pb_error.cc
+++ b/src/pb_error.cc
@@ -73,16 +73,6 @@ PbError::LoadFromSharedMemory(
       std::move(message_shm), std::move(error_shm), code, std::move(message)));
 }
 
-PbError::PbError(const std::string& message)
-    : code_(TRITONSERVER_ERROR_INTERNAL), message_(message)
-{
-}
-
-PbError::PbError(TRITONSERVER_Error_Code code, const std::string& message)
-    : code_(code), message_(message)
-{
-}
-
 PbError::PbError(
     std::shared_ptr<PbString>&& message_shm,
     AllocatedSharedMemory<PbErrorShm>&& error_shm, TRITONSERVER_Error_Code code,

--- a/src/pb_error.cc
+++ b/src/pb_error.cc
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -27,6 +27,13 @@
 #include "pb_error.h"
 
 namespace triton { namespace backend { namespace python {
+
+TRITONSERVER_Error_Code
+PbError::Code()
+{
+  return code_;
+}
+
 const std::string&
 PbError::Message()
 {
@@ -43,7 +50,10 @@ void
 PbError::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
 {
   message_shm_ = PbString::Create(shm_pool, message_);
-  shm_handle_ = message_shm_->ShmHandle();
+  error_shm_ = shm_pool->Construct<PbErrorShm>();
+  error_shm_.data_->code = code_;
+  error_shm_.data_->message_shm_handle = message_shm_->ShmHandle();
+  shm_handle_ = error_shm_.handle_;
 }
 
 std::shared_ptr<PbError>
@@ -51,14 +61,35 @@ PbError::LoadFromSharedMemory(
     std::unique_ptr<SharedMemoryManager>& shm_pool,
     bi::managed_external_buffer::handle_t shm_handle)
 {
-  std::unique_ptr<PbString> message_shm =
-      PbString::LoadFromSharedMemory(shm_pool, shm_handle);
-  return std::shared_ptr<PbError>(new PbError(message_shm));
+  AllocatedSharedMemory<PbErrorShm> error_shm =
+      shm_pool->Load<PbErrorShm>(shm_handle);
+  std::unique_ptr<PbString> message_shm = PbString::LoadFromSharedMemory(
+      shm_pool, error_shm.data_->message_shm_handle);
+
+  TRITONSERVER_Error_Code code = error_shm.data_->code;
+  std::string message = message_shm->String();
+
+  return std::shared_ptr<PbError>(new PbError(
+      std::move(message_shm), std::move(error_shm), code, std::move(message)));
 }
 
-PbError::PbError(std::unique_ptr<PbString>& message_shm)
+PbError::PbError(const std::string& message)
+    : code_(TRITONSERVER_ERROR_INTERNAL), message_(message)
 {
-  message_shm_ = std::move(message_shm);
-  message_ = message_shm_->String();
 }
+
+PbError::PbError(TRITONSERVER_Error_Code code, const std::string& message)
+    : code_(code), message_(message)
+{
+}
+
+PbError::PbError(
+    std::shared_ptr<PbString>&& message_shm,
+    AllocatedSharedMemory<PbErrorShm>&& error_shm, TRITONSERVER_Error_Code code,
+    std::string&& message)
+    : message_shm_(std::move(message_shm)), error_shm_(std::move(error_shm)),
+      code_(code), message_(std::move(message))
+{
+}
+
 }}}  // namespace triton::backend::python

--- a/src/pb_error.h
+++ b/src/pb_error.h
@@ -40,8 +40,12 @@ struct PbErrorShm {
 
 class PbError {
  public:
-  PbError(const std::string& message);
-  PbError(TRITONSERVER_Error_Code code, const std::string& message);
+  PbError(
+      const std::string& message,
+      TRITONSERVER_Error_Code code = TRITONSERVER_ERROR_INTERNAL)
+      : code_(code), message_(message)
+  {
+  }
   DISALLOW_COPY_AND_ASSIGN(PbError);
 
   TRITONSERVER_Error_Code Code();

--- a/src/pb_error.h
+++ b/src/pb_error.h
@@ -1,4 +1,4 @@
-// Copyright 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -32,21 +32,40 @@
 #include "pb_utils.h"
 
 namespace triton { namespace backend { namespace python {
+
+struct PbErrorShm {
+  TRITONSERVER_Error_Code code;
+  bi::managed_external_buffer::handle_t message_shm_handle;
+};
+
 class PbError {
  public:
-  PbError(const std::string& message) : message_(message) {}
+  PbError(const std::string& message);
+  PbError(TRITONSERVER_Error_Code code, const std::string& message);
+  DISALLOW_COPY_AND_ASSIGN(PbError);
+
+  TRITONSERVER_Error_Code Code();
   const std::string& Message();
+
   void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
   bi::managed_external_buffer::handle_t ShmHandle();
+
   static std::shared_ptr<PbError> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       bi::managed_external_buffer::handle_t handle);
-  DISALLOW_COPY_AND_ASSIGN(PbError);
 
  private:
-  PbError(std::unique_ptr<PbString>& pb_error);
-  std::string message_;
+  PbError(
+      std::shared_ptr<PbString>&& message_shm,
+      AllocatedSharedMemory<PbErrorShm>&& error_shm,
+      TRITONSERVER_Error_Code code, std::string&& message);
+
   std::shared_ptr<PbString> message_shm_;
+  AllocatedSharedMemory<PbErrorShm> error_shm_;
   bi::managed_external_buffer::handle_t shm_handle_;
+
+  TRITONSERVER_Error_Code code_;
+  std::string message_;
 };
+
 }}};  // namespace triton::backend::python

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1387,9 +1387,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
       "ALREADY_EXISTS",
       [](py::object /* self */) { return TRITONSERVER_ERROR_ALREADY_EXISTS; });
   triton_error.def(
-      py::init([](const std::string& message, TRITONSERVER_Error_Code code) {
-        return std::make_shared<PbError>(code, message);
-      }),
+      py::init<const std::string&, TRITONSERVER_Error_Code>(),
       py::arg("message").none(false),
       py::arg("code").none(false) = TRITONSERVER_ERROR_INTERNAL);
   triton_error.def("code", &PbError::Code);

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -383,6 +383,9 @@ Stub::StubSetup()
   py::module c_python_backend_utils =
       py::module_::import("c_python_backend_utils");
   py::setattr(
+      python_backend_utils, "ErrorCode",
+      c_python_backend_utils.attr("ErrorCode"));
+  py::setattr(
       python_backend_utils, "TritonError",
       c_python_backend_utils.attr("TritonError"));
   py::setattr(
@@ -474,6 +477,9 @@ Stub::Initialize(bi::managed_external_buffer::handle_t map_handle)
       py::module_::import("triton_python_backend_utils");
   py::module c_python_backend_utils =
       py::module_::import("c_python_backend_utils");
+  py::setattr(
+      python_backend_utils, "ErrorCode",
+      c_python_backend_utils.attr("ErrorCode"));
   py::setattr(
       python_backend_utils, "TritonError",
       c_python_backend_utils.attr("TritonError"));
@@ -1346,8 +1352,39 @@ Logger::BackendLoggingActive()
 
 PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
 {
+  py::enum_<TRITONSERVER_Error_Code>(module, "ErrorCode")
+      .value(
+          "TRITONSERVER_ERROR_UNKNOWN",
+          TRITONSERVER_Error_Code::TRITONSERVER_ERROR_UNKNOWN)
+      .value(
+          "TRITONSERVER_ERROR_INTERNAL",
+          TRITONSERVER_Error_Code::TRITONSERVER_ERROR_INTERNAL)
+      .value(
+          "TRITONSERVER_ERROR_NOT_FOUND",
+          TRITONSERVER_Error_Code::TRITONSERVER_ERROR_NOT_FOUND)
+      .value(
+          "TRITONSERVER_ERROR_INVALID_ARG",
+          TRITONSERVER_Error_Code::TRITONSERVER_ERROR_INVALID_ARG)
+      .value(
+          "TRITONSERVER_ERROR_UNAVAILABLE",
+          TRITONSERVER_Error_Code::TRITONSERVER_ERROR_UNAVAILABLE)
+      .value(
+          "TRITONSERVER_ERROR_UNSUPPORTED",
+          TRITONSERVER_Error_Code::TRITONSERVER_ERROR_UNSUPPORTED)
+      .value(
+          "TRITONSERVER_ERROR_ALREADY_EXISTS",
+          TRITONSERVER_Error_Code::TRITONSERVER_ERROR_ALREADY_EXISTS)
+      .export_values();
+
   py::class_<PbError, std::shared_ptr<PbError>>(module, "TritonError")
-      .def(py::init<std::string>())
+      .def(
+          py::init(
+              [](const std::string& message, TRITONSERVER_Error_Code code) {
+                return std::make_shared<PbError>(code, message);
+              }),
+          py::arg("message").none(false),
+          py::arg("code").none(false) = TRITONSERVER_ERROR_INTERNAL)
+      .def("code", &PbError::Code)
       .def("message", &PbError::Message);
 
   py::class_<PreferredMemory, std::shared_ptr<PreferredMemory>>(

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1348,7 +1348,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
 {
   py::class_<PbError, std::shared_ptr<PbError>> triton_error(
       module, "TritonError");
-  py::enum_<TRITONSERVER_Error_Code>(triton_error, "ErrorCode")
+  py::enum_<TRITONSERVER_Error_Code>(triton_error, "__ErrorCode")
       .value("UNKNOWN", TRITONSERVER_Error_Code::TRITONSERVER_ERROR_UNKNOWN)
       .value("INTERNAL", TRITONSERVER_Error_Code::TRITONSERVER_ERROR_INTERNAL)
       .value("NOT_FOUND", TRITONSERVER_Error_Code::TRITONSERVER_ERROR_NOT_FOUND)
@@ -1365,6 +1365,27 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
           "ALREADY_EXISTS",
           TRITONSERVER_Error_Code::TRITONSERVER_ERROR_ALREADY_EXISTS)
       .export_values();
+  triton_error.def_property_readonly_static(
+      "UNKNOWN",
+      [](py::object /* self */) { return TRITONSERVER_ERROR_UNKNOWN; });
+  triton_error.def_property_readonly_static(
+      "INTERNAL",
+      [](py::object /* self */) { return TRITONSERVER_ERROR_INTERNAL; });
+  triton_error.def_property_readonly_static(
+      "NOT_FOUND",
+      [](py::object /* self */) { return TRITONSERVER_ERROR_NOT_FOUND; });
+  triton_error.def_property_readonly_static(
+      "INVALID_ARG",
+      [](py::object /* self */) { return TRITONSERVER_ERROR_INVALID_ARG; });
+  triton_error.def_property_readonly_static(
+      "UNAVAILABLE",
+      [](py::object /* self */) { return TRITONSERVER_ERROR_UNAVAILABLE; });
+  triton_error.def_property_readonly_static(
+      "UNSUPPORTED",
+      [](py::object /* self */) { return TRITONSERVER_ERROR_UNSUPPORTED; });
+  triton_error.def_property_readonly_static(
+      "ALREADY_EXISTS",
+      [](py::object /* self */) { return TRITONSERVER_ERROR_ALREADY_EXISTS; });
   triton_error.def(
       py::init([](const std::string& message, TRITONSERVER_Error_Code code) {
         return std::make_shared<PbError>(code, message);

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1456,7 +1456,7 @@ ModelInstanceState::ProcessRequests(
           false /* open_cuda_handle */);
       if (infer_response->HasError()) {
         TRITONSERVER_Error* err = TRITONSERVER_ErrorNew(
-            TRITONSERVER_ERROR_INTERNAL,
+            infer_response->Error()->Code(),
             infer_response->Error()->Message().c_str());
 
         LOG_IF_ERROR(


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/server/pull/6228

Currently, the `execute()` can return an error if needed, for example:
```
error = pb_utils.TritonError("error message")
```
The `pb_utils.TritonError()` has a new optional parameter `code` that allows returning a code, for example:
```
error = pb_utils.TritonError(message="error message", code=pb_utils.ErrorCode.TRITONSERVER_ERROR_INVALID_ARG)
```