### PR TITLE
Response sender to check for improper non-decoupled model usage

### DIFF
--- a/src/infer_request.h
+++ b/src/infer_request.h
@@ -118,7 +118,7 @@ class InferRequest {
   static std::unique_ptr<InferRequest> LoadFromSharedMemory(
       std::unique_ptr<SharedMemoryManager>& shm_pool,
       bi::managed_external_buffer::handle_t request_handle,
-      bool open_cuda_handle);
+      bool open_cuda_handle, bool const* is_model_decoupled);
 
   /// Disallow copying the inference request object.
   DISALLOW_COPY_AND_ASSIGN(InferRequest);
@@ -135,7 +135,8 @@ class InferRequest {
       std::unique_ptr<PbString>& model_name_shm,
       std::vector<std::shared_ptr<PbTensor>>& input_tensors,
       std::unique_ptr<PbString>& parameters_shm,
-      std::unique_ptr<InferenceTrace>& infer_trace_shm);
+      std::unique_ptr<InferenceTrace>& infer_trace_shm,
+      bool const* is_model_decoupled);
 
   std::string request_id_;
   CorrelationId correlation_id_;

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -658,7 +658,8 @@ Stub::LoadRequestsFromSharedMemory(RequestBatch* request_batch_shm_ptr)
   for (size_t i = 0; i < batch_size; i++) {
     std::shared_ptr<InferRequest> infer_request =
         InferRequest::LoadFromSharedMemory(
-            shm_pool_, request_shm_handle[i], true /* open_cuda_handle */);
+            shm_pool_, request_shm_handle[i], true /* open_cuda_handle */,
+            &ipc_control_->decoupled /* is_model_decoupled */);
     py_request_list.append(infer_request);
   }
 

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -747,7 +747,7 @@ Stub::ProcessRequests(RequestBatch* request_batch_shm_ptr)
     // responses after the factories are closed.
     for (py::handle py_request : py_request_list) {
       InferRequest* request = py_request.cast<InferRequest*>();
-      request->GetResponseSender()->ForceClose();
+      request->GetResponseSender()->Close();
     }
   }
 }

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -571,7 +571,8 @@ ModelInstanceState::ExecuteBLSRequest(
           reinterpret_cast<bi::managed_external_buffer::handle_t*>(
               request_batch.data_.get() + sizeof(RequestBatch));
       infer_request = InferRequest::LoadFromSharedMemory(
-          Stub()->ShmPool(), *request_handle, false /* open_cuda_handle */);
+          Stub()->ShmPool(), *request_handle, false /* open_cuda_handle */,
+          nullptr /* is_model_decoupled */);
 
       // If the BLS inputs are in GPU an additional round trip between the
       // stub process and the main process is required. The reason is that we

--- a/src/response_sender.cc
+++ b/src/response_sender.cc
@@ -245,4 +245,11 @@ ResponseSender::IsCancelled()
   return pb_cancel_->IsCancelled();
 }
 
+void
+ResponseSender::ForceClose()
+{
+  std::lock_guard<std::mutex> lk(mu_);
+  closed_ = true;
+}
+
 }}}  // namespace triton::backend::python

--- a/src/response_sender.cc
+++ b/src/response_sender.cc
@@ -36,7 +36,7 @@
 namespace triton { namespace backend { namespace python {
 
 void
-AssertResponseSenderArgumentsWellFormed(
+CheckResponseSenderArguments(
     const std::shared_ptr<InferResponse>& response, const uint32_t flags)
 {
   // Check the correctness of the provided flags.
@@ -121,7 +121,7 @@ ResponseSender::Send(
   // the next available thread to pick up the job during resource contention.
   py::gil_scoped_release release;
 
-  AssertResponseSenderArgumentsWellFormed(infer_response, flags);
+  CheckResponseSenderArguments(infer_response, flags);
   UpdateStateAndCounters(infer_response, flags);
 
   std::unique_ptr<Stub>& stub = Stub::GetOrCreateInstance();
@@ -246,7 +246,7 @@ ResponseSender::IsCancelled()
 }
 
 void
-ResponseSender::ForceClose()
+ResponseSender::Close()
 {
   std::lock_guard<std::mutex> lk(mu_);
   closed_ = true;

--- a/src/response_sender.h
+++ b/src/response_sender.h
@@ -44,6 +44,9 @@ class ResponseSender {
   void Send(std::shared_ptr<InferResponse> response, const uint32_t flags);
   bool IsCancelled();
 
+  // Can be useful at stopping the model from sending any more responses.
+  void ForceClose();
+
  private:
   void UpdateStateAndCounters(
       const std::shared_ptr<InferResponse>& response, const uint32_t flags);

--- a/src/response_sender.h
+++ b/src/response_sender.h
@@ -45,7 +45,7 @@ class ResponseSender {
   bool IsCancelled();
 
   // Can be useful at stopping the model from sending any more responses.
-  void ForceClose();
+  void Close();
 
  private:
   void UpdateStateAndCounters(


### PR DESCRIPTION
Previous PRs:
* https://github.com/triton-inference-server/server/pull/7258
* https://github.com/triton-inference-server/python_backend/pull/362

Related PR: https://github.com/triton-inference-server/server/pull/7292

The response sender will raise an exception if any one of the following is detected:
* Try to send more than one response on non-decoupled model.
* Try to send complete final flag without including a response or already sent a response on non-decoupled model.