### PR TITLE
fix: Define ssize_t for windows build

### DIFF
--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -35,6 +35,11 @@ namespace py = pybind11;
 #endif
 #include "pb_tensor.h"
 
+// WAR for undefined ssize_t on Windows: https://stackoverflow.com/a/35368387
+#if defined(_MSC_VER)
+#include <BaseTsd.h>
+typedef SSIZE_T ssize_t;
+#endif
 
 namespace triton { namespace backend { namespace python {
 


### PR DESCRIPTION
`ssize_t` was not defined or understood for Windows build and caused compilation issues where it was used.