### PR TITLE
Randomize Python backend shared memory region naming

### DIFF
--- a/README.md
+++ b/README.md
@@ -1067,11 +1067,13 @@ will create additional threads instead of spawning separate processes.
 
 ## Running Multiple Instances of Triton Server
 
-Python backend uses shared memory to transfer requests to the stub process.
-When running multiple instances of Triton Server on the same machine that use
-Python models, there would be shared memory region name conflicts that can
-result in segmentation faults or hangs. In order to avoid this issue, you need
-to specify different `shm-region-prefix-name` using the `--backend-config` flag.
+Starting from 24.04 release, Python backend uses UUID to generate unique
+names for Python backend shared memory regions so that multiple instances of
+the server can run at the same time without any conflicts.
+
+If you're using a Python backend released before the 24.04 release, you need
+to specify different `shm-region-prefix-name` using the `--backend-config` flag
+to avoid conflicts between the shared memory regions. For example:
 
 ```
 # Triton instance 1

--- a/examples/preprocessing/client.py
+++ b/examples/preprocessing/client.py
@@ -29,7 +29,7 @@ import json
 import sys
 
 import numpy as np
-import tritongrpcclient
+import tritonclient.grpc as tritongrpcclient
 
 
 def load_image(img_path: str):

--- a/src/pb_utils.cc
+++ b/src/pb_utils.cc
@@ -314,4 +314,13 @@ WrapTritonErrorInSharedPtr(TRITONSERVER_Error* error)
   return response_error;
 }
 #endif  // NOT TRITON_PB_STUB
-}}}     // namespace triton::backend::python
+
+std::string
+GenerateUUID()
+{
+  static boost::uuids::random_generator generator;
+  boost::uuids::uuid uuid = generator();
+  return boost::uuids::to_string(uuid);
+}
+
+}}}  // namespace triton::backend::python

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -32,6 +32,9 @@
 
 #include <boost/interprocess/sync/interprocess_condition.hpp>
 #include <boost/interprocess/sync/interprocess_mutex.hpp>
+#include <boost/uuid/uuid.hpp>
+#include <boost/uuid/uuid_generators.hpp>
+#include <boost/uuid/uuid_io.hpp>
 #include <climits>
 #include <memory>
 #include <mutex>
@@ -334,5 +337,7 @@ void SanitizePath(std::string& path);
 std::shared_ptr<TRITONSERVER_Error*> WrapTritonErrorInSharedPtr(
     TRITONSERVER_Error* error);
 #endif
+
+std::string GenerateUUID();
 
 }}}  // namespace triton::backend::python

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -2131,7 +2131,6 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
   backend_state->shm_growth_byte_size = 1 * 1024 * 1024;   // 1 MB
   backend_state->stub_timeout_seconds = 30;
   backend_state->shm_message_queue_size = 1000;
-  backend_state->number_of_instance_inits = 0;
   backend_state->thread_pool_size = 32;
   // Initialize shared memory region prefix to include backend's name
   // to avoid collision between python backend and python-based backends.

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -78,12 +78,9 @@ StubLauncher::Initialize(ModelState* model_state)
   stub_pid_ = 0;
 #endif
 
-  // Atomically increase and read the stub process count to avoid shared memory
-  // region name collision
-  int num_init = ++model_state->StateForBackend()->number_of_instance_inits;
   shm_region_name_ =
       model_state->StateForBackend()->shared_memory_region_prefix +
-      std::to_string(num_init);
+      GenerateUUID();
 
   model_version_ = model_state->Version();
 


### PR DESCRIPTION
I did some testing with 10 regions and everything seems to work fine.