### PR TITLE
Fix: Launch the python backend on Windows when spaces exist in the path.

### DIFF
--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -240,10 +240,10 @@ StubLauncher::Launch()
   std::string launch_command;
 
   std::stringstream ss;
-  ss << python_backend_stub << " " << model_path_ << " " << shm_region_name_
+  ss << "\"" << python_backend_stub << "\" \"" << model_path_ << "\" " << shm_region_name_
      << " " << shm_default_byte_size_ << " " << shm_growth_byte_size_ << " "
-     << parent_pid_ << " " << python_lib_ << " " << ipc_control_handle_ << " "
-     << stub_name << " " << runtime_modeldir_;
+     << parent_pid_ << " \"" << python_lib_ << "\" " << ipc_control_handle_ << " \""
+     << stub_name << "\" \"" << runtime_modeldir_ << "\"";
   launch_command = ss.str();
 
   LOG_MESSAGE(


### PR DESCRIPTION
There were no quotes around any of the paths in the stub launcher. As a result, if you tried launching the stub, it would always fail. Normally this is not an issue in Linux, but having spaces is very common in Windows. Added quotes around all the pathing of the launcher code to resolve this problem.