### PR TITLE
Fix decoupled batch statistics to account for implicit batch size

### DIFF
--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1236,7 +1236,7 @@ ModelInstanceState::ProcessRequests(
   uint64_t compute_end_ns = 0;
   SET_TIMESTAMP(compute_end_ns);
   reporter.SetComputeEndNs(compute_end_ns);
-  reporter.SetBatchStatistics(request_count);
+  reporter.SetBatchStatistics(total_batch_size);
 
   if (response_batch.data_->has_error) {
     if (response_batch.data_->is_error_set) {


### PR DESCRIPTION
Previous PRs:
* https://github.com/triton-inference-server/server/pull/7257
* https://github.com/triton-inference-server/python_backend/pull/360

The decoupled metrics reporting should consider implicit batch size when reporting batch statistics. Previously, the batch statistics uses the number of requests as batch size, which does not account for batched request(s). Now, it is modified to take the number of requests multiplied by its respective implicit batch size.

Next PRs:
* https://github.com/triton-inference-server/server/pull/7258
* https://github.com/triton-inference-server/python_backend/pull/362