### PR TITLE
feat: Extend response parameters support to BLS in python backend

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -138,3 +138,5 @@ dmypy.json
 # pytype static type analyzer
 .pytype/
 
+# vscode
+.vscode/settings.json

--- a/README.md
+++ b/README.md
@@ -803,8 +803,9 @@ You can read more about the inference response parameters in the [parameters
 extension](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_parameters.md)
 documentation.
 
-Inference response parameters is currently not supported on BLS inference
-responses received by BLS models.
+Inference response parameters is supported when using BLS as well, i.e. when
+using BLS to call another model A, you can access the the optional parameters
+if set by A in its response.
 
 ## Managing Python Runtime and Libraries
 

--- a/README.md
+++ b/README.md
@@ -803,9 +803,11 @@ You can read more about the inference response parameters in the [parameters
 extension](https://github.com/triton-inference-server/server/blob/main/docs/protocol/extension_parameters.md)
 documentation.
 
-Inference response parameters is supported when using BLS as well, i.e. when
-using BLS to call another model A, you can access the the optional parameters
-if set by A in its response.
+The parameters associated with an inference response can be retrieved using the
+`inference_response.parameters()` function. This function returns a JSON string
+where the keys are the keys of the parameters object and the values are the
+values for the parameters field. Note that you need to parse this string using
+`json.loads` to convert it to a dictionary.
 
 ## Managing Python Runtime and Libraries
 

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -158,14 +158,14 @@ InferResponseComplete(
       triton::common::TritonJson::Value parameters_json(
           triton::common::TritonJson::ValueType::OBJECT);
       uint32_t parameter_count;
-      THROW_IF_TRITON_ERROR(
-          TRITONSERVER_InferenceResponseParameterCount(response, &parameter_count));
+      THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceResponseParameterCount(
+          response, &parameter_count));
       for (size_t i = 0; i < parameter_count; i++) {
         const char* name;
         TRITONSERVER_ParameterType type;
         const void* vvalue;
-        THROW_IF_TRITON_ERROR(
-            TRITONSERVER_InferenceResponseParameter(response, i, &name, &type, &vvalue));
+        THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceResponseParameter(
+            response, i, &name, &type, &vvalue));
         if (type == TRITONSERVER_PARAMETER_INT) {
           THROW_IF_TRITON_ERROR(parameters_json.AddInt(
               name, *(reinterpret_cast<const int64_t*>(vvalue))));
@@ -179,7 +179,9 @@ InferResponseComplete(
           THROW_IF_TRITON_ERROR(parameters_json.AddDouble(
               name, *(reinterpret_cast<const double*>(vvalue))));
         } else {
-          throw PythonBackendException((std::string("Unsupported parameter type for parameter '") + name + "'."))
+          throw PythonBackendException(
+              (std::string("Unsupported parameter type for parameter '") +
+               name + "'."))
         }
       }
 
@@ -197,7 +199,11 @@ InferResponseComplete(
       }
       pb_error = std::make_shared<PbError>(pb_exception.what());
     }
+<<<<<<< HEAD
     
+=======
+
+>>>>>>> 408c23b (feat: Extend response parameters support to BLS in python backend)
     if (!infer_payload->IsDecoupled()) {
       infer_response = std::make_unique<InferResponse>(
           output_tensors, pb_error, parameters_string,

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -147,6 +147,7 @@ InferResponseComplete(
       uint32_t parameter_count;
       THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceResponseParameterCount(
           response, &parameter_count));
+
       for (size_t i = 0; i < parameter_count; i++) {
         const char* name;
         TRITONSERVER_ParameterType type;
@@ -162,15 +163,13 @@ InferResponseComplete(
         } else if (type == TRITONSERVER_PARAMETER_STRING) {
           std::string string = reinterpret_cast<const char*>(vvalue);
           THROW_IF_TRITON_ERROR(parameters_json.AddString(name, string));
-        } else if (type == TRITONSERVER_PARAMETER_DOUBLE) {
-          THROW_IF_TRITON_ERROR(parameters_json.AddDouble(
-              name, *(reinterpret_cast<const double*>(vvalue))));
         } else {
           throw PythonBackendException(
               (std::string("Unsupported parameter type for parameter '") +
                name + "'."));
         }
       }
+
       triton::common::TritonJson::WriteBuffer buffer;
       THROW_IF_TRITON_ERROR(parameters_json.Write(&buffer));
       parameters_string = buffer.Contents();

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -171,6 +171,9 @@ InferResponseComplete(
                name + "'."));
         }
       }
