### PR TITLE
Load model from installed torchvision version

### DIFF
--- a/examples/pytorch_platform_handler/model.py
+++ b/examples/pytorch_platform_handler/model.py
@@ -27,6 +27,7 @@
 # OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
 import torch
+import torchvision
 
 
 class ResNet50(torch.nn.Module):
@@ -35,7 +36,7 @@ class ResNet50(torch.nn.Module):
     def __init__(self):
         super().__init__()
         self._model = torch.hub.load(
-            "pytorch/vision",
+            "pytorch/vision:v" + torchvision.__version__.split("+")[0],
             "resnet50",
             weights="ResNet50_Weights.IMAGENET1K_V2",
             skip_validation=True,


### PR DESCRIPTION
This is a quick fix to ensure the model loaded is composed of the currently installed torchvision version.