### PR TITLE
Add debug mode support for python backend

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -447,6 +447,21 @@ Stub::StubSetup()
   deserialize_bytes_ = python_backend_utils.attr("deserialize_bytes_tensor");
   serialize_bytes_ = python_backend_utils.attr("serialize_byte_tensor");
 
+  // add a debug mode for triton python backend
+  py::module os = py::module_::import("os");  
+  py::object env = os.attr("environ");  
+  std::string triton_debug = py::str(env.attr("get")("TRITON_DEBUG", "0"));
+  if (triton_debug == "1") {  
+    py::module debugpy = py::module_::import("debugpy");
+    std::string debug_port = py::str(env.attr("get")("TRITON_DEBUG_PORT", "8003"));  
+    int triton_debug_port = std::stoi(debug_port); 
+    LOG_INFO << "Running with debugpy mode on 0.0.0.0:" << triton_debug_port;
+    py::tuple listen_args(2);  
+    listen_args[0] = "0.0.0.0";  
+    listen_args[1] = triton_debug_port;  
+    debugpy.attr("listen")(listen_args);
+  }
+
   return sys;
 }
 


### PR DESCRIPTION
This commit introduces a debug mode for the Triton Python backend. When the environment variable `TRITON_DEBUG` is set to "1", the backend will import the `debugpy` module and start listening on a specified port (`TRITON_DEBUG_PORT`, default is 8003). This feature allows developers to debug their Python backend code with IDE like vscode more effectively.
