### PR TITLE
Follow up to autocomplete pr #317

### DIFF
--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1862,7 +1862,6 @@ ModelState::Create(TRITONBACKEND_Model* triton_model, ModelState** state)
     RETURN_IF_ERROR((*state)->LaunchAutoCompleteStubProcess());
     (*state)->ModelConfig() = std::move((*state)->Stub()->AutoCompleteConfig());
     RETURN_IF_ERROR((*state)->SetModelConfig());
-    RETURN_IF_ERROR((*state)->PropagateAutoCompletedConfig());
 
     (*state)->Stub()->UpdateHealth();
     (*state)->Stub()->TerminateStub();
@@ -2007,8 +2006,9 @@ ModelState::ValidateModelConfig()
 }
 
 TRITONSERVER_Error*
-ModelState::PropagateAutoCompletedConfig()
+ModelState::SetModelConfig()
 {
+  BackendModel::SetModelConfig();
   // `Update model_transaction_policy` if setting was set
   // with `set_model_transaction_policy`
   triton::common::TritonJson::Value model_transaction_policy;

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -250,9 +250,9 @@ class ModelState : public BackendModel {
   // Validate Model Configuration
   TRITONSERVER_Error* ValidateModelConfig();
 
-  // Update values set during auto_complete to `ModelState`
-  // Currently only updates `decoupled_`
-  TRITONSERVER_Error* PropagateAutoCompletedConfig();
+  // Overrides `BackendModel::SetModelConfig` to also
+  // set `ModelState::decoupled_`
+  TRITONSERVER_Error* SetModelConfig();
 
   // Auto-complete stub
   std::unique_ptr<StubLauncher>& Stub() { return auto_complete_stub_; }

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -238,6 +238,9 @@ class ModelState : public BackendModel {
   // Is decoupled API being used.
   bool IsDecoupled() { return decoupled_; }
 
+  // Set decoupled mode
+  void SetDecoupled(bool decoupled) { decoupled_ = decoupled; }
+
   // Returns the value in the `runtime_modeldir_` field
   std::string RuntimeModelDir() { return runtime_modeldir_; }
 

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -250,6 +250,10 @@ class ModelState : public BackendModel {
   // Validate Model Configuration
   TRITONSERVER_Error* ValidateModelConfig();
 
+  // Update values set during auto_complete to `ModelState`
+  // Currently only updates `decoupled_`
+  TRITONSERVER_Error* PropagateAutoCompletedConfig();
+
   // Auto-complete stub
   std::unique_ptr<StubLauncher>& Stub() { return auto_complete_stub_; }
 

--- a/src/resources/triton_python_backend_utils.py
+++ b/src/resources/triton_python_backend_utils.py
@@ -394,7 +394,7 @@ class ModelConfig:
                     + input["name"]
                     + "' in auto-complete-config function for model '"
                     + self._model_config["name"]
-                    + "' contains property other than 'name', 'data_type' and 'dims'."
+                    + "' contains property other than 'name', 'data_type', 'dims' and 'optional'."
                 )
 
         if "name" not in input:


### PR DESCRIPTION
This is a follow up PR to : #317 . Unfortunately, I missed essential part.

After we retrieved updated model configuration from core during the call:
https://github.com/triton-inference-server/python_backend/blob/0f1221129a01b067b93a4abc4a2c30a9e2856e01/src/python_be.cc#L1864

`decoupled_` is not updated on the python backend site, since it is a part of `ModelState`. 

I've added `PropagateAutoCompletedConfig() ` that does exactly that, i.e. looks for `model_transaction_policy` in the model config (already filled by core), and if `decoupled` is found in `model_transaction_policy` , we update `decoupled_` property.

Actual functionality is tested with vllm backend on this PR: https://github.com/triton-inference-server/vllm_backend/pull/20 
