### PR TITLE
fix: Verify MemoryShm::byte_size inside shared memory boundary

### DIFF
--- a/src/pb_memory.cc
+++ b/src/pb_memory.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -226,6 +226,11 @@ PbMemory::LoadFromSharedMemory(
   MemoryShm* memory_shm_ptr = reinterpret_cast<MemoryShm*>(data_shm);
   char* memory_data_shm = data_shm + sizeof(MemoryShm);
 
+  if (memory_data_shm + memory_shm_ptr->byte_size >
+      (char*)shm_pool->GetBaseAddress() + shm_pool->GetCurrentCapacity()) {
+    throw PythonBackendException("Attempted to access out of bounds memory.");
+  }
+
   char* data_ptr = nullptr;
   bool opened_cuda_ipc_handle = false;
   if (memory_shm_ptr->memory_type == TRITONSERVER_MEMORY_GPU &&
@@ -274,6 +279,11 @@ PbMemory::LoadFromSharedMemory(
   MemoryShm* memory_shm_ptr =
       reinterpret_cast<MemoryShm*>(memory_shm.data_.get());
   char* memory_data_shm = memory_shm.data_.get() + sizeof(MemoryShm);
+
+  if (memory_data_shm + memory_shm_ptr->byte_size >
+      (char*)shm_pool->GetBaseAddress() + shm_pool->GetCurrentCapacity()) {
+    throw PythonBackendException("Attempted to access out of bounds memory.");
+  }
 
   char* data_ptr = nullptr;
   bool opened_cuda_ipc_handle = false;

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -187,6 +187,9 @@ class SharedMemoryManager {
   {
     return cuda_memory_pool_manager_;
   }
+
+  uint64_t GetCurrentCapacity() { return current_capacity_; }
+  void* GetBaseAddress() { return managed_buffer_->get_address(); }
 
   ~SharedMemoryManager() noexcept(false);
 


### PR DESCRIPTION
#### What does the PR do?
When attacker registers the same shm created by python backend, they can overwrite `MemoryShm::byte_size` data with a very large value. Identity model will read a large chunk of sensitive data (e.g. glibc.so) as input tensor, copy to the output tensor and send back to the client.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated [github labels](https://docs.github.com/en/issues/using-labels-and-milestones-to-track-work/managing-labels) field
- [ ] Added [test plan](#test-plan) and verified test passes.
- [ ] Verified that the PR passes existing CI.
- [x] Verified copyright is correct on all changed files.
- [ ] Added _succinct_ git squash message before merging [ref](https://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html).
- [ ] All template sections are filled out.
- [ ] Optional: Additional screenshots for behavior/output changes with before/after.

#### Commit Type:
- [x] fix

#### Related PRs:

#### Where should the reviewer start?

#### Test plan:
<!-- list steps to verify -->
<!-- were e2e tests added?-->

- CI Pipeline ID:
31182731

#### Caveats:
<!-- any limitations or possible things missing from this PR -->

#### Background
<!-- e.g. what led to this change being made. this is optional extra information to help the reviewer -->

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- closes GitHub issue: #xxx