### PR TITLE
Decoupled Async Execute

### DIFF
--- a/README.md
+++ b/README.md
@@ -620,9 +620,22 @@ full power of what can be achieved from decoupled API. Read
 [Decoupled Backends and Models](https://github.com/triton-inference-server/server/blob/main/docs/user_guide/decoupled_models.md)
 for more details on how to host a decoupled model.
 
-##### Known Issues
+##### Async Execute
 
-* Currently, decoupled Python models can not make async infer requests.
+Starting from 24.04, `async def execute(self, requests):` is supported for
+decoupled Python models. Its coroutine will be executed by an AsyncIO event loop
+shared with requests executing in a model instance. The next request for the
+model instance can start executing while the current request is waiting.
+
+This is useful for minimizing the number of model instances for models that
+spend the majority of its time waiting, given requests can be executed
+"concurrently" by AsyncIO. To take full advantage of the "concurrency", it is
+vital for the async execute function to not block the event loop from making
+progress while it is waiting, i.e. downloading over the network.
+
+Limitations:
+* The server/backend do not control how many requests can be executed
+"concurrently" by a model instance.
 
 #### Request Rescheduling
 

--- a/README.md
+++ b/README.md
@@ -624,8 +624,8 @@ for more details on how to host a decoupled model.
 
 Starting from 24.04, `async def execute(self, requests):` is supported for
 decoupled Python models. Its coroutine will be executed by an AsyncIO event loop
-shared with requests executing in a model instance. The next request for the
-model instance can start executing while the current request is waiting.
+shared with requests executing in the same model instance. The next request for
+the model instance can start executing while the current request is waiting.
 
 This is useful for minimizing the number of model instances for models that
 spend the majority of its time waiting, given requests can be executed

--- a/README.md
+++ b/README.md
@@ -629,15 +629,15 @@ the model instance can start executing while the current request is waiting.
 
 This is useful for minimizing the number of model instances for models that
 spend the majority of its time waiting, given requests can be executed
-"concurrently" by AsyncIO. To take full advantage of the "concurrency", it is
-vital for the async execute function to not block the event loop from making
-progress while it is waiting, i.e. downloading over the network.
+concurrently by AsyncIO. To take full advantage of the concurrency, it is vital
+for the async execute function to not block the event loop from making progress
+while it is waiting, i.e. downloading over the network.
 
 Notes:
 * The model should not modify the running event loop, as this might cause
 unexpected issues.
-* The server/backend do not control how many requests can be executed
-"concurrently" by a model instance.
+* The server/backend do not control how many requests are added to the event
+loop by a model instance.
 
 #### Request Rescheduling
 

--- a/README.md
+++ b/README.md
@@ -633,7 +633,9 @@ spend the majority of its time waiting, given requests can be executed
 vital for the async execute function to not block the event loop from making
 progress while it is waiting, i.e. downloading over the network.
 
-Limitations:
+Notes:
+* The model should not modify the running event loop, as this might cause
+unexpected issues.
 * The server/backend do not control how many requests can be executed
 "concurrently" by a model instance.
 

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ any C++ code.
       - [Request Cancellation Handling](#request-cancellation-handling)
       - [Decoupled mode](#decoupled-mode)
         - [Use Cases](#use-cases)
-        - [Known Issues](#known-issues)
+        - [Async Execute](#async-execute)
       - [Request Rescheduling](#request-rescheduling)
     - [`finalize`](#finalize)
   - [Model Config File](#model-config-file)

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -112,8 +112,10 @@ AsyncEventFutureDoneCallback(const py::object& py_future)
     py::object exception = py_future.attr("exception")();
     if (!py::isinstance<py::none>(exception)) {
       std::string err_msg = "";
-      py::list traceback =
-          py::module_::import("traceback").attr("format_exception")(exception);
+      py::object traceback = py::module_::import("traceback")
+                                 .attr("TracebackException")
+                                 .attr("from_exception")(exception)
+                                 .attr("format")();
       for (py::handle line : traceback) {
         err_msg += py::str(line);
       }

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -884,7 +884,9 @@ Stub::GetAsyncEventLoop()
 {
   if (py::isinstance<py::none>(async_event_loop_)) {
     // Create the event loop if not already.
-    async_event_loop_ = py::module_::import("asyncio").attr("new_event_loop")();
+    py::module asyncio = py::module_::import("asyncio");
+    async_event_loop_ = asyncio.attr("new_event_loop")();
+    asyncio.attr("set_event_loop")(async_event_loop_);
     py::object py_thread =
         py::module_::import("threading")
             .attr("Thread")(
@@ -1802,11 +1804,6 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
           [](std::shared_ptr<InferRequest>& infer_request,
              const bool decoupled) {
             std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
-            if (stub->IsDecoupled()) {
-              throw PythonBackendException(
-                  "Async BLS request execution is not support in the decoupled "
-                  "API.");
-            }
             py::object loop =
                 py::module_::import("asyncio").attr("get_running_loop")();
             py::cpp_function callback = [&stub, infer_request, decoupled]() {

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -919,9 +919,6 @@ Stub::RunCoroutine(py::object coroutine)
             LOG_ERROR << error.what();
           }
           py_future = py::none();
-        }
-        {
-          std::lock_guard<std::mutex> lock(async_event_future_mu_);
           prev_done_async_event_future_.swap(shared_future);
         }
         shared_future.reset();

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -33,7 +33,7 @@
 #include <filesystem>
 #include <future>
 #include <memory>
-#include <unordered_set>
+#include <vector>
 
 #include "infer_request.h"
 #include "infer_response.h"
@@ -371,7 +371,7 @@ class Stub {
   py::object deserialize_bytes_;
   py::object serialize_bytes_;
   py::object async_event_loop_;
-  std::unordered_set<std::shared_ptr<std::future<void>>> async_event_futures_;
+  std::vector<std::shared_ptr<std::future<void>>> done_async_event_futures_;
   std::mutex async_event_futures_mu_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>
       stub_message_queue_;

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -31,8 +31,6 @@
 #include <pybind11/stl.h>
 
 #include <filesystem>
-#include <future>
-#include <memory>
 
 #include "infer_request.h"
 #include "infer_response.h"
@@ -259,7 +257,7 @@ class Stub {
 
   py::object GetAsyncEventLoop();
 
-  py::object RunCoroutine(py::object coroutine);
+  void RunCoroutine(py::object coroutine);
 
   /// Get the memory manager message queue
   std::unique_ptr<MessageQueue<uint64_t>>& MemoryManagerQueue();
@@ -370,7 +368,6 @@ class Stub {
   py::object deserialize_bytes_;
   py::object serialize_bytes_;
   py::object async_event_loop_;
-  std::shared_ptr<std::future<void>> prev_done_async_event_future_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>
       stub_message_queue_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -31,6 +31,9 @@
 #include <pybind11/stl.h>
 
 #include <filesystem>
+#include <future>
+#include <memory>
+#include <unordered_set>
 
 #include "infer_request.h"
 #include "infer_response.h"
@@ -255,6 +258,10 @@ class Stub {
 
   void ProcessRequestsDecoupled(RequestBatch* request_batch_shm_ptr);
 
+  py::object GetAsyncEventLoop();
+
+  py::object RunCoroutine(py::object coroutine);
+
   /// Get the memory manager message queue
   std::unique_ptr<MessageQueue<uint64_t>>& MemoryManagerQueue();
 
@@ -363,6 +370,9 @@ class Stub {
   py::object model_instance_;
   py::object deserialize_bytes_;
   py::object serialize_bytes_;
+  py::object async_event_loop_;
+  std::unordered_set<std::shared_ptr<std::future<void>>> async_event_futures_;
+  std::mutex async_event_futures_mu_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>
       stub_message_queue_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -33,7 +33,6 @@
 #include <filesystem>
 #include <future>
 #include <memory>
-#include <vector>
 
 #include "infer_request.h"
 #include "infer_response.h"
@@ -371,8 +370,8 @@ class Stub {
   py::object deserialize_bytes_;
   py::object serialize_bytes_;
   py::object async_event_loop_;
-  std::vector<std::shared_ptr<std::future<void>>> done_async_event_futures_;
-  std::mutex async_event_futures_mu_;
+  std::shared_ptr<std::future<void>> prev_done_async_event_future_;
+  std::mutex async_event_future_mu_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>
       stub_message_queue_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -371,7 +371,6 @@ class Stub {
   py::object serialize_bytes_;
   py::object async_event_loop_;
   std::shared_ptr<std::future<void>> prev_done_async_event_future_;
-  std::mutex async_event_future_mu_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>
       stub_message_queue_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -768,6 +768,7 @@ ModelInstanceState::ExecuteBLSRequest(
         if (is_decoupled && (infer_response->Id() != nullptr)) {
           // Need to manage the lifetime of InferPayload object for bls
           // decoupled responses.
+          std::lock_guard<std::mutex> lock(infer_payload_mu_);
           infer_payload_[reinterpret_cast<intptr_t>(infer_payload.get())] =
               infer_payload;
         }
@@ -961,6 +962,7 @@ ModelInstanceState::ProcessCleanupRequest(
   intptr_t id = reinterpret_cast<intptr_t>(cleanup_message_ptr->id);
   if (message->Command() == PYTHONSTUB_BLSDecoupledInferPayloadCleanup) {
     // Remove the InferPayload object from the map.
+    std::lock_guard<std::mutex> lock(infer_payload_mu_);
     infer_payload_.erase(id);
   } else if (message->Command() == PYTHONSTUB_DecoupledResponseFactoryCleanup) {
     // Delete response factory

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -296,6 +296,7 @@ class ModelInstanceState : public BackendModelInstance {
   std::vector<std::future<void>> futures_;
   std::unique_ptr<boost::asio::thread_pool> thread_pool_;
   std::unordered_map<intptr_t, std::shared_ptr<InferPayload>> infer_payload_;
+  std::mutex infer_payload_mu_;
   std::unique_ptr<RequestExecutor> request_executor_;
 
  public:


### PR DESCRIPTION
Related PR: https://github.com/triton-inference-server/server/pull/7062

Add support for decoupled async execute function on `model.py` and enable overlapping between different calls into the execute function by having them execute on the same event loop. Also, enable async exec BLS function for decoupled async execute function.

Closes: https://github.com/triton-inference-server/server/issues/3482