### PR TITLE
Move from jfrog artifactory to archives.boost.io to fix boost download

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -100,7 +100,7 @@ FetchContent_MakeAvailable(dlpack)
 #
 ExternalProject_Add(
   boostorg
-  URL https://boostorg.jfrog.io/artifactory/main/release/1.79.0/source/boost_1_79_0.tar.gz
+  URL https://archives.boost.io/release/1.79.0/source/boost_1_79_0.tar.gz
   URL_HASH SHA256=273f1be93238a068aba4f9735a4a2b003019af067b9c183ed227780b8f36062c
   PREFIX "boost-src"
   CONFIGURE_COMMAND ${CMAKE_COMMAND} -E copy_directory


### PR DESCRIPTION
Confirmed sha256sum is the same locally

Server: https://github.com/triton-inference-server/server/pull/6775
Python Backend: https://github.com/triton-inference-server/python_backend/pull/334
Gitlab: !1027

Based on issues with jfrog similar to this: https://github.com/boostorg/boost/issues/849#issue-2069720679