### PR TITLE
Fix: Boost build failed

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -121,6 +121,7 @@ ExternalProject_Add(
   INSTALL_COMMAND ""
   BUILD_COMMAND ""
 )
+add_compile_definitions(BOOST_NO_CXX98_FUNCTION_BASE)
 set(boostorg_INCLUDE_DIRS "${CMAKE_BINARY_DIR}/boost/")
 
 #


### PR DESCRIPTION
This PR resolves the known compilation error caused by deprecated std::unary_function in Boost's container_hash implementation when building with C++17.

Error Message:
```
[ 26%] Building CXX object CMakeFiles/triton-python-backend.dir/src/python_be.cc.o
In file included from /python_backend/build/boost/functional/hash.hpp:6,
                 from /python_backend/src/python_be.h:37,
                 from /python_backend/src/python_be.cc:26:
/python_backend/build/boost/container_hash/hash.hpp:132:33: error: ‘template<class _Arg, class _Result> struct std::unary_function’ is deprecated [-Werror=deprecated-declarations]
  132 |         struct hash_base : std::unary_function<T, std::size_t> {};
      |                                 ^~~~~~~~~~~~~~
In file included from /usr/include/c++/12/bits/unique_ptr.h:37,
                 from /usr/include/c++/12/memory:75,
                 from /python_backend/build/boost/asio/associated_allocator.hpp:19,
                 from /python_backend/build/boost/asio.hpp:20,
                 from /python_backend/src/python_be.h:34:
/usr/include/c++/12/bits/stl_function.h:117:12: note: declared here
  117 |     struct unary_function
      |            ^~~~~~~~~~~~~~
cc1plus: all warnings being treated as errors
```

releated issue: https://github.com/boostorg/container_hash/issues/22