### PR TITLE
Fix decoupled ensemble IO shared memory leak

### DIFF
--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1328,6 +1328,7 @@ ModelInstanceState::ProcessRequestsDecoupled(
 
   AllocatedSharedMemory<ResponseBatch> response_batch =
       Stub()->ShmPool()->Load<ResponseBatch>(received_message_->Args());
+  received_message_.reset();
 
   uint64_t compute_end_ns = 0;
   SET_TIMESTAMP(compute_end_ns);


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/server/pull/6784

The shm block that holds an shm address to another shm block is no longer accessed after dereference. Although the block will eventually be cleaned up on next decoupled inference request or model unload, it is still a leak for this current decoupled inference request and cause the decoupled ensemble IO test to constantly fail on shm leak detected.