### PR TITLE
feat: Add vLLM metrics (counter and gauge) access through Triton

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -564,6 +564,24 @@ Stub::Initialize(bi::managed_external_buffer::handle_t map_handle)
     model_config_params[pair.first.c_str()] = pair.second;
   }
 
+  // Set metrics_mode value based on the build flag.
+#ifdef TRITON_ENABLE_METRICS
+#if defined(TRITON_ENABLE_METRICS_CPU) && defined(TRITON_ENABLE_METRICS_GPU)
+  model_config_params["metrics_mode"] = "all";
+#else  // defined(TRITON_ENABLE_METRICS_CPU) &&
+       // defined(TRITON_ENABLE_METRICS_GPU)
+#ifdef TRITON_ENABLE_METRICS_CPU
+  model_config_params["metrics_mode"] = "cpu";
+#endif  // TRITON_ENABLE_METRICS_CPU
+#ifdef TRITON_ENABLE_METRICS_GPU
+  model_config_params["metrics_mode"] = "gpu";
+#endif  // TRITON_ENABLE_METRICS_GPU
+#endif  // defined(TRITON_ENABLE_METRICS_CPU) &&
+        // defined(TRITON_ENABLE_METRICS_GPU)
+#else   // TRITON_ENABLE_METRICS
+  model_config_params["metrics_mode"] = "off";
+#endif  // TRITON_ENABLE_METRICS
+
   LaunchStubToParentQueueMonitor();
   LaunchParentToStubQueueMonitor();
 


### PR DESCRIPTION
#### What does the PR do?
Add vLLM metrics (counter and gauge) access through python_backend custom metrics.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [ ] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [x] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [x] feat

#### Related PRs:
https://github.com/triton-inference-server/vllm_backend/pull/53
https://github.com/triton-inference-server/server/pull/7493

#### Where should the reviewer start?
n/a

#### Test plan:
n/a

- CI Pipeline ID:
17273623

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
Customers requested.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
n/a