### PR TITLE
Clean up ResponseFactory when a final complete flag is set

### DIFF
--- a/README.md
+++ b/README.md
@@ -599,6 +599,11 @@ Starting from 23.10, request cancellation can be checked directly on the
 the TRITONSERVER_RESPONSE_COMPLETE_FINAL flag at the end of response is still
 needed even the request is cancelled.
 
+*Note:*: If `response_sender` is reused across multiple requests, the model must
+ensure that the `response_sender` is properly cleaned up when the
+`pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL` flag has not been sent for the
+request and the request is rescheduled or cancelled.
+
 ##### Use Cases
 
 The decoupled mode is powerful and supports various other use cases:

--- a/README.md
+++ b/README.md
@@ -599,11 +599,6 @@ Starting from 23.10, request cancellation can be checked directly on the
 the TRITONSERVER_RESPONSE_COMPLETE_FINAL flag at the end of response is still
 needed even the request is cancelled.
 
-*Note:*: If `response_sender` is reused across multiple requests, the model must
-ensure that the `response_sender` is properly cleaned up when the
-`pb_utils.TRITONSERVER_RESPONSE_COMPLETE_FINAL` flag has not been sent for the
-request and the request is rescheduled or cancelled.
-
 ##### Use Cases
 
 The decoupled mode is powerful and supports various other use cases:

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -225,6 +225,7 @@ struct ResponseSenderBase {
   bi::managed_external_buffer::handle_t error;
   intptr_t request_address;
   intptr_t response_factory_address;
+  bool is_response_factory_cleaned;
 };
 
 struct ResponseSendMessage : ResponseSenderBase {

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1310,6 +1310,7 @@ ModelInstanceState::ResponseSendDecoupled(
         TRITONBACKEND_ResponseFactory, backend::ResponseFactoryDeleter>
         response_factory(reinterpret_cast<TRITONBACKEND_ResponseFactory*>(
             send_message_payload->response_factory_address));
+    send_message_payload->is_response_factory_cleaned = true;
   }
 }
 

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1303,6 +1303,14 @@ ModelInstanceState::ResponseSendDecoupled(
     SetErrorForResponseSendMessage(
         send_message_payload, WrapTritonErrorInSharedPtr(error), error_message);
   }
+
+  if (send_message_payload->flags == TRITONSERVER_RESPONSE_COMPLETE_FINAL) {
+    // Delete response factory
+    std::unique_ptr<
+        TRITONBACKEND_ResponseFactory, backend::ResponseFactoryDeleter>
+        response_factory(reinterpret_cast<TRITONBACKEND_ResponseFactory*>(
+            send_message_payload->response_factory_address));
+  }
 }
 
 TRITONSERVER_Error*

--- a/src/response_sender.cc
+++ b/src/response_sender.cc
@@ -114,6 +114,7 @@ ResponseSender::Send(
   send_message_payload->has_error = false;
   send_message_payload->is_error_set = false;
   send_message_payload->flags = flags;
+  send_message_payload->is_response_factory_cleaned = false;
 
   std::unique_ptr<IPCMessage> ipc_message =
       IPCMessage::Create(shm_pool_, false /* inline_response */);

--- a/src/response_sender.cc
+++ b/src/response_sender.cc
@@ -47,10 +47,11 @@ ResponseSender::ResponseSender(
 
 ResponseSender::~ResponseSender()
 {
-  std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
-  stub->EnqueueCleanupId(
-      reinterpret_cast<void*>(response_factory_address_),
-      PYTHONSTUB_DecoupledResponseFactoryCleanup);
+  // std::cerr << "===== ResponseSender::~ResponseSender() =====" << std::endl;
+  // std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
+  // stub->EnqueueCleanupId(
+  //     reinterpret_cast<void*>(response_factory_address_),
+  //     PYTHONSTUB_DecoupledResponseFactoryCleanup);
 }
 
 void

--- a/src/response_sender.h
+++ b/src/response_sender.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -46,7 +46,16 @@ class ResponseSender {
   intptr_t request_address_;
   intptr_t response_factory_address_;
   std::unique_ptr<SharedMemoryManager>& shm_pool_;
+  // The flag to indicate if the response sender is closed. It is set to true
+  // once the TRITONSERVER_RESPONSE_COMPLETE_FINAL flag is set, meaning that the
+  // response_sender should not be used anymore. This flag is separate from the
+  // `is_response_factory_cleaned_` flag because errors might occur after
+  // complete_final flag is set but before the response_factory gets cleaned up.
   bool closed_;
   std::shared_ptr<PbCancel> pb_cancel_;
+  // The flag to indicate if the response_factory is already cleaned up in the
+  // python backend side. If not, the response_factory will be cleaned up in the
+  // destructor.
+  bool is_response_factory_cleaned_;
 };
 }}}  // namespace triton::backend::python


### PR DESCRIPTION
In the current implementation, users need to ensure that the `response_sender` goes out of scope or is properly cleaned up before unloading the model to guarantee that the unloading process executes correctly. This is because the `response_sender` is responsible for cleaning up the `response_factory`, which holds a shared_ptr to the underlying model. Only when the reference count of the model's shared_ptr drops to 0 will the model be unloaded.

This PR enhances the lifetime management of `response_factory` so that when the complete final flag is sent, the `response_factory` will be cleaned up immediately. This allows users to not worry about the lifetime of `response_sender` and to reuse `response_sender` if they choose to.

For rescheduled or cancelled requests, updated the documentation for the issue since it's hard and tricky to propagate that information back to the `response_sender`. I think we can enhance that after Jacky's ongoing changes for response_sender are in place.

Testing: https://github.com/triton-inference-server/server/pull/7246