### PR TITLE
Fix returning error  when tracing is off

### DIFF
--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -365,8 +365,11 @@ ModelInstanceState::SaveRequestsToSharedMemory(
     RETURN_IF_ERROR(TRITONBACKEND_RequestFlags(request, &flags));
 
     TRITONSERVER_InferenceTrace* triton_trace;
-    RETURN_IF_ERROR(TRITONBACKEND_RequestTrace(request, &triton_trace));
-
+    auto err = TRITONBACKEND_RequestTrace(request, &triton_trace);
+    if (err != nullptr) {
+      triton_trace = nullptr;
+      TRITONSERVER_ErrorDelete(err);
+    }
     InferenceTrace trace = InferenceTrace(triton_trace);
 
     std::unique_ptr<InferRequest> infer_request;


### PR DESCRIPTION
We should not use `RETURN_IF_ERROR`  for `TRITONBACKEND_RequestTrace` call, since when tracing is disabled, core side returns error.