### PR TITLE
refactor: Delete response factory after sending complete final

### DIFF
--- a/src/response_sender.h
+++ b/src/response_sender.h
@@ -26,6 +26,7 @@
 
 #pragma once
 
+#include <atomic>
 #include <mutex>
 
 #include "infer_response.h"
@@ -52,6 +53,7 @@ class ResponseSender {
  private:
   void UpdateStateAndCounters(
       const std::shared_ptr<InferResponse>& response, const uint32_t flags);
+  void DeleteResponseFactory();
 
   intptr_t request_address_;
   intptr_t response_factory_address_;
@@ -63,5 +65,7 @@ class ResponseSender {
   std::mutex mu_;
   bool closed_;
   size_t number_of_response_sent_;
+
+  std::atomic<bool> response_factory_deleted_;
 };
 }}}  // namespace triton::backend::python


### PR DESCRIPTION
#### What does the PR do?
<!-- Describe your pull request here. Please read the text below the line, and make sure you follow the checklist.-->
Delete the response factory after the response sender sends a response with complete final flag. If the Python process did not get a chance to garbage collect the response sender before unloading the model, the response factory would be destructed which allows the model to gracefully unload.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [x] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [ ] feat
- [ ] fix
- [ ] perf
- [x] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
<!-- Related PRs from other Repositories -->
https://github.com/triton-inference-server/server/pull/7504
https://github.com/triton-inference-server/vllm_backend/pull/55

#### Where should the reviewer start?
<!-- call out specific files that should be looked at closely -->
N/A

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->
The PR refactors how a response factory object can be deleted, it is neither a feature nor a bug fix, so existing tests should be sufficient to cover any regression.

A test enhancement is added for response sender to ensure the deleted response factory cannot be accidentally dereferenced. See https://github.com/triton-inference-server/server/pull/7504 for more details.

- CI Pipeline ID: 17156719
<!-- Only Pipeline ID and no direct link here -->

#### Caveats:
<!-- any limitations or possible things missing from this PR -->
N/A

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->
N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
N/A