+      triton::common::TritonJson::WriteBuffer buffer;
+      THROW_IF_TRITON_ERROR(parameters_json.Write(&buffer));
+      parameters_string = buffer.Contents();
     }
     catch (const PythonBackendException& pb_exception) {
       if (response != nullptr) {

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -157,6 +157,7 @@ InferResponseComplete(
     try {
       triton::common::TritonJson::Value parameters_json(
           triton::common::TritonJson::ValueType::OBJECT);
+      std::cerr << "debug ziqif: response = " << response << std::endl;
       uint32_t parameter_count;
       THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceResponseParameterCount(
           response, &parameter_count));

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -141,23 +141,9 @@ InferResponseComplete(
           output_tensors.push_back(pb_tensor);
         }
       }
-    }
-    catch (const PythonBackendException& pb_exception) {
-      if (response != nullptr) {
-        LOG_IF_ERROR(
-            TRITONSERVER_InferenceResponseDelete(response),
-            "Failed to delete inference response.");
 
-        response = nullptr;
-      }
-      pb_error = std::make_shared<PbError>(pb_exception.what());
-      output_tensors.clear();
-    }
-
-    try {
       triton::common::TritonJson::Value parameters_json(
           triton::common::TritonJson::ValueType::OBJECT);
-      std::cerr << "debug ziqif: response = " << response << std::endl;
       uint32_t parameter_count;
       THROW_IF_TRITON_ERROR(TRITONSERVER_InferenceResponseParameterCount(
           response, &parameter_count));
@@ -185,10 +171,6 @@ InferResponseComplete(
                name + "'."));
         }
       }
