### PR TITLE
feat: Add BF16 tensor support via dlpack

### DIFF
--- a/README.md
+++ b/README.md
@@ -1557,6 +1557,10 @@ input0 = pb_utils.Tensor.from_dlpack("INPUT0", pytorch_tensor)
 This method only supports contiguous Tensors that are in C-order. If the tensor
 is not C-order contiguous an exception will be raised.
 
+For python models with input or output tensors of type BFloat16 (BF16), the
+`as_numpy()` method is not supported, and the `from_dlpack` and `to_dlpack`
+methods must be used instead.
+
 ## `pb_utils.Tensor.is_cpu() -> bool`
 
 This function can be used to check whether a tensor is placed in CPU or not.

--- a/src/pb_stub_utils.cc
+++ b/src/pb_stub_utils.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -168,8 +168,8 @@ triton_to_pybind_dtype(TRITONSERVER_DataType data_type)
       dtype_numpy = py::dtype(py::format_descriptor<uint8_t>::format());
       break;
     case TRITONSERVER_TYPE_BF16:
-      // Currently skipping this call via `if (BF16)` check, but probably
-      // need to handle this or set some default/invalid dtype.
+      // NOTE: Currently skipping this call via `if (BF16)` check, but may
+      // want to better handle this or set some default/invalid dtype.
       throw PythonBackendException("TYPE_BF16 not currently supported.");
     case TRITONSERVER_TYPE_INVALID:
       throw PythonBackendException("Dtype is invalid.");

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2024, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -152,7 +152,10 @@ PbTensor::PbTensor(
 #ifdef TRITON_PB_STUB
   if (memory_type_ == TRITONSERVER_MEMORY_CPU ||
       memory_type_ == TRITONSERVER_MEMORY_CPU_PINNED) {
-    if (dtype != TRITONSERVER_TYPE_BYTES) {
+    if (dtype == TRITONSERVER_TYPE_BF16) {
+      // No native numpy representation for BF16. DLPack should be used instead.
+      numpy_array_ = py::none();
+    } else if (dtype != TRITONSERVER_TYPE_BYTES) {
       py::object numpy_array =
           py::array(triton_to_pybind_dtype(dtype_), dims_, (void*)memory_ptr_);
       numpy_array_ = numpy_array.attr("view")(triton_to_numpy_type(dtype_));
@@ -643,7 +646,10 @@ PbTensor::PbTensor(
 #ifdef TRITON_PB_STUB
   if (memory_type_ == TRITONSERVER_MEMORY_CPU ||
       memory_type_ == TRITONSERVER_MEMORY_CPU_PINNED) {
-    if (dtype_ != TRITONSERVER_TYPE_BYTES) {
+    if (dtype_ == TRITONSERVER_TYPE_BF16) {
+      // No native numpy representation for BF16. DLPack should be used instead.
+      numpy_array_ = py::none();
+    } else if (dtype_ != TRITONSERVER_TYPE_BYTES) {
       py::object numpy_array =
           py::array(triton_to_pybind_dtype(dtype_), dims_, (void*)memory_ptr_);
       numpy_array_ = numpy_array.attr("view")(triton_to_numpy_type(dtype_));

--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -515,12 +515,18 @@ PbTensor::Name() const
 const py::array*
 PbTensor::AsNumpy() const
 {
-  if (IsCPU()) {
-    return &numpy_array_;
-  } else {
+  if (!IsCPU()) {
     throw PythonBackendException(
         "Tensor is stored in GPU and cannot be converted to NumPy.");
   }
+
+  if (dtype_ == TRITONSERVER_TYPE_BF16) {
+    throw PythonBackendException(
+        "Tensor dtype is BF16 and cannot be converted to NumPy. Use "
+        "to_dlpack() and from_dlpack() instead.");
+  }
+
+  return &numpy_array_;
 }
 #endif  // TRITON_PB_STUB
 


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->

Adds BF16 tensor support via DLPack. `tensor.as_numpy()` will not be supported for `TYPE_BF16` tensors at this time due to lack of native support for BF16 in numpy. 

These BF16 tensors can easily be converted around with zero copies to dlpack-compatible frameworks like PyTorch and TensorFlow with their respective `to_dlpack` and `from_dlpack` utilities.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [x] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [x] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [x] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [x] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->

- https://github.com/triton-inference-server/python_backend/pull/371

#### Test plan:

See testing PR.

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

`as_numpy()` is not supported on BF16 tensors due to lack of native BF16 support in `numpy`, and DLPack must be used instead.

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

LLMs are commonly trained in BF16, and when deployed for serving often have a pre/post processing model written in Python. This makes lack of BF16 support in the python models a blocker or requires significant workarounds for writing an ensemble/BLS LLM pipeline. 

Adding BF16 support to the python backend will simplify this workflow.

#### Example

Example `model.py` using BF16 tensors via `dlpack` and `torch`:
```python
from torch.utils.dlpack import to_dlpack, from_dlpack
import triton_python_backend_utils as pb_utils

class TritonPythonModel:
    @classmethod
    def auto_complete_config(cls, cfg):
        inputs = [{
            'name': 'INPUT0',
            'data_type': 'TYPE_BF16',
            'dims': [-1, -1]
        }]
        outputs = [{
            'name': 'OUTPUT0',
            'data_type': 'TYPE_BF16',
            'dims': [-1, -1]
        }]

        [cfg.add_input(i) for i in inputs]
        [cfg.add_output(o) for o in outputs]
        cfg.set_max_batch_size(64)
        return cfg

    def infer(self, request):
        output_tensors = []
        for input_tensor in request.inputs():
            # Numpy representation is not supported for BF16
            # NOTE: Could raise an exception or an error instead
            assert input_tensor.as_numpy() == None
            # Convert PB tensor to torch tensor with dlpack
            torch_tensor = from_dlpack(input_tensor.to_dlpack())
            # Manipulate torch tensor
            torch_tensor *= 2
            # Convert torch tensor back to PB tensor with dlpack
            output_tensor = pb_utils.Tensor.from_dlpack(
                input_tensor.name().replace("INPUT", "OUTPUT"),
                to_dlpack(torch_tensor)
            )
            output_tensors.append(output_tensor)
        return pb_utils.InferenceResponse(output_tensors=output_tensors)

    def execute(self, requests):
        responses = []
        for request in requests:
            responses.append(self.infer(request))

        return responses
```