### PR TITLE
Fix decoupled gpu output error handling

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -737,7 +737,7 @@ Stub::ProcessRequests(RequestBatch* request_batch_shm_ptr)
         error_string;
     LOG_ERROR << err_message.c_str();
     response_batch_shm_ptr->has_error = true;
-    error_string_shm = PbString::Create(shm_pool_, error_string);
+    error_string_shm = PbString::Create(shm_pool_, err_message);
     response_batch_shm_ptr->error = error_string_shm->ShmHandle();
     response_batch_shm_ptr->is_error_set = true;
   }

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -735,7 +735,7 @@ Stub::ProcessRequests(RequestBatch* request_batch_shm_ptr)
             "Failed to process the request(s) for model '" + name_ +
             "', message: ") +
         error_string;
-    LOG_INFO << err_message.c_str();
+    LOG_ERROR << err_message.c_str();
     response_batch_shm_ptr->has_error = true;
     error_string_shm = PbString::Create(shm_pool_, error_string);
     response_batch_shm_ptr->error = error_string_shm->ShmHandle();


### PR DESCRIPTION
Previous PR: https://github.com/triton-inference-server/python_backend/pull/361
Related PR: https://github.com/triton-inference-server/server/pull/7258

Fix two things:
* The decoupled GPU tensors output does not check if the GPU output buffers are successfully allocated. This adds the check.
* If there is an error in buffer, it will throw an exception instead of logging the exception. The stub/parent turn flag will be updated correctly if an exception is raised or completed successfully.

Enhance one thing:
* The error message returned to the request will match the full one printed to the log, instead of only returning the basic message from the model.

Next PRs:
* https://github.com/triton-inference-server/server/pull/7292
* https://github.com/triton-inference-server/python_backend/pull/363