### PR TITLE
Delete TRITONSERVER_Error - #344

### DIFF
--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -369,6 +369,7 @@ ModelInstanceState::SaveRequestsToSharedMemory(
     auto error =
         TRITONBACKEND_RequestCorrelationId(request, &correlation_id_uint);
     if (error != nullptr) {
+      TRITONSERVER_ErrorDelete(error);
       const char* correlation_id_string = "";
       RETURN_IF_ERROR(TRITONBACKEND_RequestCorrelationIdString(
           request, &correlation_id_string));


### PR DESCRIPTION
Delete TRITONSERVER_Error when correlation_id is a string and an error occurs while checking for uint.
Follow-up PR for #344