### PR TITLE
Reset async_event_loop_ only if initialized

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -945,17 +945,19 @@ void
 Stub::Finalize()
 {
   finalizing_ = true;
-  // Stop async event loop if created.
-  if (!py::isinstance<py::none>(async_event_loop_)) {
-    async_event_loop_.attr("stop")();
-  }
-  // Call finalize if exists.
-  if (initialized_ && py::hasattr(model_instance_, "finalize")) {
-    try {
-      model_instance_.attr("finalize")();
+  if (initialized_) {
+    // Stop async event loop if created.
+    if (!py::isinstance<py::none>(async_event_loop_)) {
+      async_event_loop_.attr("stop")();
     }
-    catch (const py::error_already_set& e) {
-      LOG_INFO << e.what();
+    // Call finalize if exists.
+    if (py::hasattr(model_instance_, "finalize")) {
+      try {
+        model_instance_.attr("finalize")();
+      }
+      catch (const py::error_already_set& e) {
+        LOG_INFO << e.what();
+      }
     }
   }
 #ifdef TRITON_ENABLE_GPU


### PR DESCRIPTION
Shout-out to @fpetrini15 for finding the auto-complete stub process does not go through the `Initialize()` function but always go through the `Finalize()` function.

This fix the issue by checking the `initialized_` flag to determine if the `Initialize()` function is called before manipulating with the `async_event_loop_` variable initialized on the `Initialize()` function.