### PR TITLE
fix: [precaution fix] Capture Python futures while running in the background

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -537,7 +537,7 @@ Stub::Initialize(bi::managed_external_buffer::handle_t map_handle)
   c_python_backend_utils.attr("shared_memory") = py::cast(shm_pool_.get());
 
   async_event_loop_ = py::none();
-  background_futures_ = py::module_::import("builtins").attr("set")();
+  background_futures_ = py::set();
 
   py::object TritonPythonModel = sys.attr("TritonPythonModel");
   deserialize_bytes_ = python_backend_utils.attr("deserialize_bytes_tensor");

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -260,6 +260,8 @@ class Stub {
 
   py::object RunCoroutine(py::object coroutine, bool in_background);
 
+  void BackgroundFutureDone(const py::object& py_future);
+
   /// Get the memory manager message queue
   std::unique_ptr<MessageQueue<uint64_t>>& MemoryManagerQueue();
 
@@ -367,6 +369,7 @@ class Stub {
   py::object deserialize_bytes_;
   py::object serialize_bytes_;
   py::object async_event_loop_;
+  py::object background_futures_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>
       stub_message_queue_;
   std::unique_ptr<MessageQueue<bi::managed_external_buffer::handle_t>>


### PR DESCRIPTION
#### What does the PR do?
The `py_future` object generated by `RunCoroutine()` is lost upon the function returns if the coroutine is to be ran in the background. This can be problematic as some sources suggest the `run_coroutine_threadsafe()` only maintain a weak reference to the `py_future` object that it returns. Therefore, this PR will implement the workaround suggested on the [official Python documentation](https://docs.python.org/3/library/asyncio-task.html#asyncio.create_task) which stores the `py_future` in a Python set and remove it upon the done callback is invoked, so the `py_future` cannot be dangling while waiting for it to execute in the background.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
N/A

#### Where should the reviewer start?
N/A

#### Test plan:
No additional tests were added. The current tests, i.e. L0_backend_python should provide sufficient coverage for any new issue introduced by the change.

- CI Pipeline ID:
#15608296

#### Caveats:
We can explore if the Python library actually has weak reference while waiting for background futures.

#### Background
The future object returned from `asyncio.run_coroutine_threadsafe(...)` is not captured by the stub process while waiting for the future object to complete execution in the background. If the `run_coroutine_threadsafe()` only maintains a weak reference to the future object, the future object may be deleted by the time the result is ready.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A