### PR TITLE
fix: python backend support for numpy>=2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -88,8 +88,8 @@ FetchContent_MakeAvailable(repo-common repo-core repo-backend)
 FetchContent_Declare(
   pybind11
   GIT_REPOSITORY "https://github.com/pybind/pybind11"
-  # COMMIT ID for v2.10.0
-  GIT_TAG "aa304c9c7d725ffb9d10af08a3b34cb372307020"
+  # COMMIT ID for v2.12.0
+  GIT_TAG "3e9dfa2866941655c56877882565e7577de6fc7b"
   GIT_SHALLOW ON
 )
 FetchContent_MakeAvailable(pybind11)


### PR DESCRIPTION
Updated the PyBind11 version from `v2.10.0` to `v2.12.0`, because `v2.12` supports `numpy 2` ([Release Notes](https://github.com/pybind/pybind11/releases/tag/v2.12.0)). 

Before this update, if `numpy>=2.x` was installed in the same environment,  performing inference requests would lead to error messages, such as:
```
terminate called after throwing an instance of 'pybind11::error_already_set'
  what():  error: unpack_from requires a buffer of at least 50529031 bytes for unpacking 50529027 bytes at offset 4 (actual buffer size is 7)

At:
  /opt/tritonserver/backends/python/triton_python_backend_utils.py(123): deserialize_bytes_tensor
```  
or
```
File "/opt/.../py310/lib/python3.10/site-packages/tritonclient/grpc/_infer_result.py", line 93, in as_numpy
    np_array = np_array.reshape(shape)
ValueError: cannot reshape array of size 0 into shape (1,1)
```
