### PR TITLE
Fix BLS decoupled segfault and hang

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -465,7 +465,6 @@ InferRequest::Exec(const bool is_decoupled)
   });
 
   try {
-    py::gil_scoped_release release;
     ipc_message = IPCMessage::Create(shm_pool, true /* inline_response */);
     bool has_exception = false;
     PythonBackendException pb_exception(std::string{});
@@ -508,6 +507,13 @@ InferRequest::Exec(const bool is_decoupled)
 
     // Send the BLS request to the parent process and wait for the response.
     {
+      // Release the GIL before sending the message to the stub process. This
+      // avoids a potential deadlock situation in the parent process, where
+      // every thread in the thread pool is indirectly waiting for a function in
+      // the stub process that acquires the GIL. Meanwhile, the current thread,
+      // which holds the GIL, is also waiting for the parent side to have the
+      // next available thread to pick up the job during resource contention.
+      py::gil_scoped_release release;
       bi::scoped_lock<bi::interprocess_mutex> lock{
           *(ipc_message->ResponseMutex())};
       stub->SendIPCMessage(ipc_message);

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -752,7 +752,7 @@ ModelInstanceState::ExecuteBLSRequest(
         if (is_decoupled && (infer_response->Id() != nullptr)) {
           // Need to manage the lifetime of InferPayload object for bls
           // decoupled responses.
-          infer_payload_[reinterpret_cast<void*>(&infer_payload)] =
+          infer_payload_[reinterpret_cast<intptr_t>(infer_payload.get())] =
               infer_payload;
         }
 
@@ -943,7 +943,7 @@ ModelInstanceState::ProcessBLSCleanupRequest(
       reinterpret_cast<CleanupMessage*>(cleanup_request_message.data_.get());
 
   void* id = cleanup_message_ptr->id;
-  infer_payload_.erase(id);
+  infer_payload_.erase(reinterpret_cast<intptr_t>(id));
 
   {
     bi::scoped_lock<bi::interprocess_mutex> lock{*(message->ResponseMutex())};

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -430,22 +430,8 @@ ModelInstanceState::LaunchStubProcess()
   StartMonitor();
   RETURN_IF_ERROR(Stub()->Launch());
 
-  // Use the default thread pool for BLS requests, and the decoupled response
-  // thread pool for decoupled responses to avoid deadlock between the stub and
-  // the parent process. Only use the default thread pool when there is only one
-  // thread in the thread pool.
-  int thread_pool_size = model_state->StateForBackend()->thread_pool_size;
-  if (thread_pool_size > 1) {
-    int default_thread_pool_size = static_cast<int>(
-        std::round(static_cast<double>(thread_pool_size) * 2.0 / 3.0));
-    thread_pool_ =
-        std::make_unique<boost::asio::thread_pool>(default_thread_pool_size);
-    decoupled_response_thread_pool_ =
-        std::make_unique<boost::asio::thread_pool>(
-            thread_pool_size - default_thread_pool_size);
-  } else {
-    thread_pool_ = std::make_unique<boost::asio::thread_pool>(thread_pool_size);
-  }
+  thread_pool_ = std::make_unique<boost::asio::thread_pool>(
+      model_state->StateForBackend()->thread_pool_size);
 
   if (model_state->IsDecoupled()) {
     decoupled_thread_ = true;
@@ -825,12 +811,7 @@ ModelInstanceState::DecoupledMessageQueueMonitor()
       std::packaged_task<void()> task([this, response_send_message] {
         ResponseSendDecoupled(response_send_message);
       });
-      if (decoupled_response_thread_pool_ != nullptr) {
-        boost::asio::post(*decoupled_response_thread_pool_, std::move(task));
-      } else {
-        // If the thread pool only has one thread, use the default thread pool.
-        boost::asio::post(*thread_pool_, std::move(task));
-      }
+      boost::asio::post(*thread_pool_, std::move(task));
     } else if (
         message->Command() == PYTHONSTUB_InferExecRequest ||
         message->Command() == PYTHONSTUB_InferStreamExecRequest) {
@@ -1896,17 +1877,11 @@ ModelInstanceState::~ModelInstanceState()
     if (model_state->IsDecoupled()) {
       // Wait for all the pending tasks to finish.
       thread_pool_->wait();
-      if (decoupled_response_thread_pool_ != nullptr) {
-        decoupled_response_thread_pool_->wait();
-      }
       // Push a dummy message to signal the thread to terminate.
       Stub()->ParentMessageQueue()->Push(DUMMY_MESSAGE);
       decoupled_monitor_.join();
     } else {
       thread_pool_->wait();
-      if (decoupled_response_thread_pool_ != nullptr) {
-        decoupled_response_thread_pool_->wait();
-      }
     }
   }
   // Terminate stub first to allow any last messages to be received by the back

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -286,7 +286,7 @@ class ModelInstanceState : public BackendModelInstance {
   std::unique_ptr<IPCMessage> received_message_;
   std::vector<std::future<void>> futures_;
   std::unique_ptr<boost::asio::thread_pool> thread_pool_;
-  std::unordered_map<void*, std::shared_ptr<InferPayload>> infer_payload_;
+  std::unordered_map<intptr_t, std::shared_ptr<InferPayload>> infer_payload_;
   std::unique_ptr<RequestExecutor> request_executor_;
   std::mutex response_factory_map_mutex_;
   std::unordered_map<intptr_t, TRITONBACKEND_ResponseFactory*>

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -286,6 +286,7 @@ class ModelInstanceState : public BackendModelInstance {
   std::unique_ptr<IPCMessage> received_message_;
   std::vector<std::future<void>> futures_;
   std::unique_ptr<boost::asio::thread_pool> thread_pool_;
+  std::unique_ptr<boost::asio::thread_pool> decoupled_response_thread_pool_;
   std::unordered_map<intptr_t, std::shared_ptr<InferPayload>> infer_payload_;
   std::unique_ptr<RequestExecutor> request_executor_;
   std::mutex response_factory_map_mutex_;

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -286,7 +286,6 @@ class ModelInstanceState : public BackendModelInstance {
   std::unique_ptr<IPCMessage> received_message_;
   std::vector<std::future<void>> futures_;
   std::unique_ptr<boost::asio::thread_pool> thread_pool_;
-  std::unique_ptr<boost::asio::thread_pool> decoupled_response_thread_pool_;
   std::unordered_map<intptr_t, std::shared_ptr<InferPayload>> infer_payload_;
   std::unique_ptr<RequestExecutor> request_executor_;
   std::mutex response_factory_map_mutex_;

--- a/src/response_sender.cc
+++ b/src/response_sender.cc
@@ -114,6 +114,13 @@ ResponseSender::Send(
   });
 
   {
+    // Release the GIL before sending the message to the stub process. This
+    // avoids a potential deadlock situation in the parent process, where every
+    // thread in the thread pool is indirectly waiting for a function in the
+    // stub process that acquires the GIL. Meanwhile, the current thread, which
+    // holds the GIL, is also waiting for the parent side to have the next
+    // available thread to pick up the job during resource contention.
+    py::gil_scoped_release release;
     bi::scoped_lock<bi::interprocess_mutex> guard{send_message_payload->mu};
     stub->SendIPCMessage(ipc_message);
     while (!send_message_payload->is_stub_turn) {


### PR DESCRIPTION
This PR addresses the BLS decoupled segfault by correctly recording the `InferPayload` with the accurate address

Additionally, it resolves a hang occurring in the following scenario:
~~When the stub pushes a message of type `PYTHONSTUB_ResponseSend` to the queue, it [waits](https://github.com/triton-inference-server/python_backend/blob/main/src/response_sender.cc#L120) for the Python backend to complete. The queue is monitored by `DecoupledMessageQueueMonitor`. When there are numerous concurrent BLS requests, all threads in the `boost::asio::thread_pool` become occupied by the [ExecuteBLSRequest](https://github.com/triton-inference-server/python_backend/blob/main/src/python_be.cc#L819-L824) function. Consequently, the [ResponseSendDecoupled](https://github.com/triton-inference-server/python_backend/blob/main/src/python_be.cc#L811-L814) function is pushed into the queue, awaiting the next available thread. At this point, the stub process is blocked.~~

~~On the server side, within `InferResponseComplete`, for decoupled responses, it calls the callback function `SendBLSDecoupledResponse`, which pushes a message and [waits](https://github.com/triton-inference-server/python_backend/blob/main/src/python_be.cc#L1850) for the stub to pick it up. As the stub is still blocked, the server hangs.~~

~~One potential solution is to use separate thread pools to eliminate the dependency between them. I am open to any suggestions and discussions.~~

**Updated version**

By default, on the PYBE side, there are 32 threads in the `boost::asio::thread_pool`. When numerous concurrent BLS requests occur, all threads in the `boost::asio::thread_pool` become occupied by the [ExecuteBLSRequest](https://github.com/triton-inference-server/python_backend/blob/main/src/python_be.cc#L819-L824) function. These threads are waiting for the backend invoked by the BLS request to execute inference and return the response via the `InferResponseComplete` callback function.

Within the callback, for decoupled responses, we call `SendBLSDecoupledResponse`, which sends a decoupled response to the stub and [waits](https://github.com/triton-inference-server/python_backend/blob/main/src/python_be.cc#L1850) for the stub to process the response. Meanwhile, on the stub side, when [loading the response from shm](https://github.com/triton-inference-server/python_backend/blob/main/src/pb_stub.cc#L1340), it requires the [GIL](https://github.com/triton-inference-server/python_backend/blob/main/src/infer_response.cc#L159).

If, at this moment, a `ResponseSender` tries to [send a response to the parent process](https://github.com/triton-inference-server/python_backend/blob/main/src/response_sender.cc#L118) beforehand, it acquires the GIL. The `ResponseSender` will then be waiting for the parent process to [process the response](https://github.com/triton-inference-server/python_backend/blob/main/src/python_be.cc#L814) sent by itself. The GIL will be held until there is an available thread.

Typically, there is only a single thread to execute the inference and invoke the callback when returning responses. Therefore, those 32 threads cannot proceed since they are all waiting on the `InferResponseComplete` callback, leading to a deadlock.
