### PR TITLE
fix: Models should filter outputs based on requested outputs

### DIFF
--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -68,14 +68,15 @@ InferRequest::InferRequest(
     }
   }
 
-  inputs_ = inputs;
-  requested_output_names_ = requested_output_names;
+  inputs_ = inputs;                                  // TODO: do we need this?
+  requested_output_names_ = requested_output_names;  // TODO: do we need this?
 #ifdef TRITON_PB_STUB
   pb_cancel_ =
       std::make_shared<PbCancel>(response_factory_address_, request_address_);
   response_sender_ = std::make_shared<ResponseSender>(
       request_address_, response_factory_address_, nullptr /* is_decoupled */,
-      Stub::GetOrCreateInstance()->SharedMemory(), pb_cancel_);
+      RequestedOutputNames(), Stub::GetOrCreateInstance()->SharedMemory(),
+      pb_cancel_);
 #endif
 }
 
@@ -390,7 +391,8 @@ InferRequest::InferRequest(
       std::make_shared<PbCancel>(response_factory_address_, request_address_);
   response_sender_ = std::make_shared<ResponseSender>(
       request_address_, response_factory_address_, is_model_decoupled,
-      Stub::GetOrCreateInstance()->SharedMemory(), pb_cancel_);
+      RequestedOutputNames(), Stub::GetOrCreateInstance()->SharedMemory(),
+      pb_cancel_);
 #endif
 }
 

--- a/src/infer_request.cc
+++ b/src/infer_request.cc
@@ -68,8 +68,6 @@ InferRequest::InferRequest(
     }
   }
 
-  inputs_ = inputs;                                  // TODO: do we need this?
-  requested_output_names_ = requested_output_names;  // TODO: do we need this?
 #ifdef TRITON_PB_STUB
   pb_cancel_ =
       std::make_shared<PbCancel>(response_factory_address_, request_address_);

--- a/src/response_sender.h
+++ b/src/response_sender.h
@@ -50,11 +50,8 @@ class ResponseSender {
   void Close();
 
  private:
-  bool IsDecoupled() const;
   void UpdateStateAndCounters(
       const std::shared_ptr<InferResponse>& response, const uint32_t flags);
-  void PruneNonRequestedOutputs(
-      const std::shared_ptr<InferResponse>& infer_response) const;
 
   intptr_t request_address_;
   intptr_t response_factory_address_;

--- a/src/response_sender.h
+++ b/src/response_sender.h
@@ -38,7 +38,9 @@ class ResponseSender {
  public:
   ResponseSender(
       intptr_t request_address, intptr_t response_factory_address,
-      bool const* is_decoupled, std::unique_ptr<SharedMemoryManager>& shm_pool,
+      bool const* is_decoupled,
+      const std::set<std::string>& requested_output_names,
+      std::unique_ptr<SharedMemoryManager>& shm_pool,
       const std::shared_ptr<PbCancel>& pb_cancel);
   ~ResponseSender();
   void Send(std::shared_ptr<InferResponse> response, const uint32_t flags);
@@ -48,12 +50,16 @@ class ResponseSender {
   void Close();
 
  private:
+  bool IsDecoupled() const;
   void UpdateStateAndCounters(
       const std::shared_ptr<InferResponse>& response, const uint32_t flags);
+  void PruneNonRequestedOutputs(
+      const std::shared_ptr<InferResponse>& infer_response) const;
 
   intptr_t request_address_;
   intptr_t response_factory_address_;
   bool const* is_decoupled_;
+  std::set<std::string> requested_output_names_;
   std::unique_ptr<SharedMemoryManager>& shm_pool_;
   std::shared_ptr<PbCancel> pb_cancel_;
 


### PR DESCRIPTION
#### What does the PR do?
Models on Python backend should filter outputs based on requested outputs from the client.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [x] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
https://github.com/triton-inference-server/server/pull/7338

#### Where should the reviewer start?
N/A

#### Test plan:
Add additional tests to L0_backend_python to affirm the behavior of non-decoupled and decoupled models on filtering outputs from requested outputs.

- CI Pipeline ID:
Refer to the related server PR.

#### Caveats:
N/A

#### Background
The non-decoupled data pipeline previously does filter outputs based on requested output, so this PR essentially brings this behavior back after switching non-decoupled models to use decoupled data pipeline.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A