### PR TITLE
Add error handling in case of AutocompleteStub Failure for DLIS-5819

### DIFF
--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -2042,7 +2042,7 @@ ModelState::LaunchAutoCompleteStubProcess()
         std::string("unexpected nullptr in BackendModelException"));
     RETURN_IF_ERROR(ex.err_);
     return TRITONSERVER_ErrorNew(
-    TRITONSERVER_ERROR_INTERNAL, TRITONSERVER_ErrorMessage(ex.err_));    
+        TRITONSERVER_ERROR_INTERNAL, TRITONSERVER_ErrorMessage(ex.err_));
   }
 
   return nullptr;

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -2041,8 +2041,6 @@ ModelState::LaunchAutoCompleteStubProcess()
         ex.err_ == nullptr, TRITONSERVER_ERROR_INTERNAL,
         std::string("unexpected nullptr in BackendModelException"));
     RETURN_IF_ERROR(ex.err_);
-    return TRITONSERVER_ErrorNew(
-        TRITONSERVER_ERROR_INTERNAL, TRITONSERVER_ErrorMessage(ex.err_));
   }
 
   return nullptr;

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -2041,6 +2041,8 @@ ModelState::LaunchAutoCompleteStubProcess()
         ex.err_ == nullptr, TRITONSERVER_ERROR_INTERNAL,
         std::string("unexpected nullptr in BackendModelException"));
     RETURN_IF_ERROR(ex.err_);
+    return TRITONSERVER_ErrorNew(
+    TRITONSERVER_ERROR_INTERNAL, TRITONSERVER_ErrorMessage(ex.err_));    
   }
 
   return nullptr;

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -442,11 +442,7 @@ StubLauncher::Launch()
         stub_message_queue_.reset();
         parent_message_queue_.reset();
         memory_manager_.reset();
-        if (stub_pid_ != 0) {
-          // Added this check to ensure server doesn't hang waiting after stub
-          // process has already be killed and cannot be waited on
-          WaitForStubProcess();
-        }
+        WaitForStubProcess();
       }
     });
 
@@ -791,7 +787,11 @@ StubLauncher::WaitForStubProcess()
   CloseHandle(stub_pid_.hThread);
 #else
   int status;
-  waitpid(stub_pid_, &status, 0);
+  if (stub_pid_ != 0) {
+    // Added this check to ensure server doesn't hang waiting after stub
+    // process has already be killed and cannot be waited on
+    waitpid(stub_pid_, &status, 0);
+  }
 #endif
 }
 

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -443,7 +443,7 @@ StubLauncher::Launch()
         parent_message_queue_.reset();
         memory_manager_.reset();
         if (stub_pid_ != 0) {
-          // Added this check to ensure server doesnt hang waiting after stub
+          // Added this check to ensure server doesn't hang waiting after stub
           // process has already be killed and cannot be waited on
           WaitForStubProcess();
         }

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -443,6 +443,8 @@ StubLauncher::Launch()
         parent_message_queue_.reset();
         memory_manager_.reset();
         if (stub_pid_ != 0) {
+          // Added this check to ensure server doesnt hang waiting after stub
+          // process has already be killed and cannot be waited on
           WaitForStubProcess();
         }
       }

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -442,7 +442,9 @@ StubLauncher::Launch()
         stub_message_queue_.reset();
         parent_message_queue_.reset();
         memory_manager_.reset();
-        WaitForStubProcess();
+        if (stub_pid_ != 0) {
+          WaitForStubProcess();
+        }
       }
     });
 


### PR DESCRIPTION
Tested various failures in Load/Unload API
Handling for error in LaunchAutoCompleteStubProcess() was not complete causing the HTTP request to hang, in case of faulty autocomplete function.
Attached new behaviour in the image
<img width="1717" alt="Screenshot 2024-05-03 at 10 29 37 AM" src="https://github.com/triton-inference-server/python_backend/assets/12207181/bae350f4-9f54-4ad3-9fdb-c8c010445424">

Followup question:

I saw similar handling in ALL other backends as well, I think a fix would be needed in all of them.