### PR TITLE
Include missing unordered_map in shm

### DIFF
--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -38,6 +38,7 @@
 #include <type_traits>
 #include <typeinfo>
 #include <vector>
+#include <unordered_map>
 
 #include "pb_exception.h"
 


### PR DESCRIPTION
I tried to build triton for Ubuntu 20.04 and compilation fails with missing unordered_map:

```
cd /tmp/tritonbuild/python/build/_deps/repo-common-build/src/test/triton_json && /usr/bin/c++  -I/tmp/tritonbuild/python/build/_deps/repo-common-src/src/test/triton_json/../../../include -I/tmp/tritonbuild/python/build/_deps/repo-common-src/src/test/triton_json -isystem /tmp/tritonbuild/python/build/_deps/googletest-src/googletest/include -isystem /tmp/tritonbuild/python/build/_deps/googletest-src/googletest -O3 -DNDEBUG -pthread -MD -MT _deps/repo-common-build/src/test/triton_json/CMakeFiles/triton-json-test.dir/__/__/error.cc.o -MF CMakeFiles/triton-json-test.dir/__/__/error.cc.o.d -o CMakeFiles/triton-json-test.dir/__/__/error.cc.o -c /tmp/tritonbuild/python/build/_deps/repo-common-src/src/error.cc
In file included from /tmp/tritonbuild/python/src/ipc_message.h:32,
                 from /tmp/tritonbuild/python/src/ipc_message.cc:27:
/tmp/tritonbuild/python/src/shm_manager.h:62:8: error: 'unordered_map' in namespace 'std' does not name a template type
   62 |   std::unordered_map<int32_t, void*>& CUDAPoolAddressMap();
      |        ^~~~~~~~~~~~~
/tmp/tritonbuild/python/src/shm_manager.h:43:1: note: 'std::unordered_map' is defined in header '<unordered_map>'; did you forget to '#include <unordered_map>'?
   42 | #include "pb_exception.h"
  +++ |+#include <unordered_map>
   43 | 
```

Build command:

```
python3 build.py -v --backend python --cache loca
```

Local modification for 20.04 build:

```diff
diff --git a/Dockerfile.sdk b/Dockerfile.sdk
index 1881f6c0..678c4ad0 100644
--- a/Dockerfile.sdk
+++ b/Dockerfile.sdk
@@ -29,7 +29,7 @@
 #
 
 # Base image on the minimum Triton container
-ARG BASE_IMAGE=nvcr.io/nvidia/tritonserver:23.09-py3-min
+ARG BASE_IMAGE=ubuntu:20.04
 
 ARG TRITON_CLIENT_REPO_SUBDIR=clientrepo
 ARG TRITON_COMMON_REPO_TAG=main
diff --git a/build.py b/build.py
index 1c98c2f0..9ca12e09 100755
--- a/build.py
+++ b/build.py
@@ -72,7 +72,7 @@ import requests
 TRITON_VERSION_MAP = {
     "2.40.0dev": (
         "23.11dev",  # triton container
-        "23.09",  # upstream container
+        "23.04",  # upstream container
         "1.16.0",  # ORT
         "2023.0.0",  # ORT OpenVINO
         "2023.0.0",  # Standalone OpenVINO
@@ -1246,7 +1246,7 @@ RUN apt-get update && \
             software-properties-common \
             libb64-0d \
             libcurl4-openssl-dev \
-            libre2-9 \
+            libre2-5 \
             git \
             gperf \
             dirmngr \
@@ -1511,7 +1511,7 @@ def create_build_dockerfiles(
             FLAGS.upstream_container_version
         )
     else:
-        base_image = "ubuntu:22.04"
+        base_image = "ubuntu:20.04"
 
     dockerfileargmap = {
         "NVIDIA_BUILD_REF": "" if FLAGS.build_sha is None else FLAGS.build_sha,
```