### PR TITLE
Add Python backend request cancellation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,6 +150,8 @@ set(
   src/pb_error.h
   src/pb_log.cc
   src/pb_log.h
+  src/pb_cancel.cc
+  src/pb_cancel.h
   src/pb_memory.cc
   src/pb_memory.h
   src/pb_tensor.cc

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -150,8 +150,6 @@ set(
   src/pb_error.h
   src/pb_log.cc
   src/pb_log.h
-  src/pb_cancel.cc
-  src/pb_cancel.h
   src/pb_memory.cc
   src/pb_memory.h
   src/pb_tensor.cc
@@ -210,6 +208,8 @@ set(
   src/pb_stub.cc
   src/pb_response_iterator.h
   src/pb_response_iterator.cc
+  src/pb_cancel.cc
+  src/pb_cancel.h
 )
 
 list(APPEND

--- a/README.md
+++ b/README.md
@@ -502,6 +502,7 @@ Supported error codes:
 * `pb_utils.TritonError.UNAVAILABLE`
 * `pb_utils.TritonError.UNSUPPORTED`
 * `pb_utils.TritonError.ALREADY_EXISTS`
+* `pb_utils.TritonError.CANCELLED` (since 23.10)
 
 #### Decoupled mode
 

--- a/README.md
+++ b/README.md
@@ -576,9 +576,7 @@ object, use InferenceResponseSender.send() to send response with the
 error back to the user.
 
 Starting from 23.10, request cancellation can be checked directly on the
-`InferenceResponseSender` object using `response_sender.is_cancelled()`. If
-`response_sender.is_cancelled()` returned `True`, then no further steps are
-needed to be performed on this object.
+`InferenceResponseSender` object using `response_sender.is_cancelled()`.
 
 ##### Use Cases
 

--- a/README.md
+++ b/README.md
@@ -508,10 +508,10 @@ Supported error codes:
 #### Request Cancellation Handling
 
 One or more requests may be cancelled by the client during execution. Starting
-from 23.10, `request.is_cancelled()` returns up-to-date `True` or `False` on
-whether the request is cancelled. If a request is cancelled, the model may
-respond with any dummy object in place of the normal output tensors on the
-request. For example:
+from 23.10, `request.is_cancelled()` returns whether the request is cancelled.
+
+If a request is cancelled, the model may respond with any dummy object in place
+of the normal output tensors on the request. For example:
 
 ```python
 import triton_python_backend_utils as pb_utils
@@ -576,10 +576,9 @@ object, use InferenceResponseSender.send() to send response with the
 error back to the user.
 
 Starting from 23.10, request cancellation can be checked directly on the
-`InferenceResponseSender` object, for example `response_sender.is_cancelled()`,
-even after the request has gone out-of-scope. If
-`response_sender.is_cancelled()` returned `True`, the
-TRITONSERVER_RESPONSE_COMPLETE_FINAL flag is sent automatically.
+`InferenceResponseSender` object using `response_sender.is_cancelled()`. If
+`response_sender.is_cancelled()` returned `True`, then no further steps are
+needed to be performed on this object.
 
 ##### Use Cases
 

--- a/README.md
+++ b/README.md
@@ -575,7 +575,9 @@ object, use InferenceResponseSender.send() to send response with the
 error back to the user.
 
 Starting from 23.10, request cancellation can be checked directly on the
-`InferenceResponseSender` object using `response_sender.is_cancelled()`.
+`InferenceResponseSender` object using `response_sender.is_cancelled()`. Sending
+the TRITONSERVER_RESPONSE_COMPLETE_FINAL flag at the end of response is still
+needed even the request is cancelled.
 
 ##### Use Cases
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ any C++ code.
     - [`execute`](#execute)
       - [Default Mode](#default-mode)
       - [Error Handling](#error-handling)
-      - [Request Cancellation](#request-cancellation)
+      - [Request Cancellation Handling](#request-cancellation-handling)
       - [Decoupled mode](#decoupled-mode)
         - [Use Cases](#use-cases)
         - [Known Issues](#known-issues)
@@ -505,13 +505,13 @@ Supported error codes:
 * `pb_utils.TritonError.ALREADY_EXISTS`
 * `pb_utils.TritonError.CANCELLED` (since 23.10)
 
-#### Request Cancellation
+#### Request Cancellation Handling
 
-One or more requests may be cancelled during execution, for example, cancelled
-by the user. Starting from 23.10, `request.is_cancelled()` returns up-to-date
-`True` or `False` on whether the request is cancelled. If a request is
-cancelled, the model should respond `pb_utils.TritonError.CANCELLED` in place of
-the normal output tensors on the request. For example:
+One or more requests may be cancelled by the client during execution. Starting
+from 23.10, `request.is_cancelled()` returns up-to-date `True` or `False` on
+whether the request is cancelled. If a request is cancelled, the model may
+respond with any dummy object in place of the normal output tensors on the
+request. For example:
 
 ```python
 import triton_python_backend_utils as pb_utils
@@ -524,8 +524,7 @@ class TritonPythonModel:
 
         for request in requests:
             if request.is_cancelled():
-                responses.append(pb_utils.InferenceResponse(
-                    error=pb_utils.TritonError("Message", pb_utils.TritonError.CANCELLED)))
+                responses.append(None)
             else:
                 ...
 
@@ -576,6 +575,12 @@ request. After setting errors for an pb_utils.InferenceResponse
 object, use InferenceResponseSender.send() to send response with the
 error back to the user.
 
+Starting from 23.10, request cancellation can be checked directly on the
+`InferenceResponseSender` object, for example `response_sender.is_cancelled()`,
+even after the request has gone out-of-scope. If
+`response_sender.is_cancelled()` returned `True`, the
+TRITONSERVER_RESPONSE_COMPLETE_FINAL flag is sent automatically.
+
 ##### Use Cases
 
 The decoupled mode is powerful and supports various other use cases:
@@ -597,6 +602,8 @@ The [decoupled examples](examples/decoupled/README.md) demonstrate
 full power of what can be achieved from decoupled API. Read
 [Decoupled Backends and Models](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/decoupled_models.md)
 for more details on how to host a decoupled model.
+
+#####
 
 ##### Known Issues
 

--- a/README.md
+++ b/README.md
@@ -508,10 +508,8 @@ Supported error codes:
 #### Request Cancellation Handling
 
 One or more requests may be cancelled by the client during execution. Starting
-from 23.10, `request.is_cancelled()` returns whether the request is cancelled.
-
-If a request is cancelled, the model may respond with any dummy object in place
-of the normal output tensors on the request. For example:
+from 23.10, `request.is_cancelled()` returns whether the request is cancelled or
+not. For example:
 
 ```python
 import triton_python_backend_utils as pb_utils
@@ -524,7 +522,8 @@ class TritonPythonModel:
 
         for request in requests:
             if request.is_cancelled():
-                responses.append(None)
+                responses.append(pb_utils.InferenceResponse(
+                    error=pb_utils.TritonError("Message", pb_utils.TritonError.CANCELLED)))
             else:
                 ...
 
@@ -599,8 +598,6 @@ The [decoupled examples](examples/decoupled/README.md) demonstrate
 full power of what can be achieved from decoupled API. Read
 [Decoupled Backends and Models](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/decoupled_models.md)
 for more details on how to host a decoupled model.
-
-#####
 
 ##### Known Issues
 

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -410,12 +410,6 @@ InferRequest::IsCancelled()
   return pb_cancel_->IsCancelled();
 }
 
-bool
-InferRequest::IsCancelledLastResponse()
-{
-  return pb_cancel_->IsCancelledInternalFlag();
-}
-
 std::shared_ptr<ResponseSender>
 InferRequest::GetResponseSender()
 {

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -400,6 +400,23 @@ InferRequest::DeleteResponseFactory()
 #endif
 
 #ifdef TRITON_PB_STUB
+bool
+InferRequest::IsCancelled()
+{
+  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
+  if (!stub->StubToParentServiceActive()) {
+    LOG_ERROR << "Cannot communicate with parent service";
+    return false;
+  }
+  if (request_address_ == 0) {
+    LOG_ERROR << "Request address not provided (default initialized?)";
+    return false;
+  }
+  std::unique_ptr<PbCancel> pb_cancel(new PbCancel(request_address_));
+  stub->EnqueueIsCancelled(pb_cancel);
+  return pb_cancel->IsCancelled();
+}
+
 std::shared_ptr<ResponseSender>
 InferRequest::GetResponseSender()
 {

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -408,11 +408,8 @@ InferRequest::IsCancelled()
     LOG_ERROR << "Cannot communicate with parent service";
     return false;
   }
-  if (request_address_ == 0) {
-    LOG_ERROR << "Request address not provided (default initialized?)";
-    return false;
-  }
-  std::unique_ptr<PbCancel> pb_cancel(new PbCancel(request_address_));
+  std::unique_ptr<PbCancel> pb_cancel(
+      new PbCancel(response_factory_address_, request_address_));
   stub->EnqueueIsCancelled(pb_cancel);
   return pb_cancel->IsCancelled();
 }

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -408,10 +408,9 @@ InferRequest::IsCancelled()
     LOG_ERROR << "Cannot communicate with parent service";
     return false;
   }
-  std::unique_ptr<PbCancel> pb_cancel(
-      new PbCancel(response_factory_address_, request_address_));
-  stub->EnqueueIsCancelled(pb_cancel);
-  return pb_cancel->IsCancelled();
+  PbCancel pb_cancel(response_factory_address_, request_address_);
+  stub->EnqueueIsCancelled(&pb_cancel);
+  return pb_cancel.IsCancelled();
 }
 
 std::shared_ptr<ResponseSender>

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -34,6 +34,7 @@
 #include "pb_tensor.h"
 
 #ifdef TRITON_PB_STUB
+#include "pb_cancel.h"
 #include "response_sender.h"
 #endif
 
@@ -108,6 +109,7 @@ class InferRequest {
   std::shared_ptr<InferResponse> Exec(const bool is_decoupled);
   std::shared_ptr<ResponseSender> GetResponseSender();
   bool IsCancelled();
+  bool IsCancelledLastResponse();
 #endif
 
   /// Save an Inference Request to shared memory.
@@ -174,6 +176,7 @@ class InferRequest {
   std::unique_ptr<PbString> parameters_shm_;
 
 #ifdef TRITON_PB_STUB
+  std::shared_ptr<PbCancel> pb_cancel_;
   std::shared_ptr<ResponseSender> response_sender_;
 #endif
 };

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -109,7 +109,6 @@ class InferRequest {
   std::shared_ptr<InferResponse> Exec(const bool is_decoupled);
   std::shared_ptr<ResponseSender> GetResponseSender();
   bool IsCancelled();
-  bool IsCancelledLastResponse();
 #endif
 
   /// Save an Inference Request to shared memory.

--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -107,6 +107,7 @@ class InferRequest {
 #ifdef TRITON_PB_STUB
   std::shared_ptr<InferResponse> Exec(const bool is_decoupled);
   std::shared_ptr<ResponseSender> GetResponseSender();
+  bool IsCancelled();
 #endif
 
   /// Save an Inference Request to shared memory.

--- a/src/ipc_message.h
+++ b/src/ipc_message.h
@@ -62,7 +62,8 @@ typedef enum PYTHONSTUB_commandtype_enum {
   PYTHONSTUB_MetricRequestSet,
   PYTHONSTUB_LoadModelRequest,
   PYTHONSTUB_UnloadModelRequest,
-  PYTHONSTUB_ModelReadinessRequest
+  PYTHONSTUB_ModelReadinessRequest,
+  PYTHONSTUB_IsRequestCancelled
 } PYTHONSTUB_CommandType;
 
 ///

--- a/src/pb_cancel.cc
+++ b/src/pb_cancel.cc
@@ -35,6 +35,7 @@ PbCancel::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
   new (&(cancel_shm_.data_->mu)) bi::interprocess_mutex;
   new (&(cancel_shm_.data_->cv)) bi::interprocess_condition;
   cancel_shm_.data_->waiting_on_stub = false;
+  cancel_shm_.data_->response_factory_address = response_factory_address_;
   cancel_shm_.data_->request_address = request_address_;
   cancel_shm_.data_->is_cancelled = is_cancelled_;
 }

--- a/src/pb_cancel.cc
+++ b/src/pb_cancel.cc
@@ -1,0 +1,73 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#include "pb_cancel.h"
+
+namespace triton { namespace backend { namespace python {
+
+void
+PbCancel::SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool)
+{
+  cancel_shm_ = shm_pool->Construct<IsCancelledMessage>();
+  new (&(cancel_shm_.data_->mu)) bi::interprocess_mutex;
+  new (&(cancel_shm_.data_->cv)) bi::interprocess_condition;
+  cancel_shm_.data_->waiting_on_stub = false;
+  cancel_shm_.data_->request_address = request_address_;
+  cancel_shm_.data_->is_cancelled = is_cancelled_;
+}
+
+bi::managed_external_buffer::handle_t
+PbCancel::ShmHandle()
+{
+  return cancel_shm_.handle_;
+}
+
+IsCancelledMessage*
+PbCancel::ShmPayload()
+{
+  return cancel_shm_.data_.get();
+}
+
+bool
+PbCancel::IsCancelled()
+{
+  std::unique_lock<std::mutex> lk(mu_);
+  cv_.wait(lk, [this] { return updated_; });
+  return is_cancelled_;
+}
+
+void
+PbCancel::ReportIsCancelled(bool is_cancelled)
+{
+  {
+    std::lock_guard<std::mutex> lk(mu_);
+    is_cancelled_ = is_cancelled;
+    updated_ = true;
+  }
+  cv_.notify_all();
+}
+
+}}}  // namespace triton::backend::python

--- a/src/pb_cancel.cc
+++ b/src/pb_cancel.cc
@@ -55,12 +55,6 @@ PbCancel::ShmPayload()
 }
 
 bool
-PbCancel::IsCancelledInternalFlag()
-{
-  return is_cancelled_;
-}
-
-bool
 PbCancel::IsCancelled()
 {
   std::unique_lock<std::mutex> lk(mu_);

--- a/src/pb_cancel.h
+++ b/src/pb_cancel.h
@@ -36,7 +36,7 @@ namespace triton { namespace backend { namespace python {
 class PbCancel {
  public:
   PbCancel(intptr_t response_factory_address, intptr_t request_address)
-      : updated_(false), response_factory_address_(response_factory_address),
+      : updating_(false), response_factory_address_(response_factory_address),
         request_address_(request_address), is_cancelled_(false)
   {
   }
@@ -46,6 +46,8 @@ class PbCancel {
   bi::managed_external_buffer::handle_t ShmHandle();
   IsCancelledMessage* ShmPayload();
 
+  bool IsCancelledInternalFlag();
+
   bool IsCancelled();
   void ReportIsCancelled(bool is_cancelled);
 
@@ -54,7 +56,7 @@ class PbCancel {
 
   std::mutex mu_;
   std::condition_variable cv_;
-  bool updated_;
+  bool updating_;
 
   intptr_t response_factory_address_;
   intptr_t request_address_;

--- a/src/pb_cancel.h
+++ b/src/pb_cancel.h
@@ -1,0 +1,62 @@
+// Copyright 2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+//
+// Redistribution and use in source and binary forms, with or without
+// modification, are permitted provided that the following conditions
+// are met:
+//  * Redistributions of source code must retain the above copyright
+//    notice, this list of conditions and the following disclaimer.
+//  * Redistributions in binary form must reproduce the above copyright
+//    notice, this list of conditions and the following disclaimer in the
+//    documentation and/or other materials provided with the distribution.
+//  * Neither the name of NVIDIA CORPORATION nor the names of its
+//    contributors may be used to endorse or promote products derived
+//    from this software without specific prior written permission.
+//
+// THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS ``AS IS'' AND ANY
+// EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+// IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR
+// PURPOSE ARE DISCLAIMED.  IN NO EVENT SHALL THE COPYRIGHT OWNER OR
+// CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL,
+// EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT LIMITED TO,
+// PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA, OR
+// PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY
+// OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+// (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+// OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+
+#pragma once
+
+#include <condition_variable>
+#include <mutex>
+
+#include "pb_utils.h"
+
+namespace triton { namespace backend { namespace python {
+
+class PbCancel {
+ public:
+  PbCancel(intptr_t request_address)
+      : updated_(false), request_address_(request_address), is_cancelled_(false)
+  {
+  }
+  DISALLOW_COPY_AND_ASSIGN(PbCancel);
+
+  void SaveToSharedMemory(std::unique_ptr<SharedMemoryManager>& shm_pool);
+  bi::managed_external_buffer::handle_t ShmHandle();
+  IsCancelledMessage* ShmPayload();
+
+  bool IsCancelled();
+  void ReportIsCancelled(bool is_cancelled);
+
+ private:
+  AllocatedSharedMemory<IsCancelledMessage> cancel_shm_;
+
+  std::mutex mu_;
+  std::condition_variable cv_;
+  bool updated_;
+
+  intptr_t request_address_;
+  bool is_cancelled_;
+};
+
+}}};  // namespace triton::backend::python

--- a/src/pb_cancel.h
+++ b/src/pb_cancel.h
@@ -46,8 +46,6 @@ class PbCancel {
   bi::managed_external_buffer::handle_t ShmHandle();
   IsCancelledMessage* ShmPayload();
 
-  bool IsCancelledInternalFlag();
-
   bool IsCancelled();
   void ReportIsCancelled(bool is_cancelled);
 

--- a/src/pb_cancel.h
+++ b/src/pb_cancel.h
@@ -35,8 +35,9 @@ namespace triton { namespace backend { namespace python {
 
 class PbCancel {
  public:
-  PbCancel(intptr_t request_address)
-      : updated_(false), request_address_(request_address), is_cancelled_(false)
+  PbCancel(intptr_t response_factory_address, intptr_t request_address)
+      : updated_(false), response_factory_address_(response_factory_address),
+        request_address_(request_address), is_cancelled_(false)
   {
   }
   DISALLOW_COPY_AND_ASSIGN(PbCancel);
@@ -55,6 +56,7 @@ class PbCancel {
   std::condition_variable cv_;
   bool updated_;
 
+  intptr_t response_factory_address_;
   intptr_t request_address_;
   bool is_cancelled_;
 };

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -771,17 +771,10 @@ Stub::ProcessRequests(RequestBatch* request_batch_shm_ptr)
           std::to_string(response_size) + "\n";
       throw PythonBackendException(err);
     }
-    for (size_t i = 0; i < response_size; i++) {
-      // If the model has checked for cancellation and the request is cancelled,
-      // replace returned type with a cancelled response.
-      if (py_request_list[i].cast<InferRequest*>()->IsCancelledLastResponse()) {
-        responses[i] = std::make_shared<InferResponse>(
-            std::vector<std::shared_ptr<PbTensor>>{},
-            std::make_shared<PbError>("", TRITONSERVER_ERROR_CANCELLED));
-      }
+    for (auto& response : responses) {
       // Check the return type of execute function.
-      else if (!py::isinstance<InferResponse>(responses[i])) {
-        std::string str = py::str(responses[i].get_type());
+      if (!py::isinstance<InferResponse>(response)) {
+        std::string str = py::str(response.get_type());
         throw PythonBackendException(
             std::string("Expected an 'InferenceResponse' object in the execute "
                         "function return list, found type '") +

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -771,10 +771,17 @@ Stub::ProcessRequests(RequestBatch* request_batch_shm_ptr)
           std::to_string(response_size) + "\n";
       throw PythonBackendException(err);
     }
-    for (auto& response : responses) {
+    for (size_t i = 0; i < response_size; i++) {
+      // If the model has checked for cancellation and the request is cancelled,
+      // replace returned type with a cancelled response.
+      if (py_request_list[i].cast<InferRequest*>()->IsCancelledLastResponse()) {
+        responses[i] = std::make_shared<InferResponse>(
+            std::vector<std::shared_ptr<PbTensor>>{},
+            std::make_shared<PbError>("", TRITONSERVER_ERROR_CANCELLED));
+      }
       // Check the return type of execute function.
-      if (!py::isinstance<InferResponse>(response)) {
-        std::string str = py::str(response.get_type());
+      else if (!py::isinstance<InferResponse>(responses[i])) {
+        std::string str = py::str(responses[i].get_type());
         throw PythonBackendException(
             std::string("Expected an 'InferenceResponse' object in the execute "
                         "function return list, found type '") +

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1032,12 +1032,11 @@ Stub::EnqueueCleanupId(void* id)
 }
 
 void
-Stub::EnqueueIsCancelled(const std::unique_ptr<PbCancel>& pb_cancel)
+Stub::EnqueueIsCancelled(PbCancel* pb_cancel)
 {
   std::unique_ptr<UtilsMessagePayload> utils_msg_payload =
       std::make_unique<UtilsMessagePayload>(
-          PYTHONSTUB_IsRequestCancelled,
-          reinterpret_cast<void*>(pb_cancel.get()));
+          PYTHONSTUB_IsRequestCancelled, reinterpret_cast<void*>(pb_cancel));
   EnqueueUtilsMessage(std::move(utils_msg_payload));
 }
 

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1364,6 +1364,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
       .value(
           "ALREADY_EXISTS",
           TRITONSERVER_Error_Code::TRITONSERVER_ERROR_ALREADY_EXISTS)
+      .value("CANCELLED", TRITONSERVER_Error_Code::TRITONSERVER_ERROR_CANCELLED)
       .export_values();
   triton_error.def_property_readonly_static(
       "UNKNOWN",
@@ -1386,6 +1387,9 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
   triton_error.def_property_readonly_static(
       "ALREADY_EXISTS",
       [](py::object /* self */) { return TRITONSERVER_ERROR_ALREADY_EXISTS; });
+  triton_error.def_property_readonly_static(
+      "CANCELLED",
+      [](py::object /* self */) { return TRITONSERVER_ERROR_CANCELLED; });
   triton_error.def(
       py::init<const std::string&, TRITONSERVER_Error_Code>(),
       py::arg("message").none(false),

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1585,7 +1585,8 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
       module, "InferenceResponseSender")
       .def(
           "send", &ResponseSender::Send, py::arg("response") = nullptr,
-          py::arg("flags") = 0);
+          py::arg("flags") = 0)
+      .def("is_cancelled", &ResponseSender::IsCancelled);
 
   py::class_<ResponseIterator, std::shared_ptr<ResponseIterator>>(
       module, "ResponseIterator")

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -310,7 +310,7 @@ class Stub {
   void EnqueueCleanupId(void* id);
 
   /// Add request cancellation query to queue
-  void EnqueueIsCancelled(const std::unique_ptr<PbCancel>& pb_cancel);
+  void EnqueueIsCancelled(PbCancel* pb_cancel);
 
   /// Send request cancellation query to python backend
   void SendIsCancelled(std::unique_ptr<UtilsMessagePayload>& utils_msg_payload);

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -49,6 +49,7 @@
 #include "message_queue.h"
 #include "metric.h"
 #include "metric_family.h"
+#include "pb_cancel.h"
 #include "pb_log.h"
 #include "pb_response_iterator.h"
 #include "pb_utils.h"
@@ -307,6 +308,12 @@ class Stub {
 
   /// Add cleanup id to queue
   void EnqueueCleanupId(void* id);
+
+  /// Add request cancellation query to queue
+  void EnqueueIsCancelled(const std::unique_ptr<PbCancel>& pb_cancel);
+
+  /// Send request cancellation query to python backend
+  void SendIsCancelled(std::unique_ptr<UtilsMessagePayload>& utils_msg_payload);
 
   /// Is the stub initialized
   bool IsInitialized();

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -183,6 +183,7 @@ struct CleanupMessage : SendMessageBase {
 };
 
 struct IsCancelledMessage : SendMessageBase {
+  intptr_t response_factory_address;
   intptr_t request_address;
   bool is_cancelled;
 };

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -182,6 +182,11 @@ struct CleanupMessage : SendMessageBase {
   void* id;
 };
 
+struct IsCancelledMessage : SendMessageBase {
+  intptr_t request_address;
+  bool is_cancelled;
+};
+
 struct CustomMetricsMessage : SendMessageBase {
   bi::managed_external_buffer::handle_t message;
   bool has_error;

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -945,9 +945,7 @@ ModelInstanceState::ProcessIsRequestCancelled(
           message_payload->request_address);
       TRITONBACKEND_RequestIsCancelled(request, &message_payload->is_cancelled);
     } else {
-      LOG_MESSAGE(
-          TRITONSERVER_LOG_ERROR, "Cannot determine request cancellation");
-      message_payload->is_cancelled = false;
+      throw PythonBackendException("Cannot determine request cancellation");
     }
 
     message_payload->waiting_on_stub = true;

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -817,6 +817,10 @@ ModelInstanceState::StubToParentMQMonitor()
         ProcessBLSCleanupRequest(message);
         break;
       }
+      case PYTHONSTUB_IsRequestCancelled: {
+        ProcessIsRequestCancelled(message);
+        break;
+      }
       case PYTHONSTUB_MetricFamilyRequestNew:
       case PYTHONSTUB_MetricFamilyRequestDelete: {
         ProcessMetricFamilyRequest(message);
@@ -915,6 +919,30 @@ ModelInstanceState::ProcessBLSCleanupRequest(
     bi::scoped_lock<bi::interprocess_mutex> lock{*(message->ResponseMutex())};
     cleanup_message_ptr->waiting_on_stub = true;
     message->ResponseCondition()->notify_all();
+  }
+}
+
+void
+ModelInstanceState::ProcessIsRequestCancelled(
+    const std::unique_ptr<IPCMessage>& message)
+{
+  AllocatedSharedMemory<IsCancelledMessage> message_shm =
+      Stub()->ShmPool()->Load<IsCancelledMessage>(message->Args());
+  IsCancelledMessage* message_payload =
+      reinterpret_cast<IsCancelledMessage*>(message_shm.data_.get());
+
+  {
+    bi::scoped_lock<bi::interprocess_mutex> lk{message_payload->mu};
+
+    TRITONBACKEND_Request* request = reinterpret_cast<TRITONBACKEND_Request*>(
+        message_payload->request_address);
+    TRITONBACKEND_RequestIsCancelled(request, &message_payload->is_cancelled);
+
+    message_payload->waiting_on_stub = true;
+    message_payload->cv.notify_all();
+    while (message_payload->waiting_on_stub) {
+      message_payload->cv.wait(lk);
+    }
   }
 }
 

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -394,6 +394,9 @@ class ModelInstanceState : public BackendModelInstance {
   // Process the bls decoupled cleanup request
   void ProcessBLSCleanupRequest(const std::unique_ptr<IPCMessage>& message);
 
+  // Process request cancellation query
+  void ProcessIsRequestCancelled(const std::unique_ptr<IPCMessage>& message);
+
   // Process a message. The function 'request_handler' is invoked
   // to handle the request. T should be either 'MetricFamily', 'Metric' or
   // 'ModelLoader', and MessageType should be either 'MetricFamilyMessage',

--- a/src/response_sender.cc
+++ b/src/response_sender.cc
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/response_sender.cc
+++ b/src/response_sender.cc
@@ -184,4 +184,18 @@ ResponseSender::Send(
     }
   }
 }
+
+bool
+ResponseSender::IsCancelled()
+{
+  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
+  if (!stub->StubToParentServiceActive()) {
+    LOG_ERROR << "Cannot communicate with parent service";
+    return false;
+  }
+  PbCancel pb_cancel(response_factory_address_, request_address_);
+  stub->EnqueueIsCancelled(&pb_cancel);
+  return pb_cancel.IsCancelled();
+}
+
 }}}  // namespace triton::backend::python

--- a/src/response_sender.cc
+++ b/src/response_sender.cc
@@ -189,11 +189,7 @@ ResponseSender::Send(
 bool
 ResponseSender::IsCancelled()
 {
-  bool is_cancelled = pb_cancel_->IsCancelled();
-  if (is_cancelled && !closed_) {
-    Send(nullptr, TRITONSERVER_RESPONSE_COMPLETE_FINAL);
-  }
-  return is_cancelled;
+  return pb_cancel_->IsCancelled();
 }
 
 }}}  // namespace triton::backend::python

--- a/src/response_sender.h
+++ b/src/response_sender.h
@@ -1,4 +1,4 @@
-// Copyright (c) 2022, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/response_sender.h
+++ b/src/response_sender.h
@@ -37,6 +37,7 @@ class ResponseSender {
       intptr_t request_address, intptr_t response_factory_address,
       std::unique_ptr<SharedMemoryManager>& shm_pool);
   void Send(std::shared_ptr<InferResponse> response, const uint32_t flags);
+  bool IsCancelled();
 
  private:
   intptr_t request_address_;

--- a/src/response_sender.h
+++ b/src/response_sender.h
@@ -27,6 +27,7 @@
 #pragma once
 
 #include "infer_response.h"
+#include "pb_cancel.h"
 #include "shm_manager.h"
 
 namespace triton { namespace backend { namespace python {
@@ -35,7 +36,8 @@ class ResponseSender {
  public:
   ResponseSender(
       intptr_t request_address, intptr_t response_factory_address,
-      std::unique_ptr<SharedMemoryManager>& shm_pool);
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
+      const std::shared_ptr<PbCancel>& pb_cancel);
   void Send(std::shared_ptr<InferResponse> response, const uint32_t flags);
   bool IsCancelled();
 
@@ -44,5 +46,6 @@ class ResponseSender {
   intptr_t response_factory_address_;
   std::unique_ptr<SharedMemoryManager>& shm_pool_;
   bool closed_;
+  std::shared_ptr<PbCancel> pb_cancel_;
 };
 }}}  // namespace triton::backend::python


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/server/pull/6364

Add `is_cancelled()` check API into Python model requests, and allow Python model to respond request cancelled.