-
-      triton::common::TritonJson::WriteBuffer buffer;
-      THROW_IF_TRITON_ERROR(parameters_json.Write(&buffer));
-      parameters_string = buffer.Contents();
     }
     catch (const PythonBackendException& pb_exception) {
       if (response != nullptr) {
@@ -199,6 +181,7 @@ InferResponseComplete(
         response = nullptr;
       }
       pb_error = std::make_shared<PbError>(pb_exception.what());
+      output_tensors.clear();
     }
 
     if (!infer_payload->IsDecoupled()) {

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -84,6 +84,7 @@ InferResponseComplete(
   std::unique_ptr<InferResponse> infer_response;
   std::vector<std::shared_ptr<PbTensor>> output_tensors;
   std::shared_ptr<PbError> pb_error;
+  std::string parameters_string;
 
   if (response != nullptr) {
     try {
@@ -153,21 +154,64 @@ InferResponseComplete(
       output_tensors.clear();
     }
 
-    // TODO: [DLIS-7864] Pass response parameters from BLS response.
+    try {
+      triton::common::TritonJson::Value parameters_json(
+          triton::common::TritonJson::ValueType::OBJECT);
+      uint32_t parameter_count;
+      THROW_IF_TRITON_ERROR(
+          TRITONSERVER_InferenceResponseParameterCount(response, &parameter_count));
+      for (size_t i = 0; i < parameter_count; i++) {
+        const char* name;
+        TRITONSERVER_ParameterType type;
+        const void* vvalue;
+        THROW_IF_TRITON_ERROR(
+            TRITONSERVER_InferenceResponseParameter(response, i, &name, &type, &vvalue));
+        if (type == TRITONSERVER_PARAMETER_INT) {
+          THROW_IF_TRITON_ERROR(parameters_json.AddInt(
+              name, *(reinterpret_cast<const int64_t*>(vvalue))));
+        } else if (type == TRITONSERVER_PARAMETER_BOOL) {
+          THROW_IF_TRITON_ERROR(parameters_json.AddBool(
+              name, *(reinterpret_cast<const bool*>(vvalue))));
+        } else if (type == TRITONSERVER_PARAMETER_STRING) {
+          std::string string = reinterpret_cast<const char*>(vvalue);
+          THROW_IF_TRITON_ERROR(parameters_json.AddString(name, string));
+        } else if (type == TRITONSERVER_PARAMETER_DOUBLE) {
+          THROW_IF_TRITON_ERROR(parameters_json.AddDouble(
+              name, *(reinterpret_cast<const double*>(vvalue))));
+        } else {
+          throw PythonBackendException((std::string("Unsupported parameter type for parameter '") + name + "'."))
+        }
+      }
+
+      triton::common::TritonJson::WriteBuffer buffer;
+      THROW_IF_TRITON_ERROR(parameters_json.Write(&buffer));
+      parameters_string = buffer.Contents();
+    }
+    catch (const PythonBackendException& pb_exception) {
+      if (response != nullptr) {
+        LOG_IF_ERROR(
+            TRITONSERVER_InferenceResponseDelete(response),
+            "Failed to delete inference response.");
+
+        response = nullptr;
+      }
+      pb_error = std::make_shared<PbError>(pb_exception.what());
+    }
+    
     if (!infer_payload->IsDecoupled()) {
       infer_response = std::make_unique<InferResponse>(
-          output_tensors, pb_error, "" /* parameters */,
+          output_tensors, pb_error, parameters_string,
           true /* is_last_response */);
     } else {
       if ((flags & TRITONSERVER_RESPONSE_COMPLETE_FINAL) == 0) {
         // Not the last response.
         infer_response = std::make_unique<InferResponse>(
-            output_tensors, pb_error, "" /* parameters */,
+            output_tensors, pb_error, parameters_string,
             false /* is_last_response */, userp /* id */);
       } else {
         // The last response.
         infer_response = std::make_unique<InferResponse>(
-            output_tensors, pb_error, "" /* parameters */,
+            output_tensors, pb_error, parameters_string,
             true /* is_last_response */, userp /* id */);
       }
     }

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -199,11 +199,7 @@ InferResponseComplete(
       }
       pb_error = std::make_shared<PbError>(pb_exception.what());
     }
-<<<<<<< HEAD
-    
-=======
 
->>>>>>> 408c23b (feat: Extend response parameters support to BLS in python backend)
     if (!infer_payload->IsDecoupled()) {
       infer_response = std::make_unique<InferResponse>(
           output_tensors, pb_error, parameters_string,

--- a/src/request_executor.cc
+++ b/src/request_executor.cc
@@ -181,7 +181,7 @@ InferResponseComplete(
         } else {
           throw PythonBackendException(
               (std::string("Unsupported parameter type for parameter '") +
-               name + "'."))
+               name + "'."));
         }
       }
 


### PR DESCRIPTION
#### What does the PR do?
Add support for setting response parameters in regular and decoupled Python backend model response(s), when using BLS.

#### Checklist
- [X] PR title reflects the change and is of format `<commit_type>: <Title>`
- [X] Changes are described in the pull request.
- [X] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [X] Added [test plan](#test-plan) and verified test passes.
- [X] Verified that the PR passes existing CI.
- [X] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [X] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
Check the [conventional commit type](https://github.com/angular/angular/blob/22b96b9/CONTRIBUTING.md#type)
box here and add the label to the github PR.
- [ ] build
- [ ] ci
- [ ] docs
- [X] feat
- [ ] fix
- [ ] perf
- [ ] refactor
- [ ] revert
- [ ] style
- [ ] test

#### Related PRs:
https://github.com/triton-inference-server/server/pull/7987

#### Where should the reviewer start?
Start with the test cases on the related server PR linked above to learn the context and usage. Then the major changes in this PR are only inside `request_executor.cc`

#### Test plan:
New tests are added to the related server PR.

- CI Pipeline ID: 23548252

#### Caveats:
N/A

#### Background
N/A

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
https://jirasw.nvidia.com/browse/DLIS-7520
