### PR TITLE
Add support for an optional parameter in the example repeat int32 model

### DIFF
--- a/examples/decoupled/repeat_model.py
+++ b/examples/decoupled/repeat_model.py
@@ -116,7 +116,9 @@ class TritonPythonModel:
         # Defaults to 1 if not provided. Example: If input 'IN' is [4] and 'output_num_elements' is set to 3,
         # then 'OUT' will be [4, 4, 4]. If 'output_num_elements' is not specified, 'OUT' will default to [4].
         parameters = self.model_config.get("parameters", {})
-        self.output_num_elements = int(parameters.get("output_num_elements", {}).get("string_value", 1))
+        self.output_num_elements = int(
+            parameters.get("output_num_elements", {}).get("string_value", 1)
+        )
 
         # To keep track of response threads so that we can delay
         # the finalizing the model until all response threads


### PR DESCRIPTION
Updated the `repeat_int32` model to include an optional parameter `output_num_elements`. This parameter allows us to specify the number of elements in the output tensor for each response, which can help increase the tensor size for CI test cases. If the `output_num_elements` parameter is not provided, it defaults to 1 (existing).
For example, if the input 'IN' is [4] and 'output_num_elements' is set to 3, the output 'OUT' will be [4, 4, 4]. If 'output_num_elements' is not specified, the output 'OUT' will default to [4].

For more info https://github.com/triton-inference-server/server/pull/7879