### PR TITLE
fix: Improve error handling for Python backend model initialization failures

### DIFF
--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -303,7 +303,7 @@ StubLauncher::Launch()
   // monitoring thread may take longer which can make the server process think
   // that the stub process is unhealthy and return early. Waiting with a longer
   // timeout prevents this issue.
-  const uint64_t initialization_timeout_ms = 5000;  // 5 sec
+  const uint64_t initialization_timeout_ms = 10000;  // 10 sec
   LOG_MESSAGE(
       TRITONSERVER_LOG_VERBOSE,
       "Waiting for the stub health monitoring thread to start");
@@ -475,7 +475,7 @@ StubLauncher::Launch()
     // monitoring thread may take longer which can make the server process think
     // that the stub process is unhealthy and return early. Waiting with a
     // longer timeout prevents this issue.
-    const uint64_t initialization_timeout_ms = 5000;  // 5 sec
+    const uint64_t initialization_timeout_ms = 10000;  // 10 sec
     LOG_MESSAGE(
         TRITONSERVER_LOG_VERBOSE,
         "Waiting for the stub health monitoring thread to start");

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -288,7 +288,6 @@ StubLauncher::Launch()
       parent_message_queue_.reset();
       memory_manager_.reset();
       WaitForStubProcess();
-      shm_pool_.reset();
     }
   });
 
@@ -445,7 +444,6 @@ StubLauncher::Launch()
         parent_message_queue_.reset();
         memory_manager_.reset();
         WaitForStubProcess();
-        shm_pool_.reset();
       }
     });
 

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -280,7 +280,9 @@ StubLauncher::Launch()
     // Push a dummy message to the message queue so that the stub
     // process is notified that it can release the object stored in
     // shared memory.
-    stub_message_queue_->Push(DUMMY_MESSAGE);
+    if (stub_message_queue_) {
+      stub_message_queue_->Push(DUMMY_MESSAGE);
+    }
 
     // If the model is not initialized, wait for the stub process to exit.
     if (!is_initialized_) {
@@ -303,6 +305,9 @@ StubLauncher::Launch()
   // health thread is spawn would make sure would prevent this issue.
   bi::managed_external_buffer::handle_t message;
   auto err = ReceiveMessageFromStub(message);
+  if (err != nullptr) {
+    KillStubProcess();
+  }
 
   if (stub_process_kind_ == "AUTOCOMPLETE_STUB") {
     if (err != nullptr) {
@@ -440,7 +445,9 @@ StubLauncher::Launch()
       // Push a dummy message to the message queue so that the stub
       // process is notified that it can release the object stored in
       // shared memory.
-      stub_message_queue_->Push(DUMMY_MESSAGE);
+      if (stub_message_queue_) {
+        stub_message_queue_->Push(DUMMY_MESSAGE);
+      }
 
       // If the model is not initialized, wait for the stub process to exit.
       if (!is_initialized_) {
@@ -465,6 +472,9 @@ StubLauncher::Launch()
     // health thread is spawn would prevent this issue.
     bi::managed_external_buffer::handle_t message;
     auto err = ReceiveMessageFromStub(message);
+    if (err != nullptr) {
+      KillStubProcess();
+    }
 
     if (stub_process_kind_ == "AUTOCOMPLETE_STUB") {
       if (err != nullptr) {

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -288,6 +288,7 @@ StubLauncher::Launch()
       parent_message_queue_.reset();
       memory_manager_.reset();
       WaitForStubProcess();
+      shm_pool_.reset();
     }
   });
 
@@ -444,6 +445,7 @@ StubLauncher::Launch()
         parent_message_queue_.reset();
         memory_manager_.reset();
         WaitForStubProcess();
+        shm_pool_.reset();
       }
     });
 

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -302,9 +302,12 @@ StubLauncher::Launch()
   // that the stub process is unhealthy and return early. Waiting until the
   // health thread is spawn would make sure would prevent this issue.
   bi::managed_external_buffer::handle_t message;
-  RETURN_IF_ERROR(ReceiveMessageFromStub(message));
+  auto err = ReceiveMessageFromStub(message);
 
   if (stub_process_kind_ == "AUTOCOMPLETE_STUB") {
+    if (err != nullptr) {
+      throw BackendModelException(err);
+    }
     try {
       AutocompleteStubProcess();
     }
@@ -315,6 +318,7 @@ StubLauncher::Launch()
           TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INTERNAL, ex.what()));
     }
   } else if (stub_process_kind_ == "MODEL_INSTANCE_STUB") {
+    RETURN_IF_ERROR(err);
     RETURN_IF_ERROR(ModelInstanceStubProcess());
   } else {
     return TRITONSERVER_ErrorNew(
@@ -460,9 +464,12 @@ StubLauncher::Launch()
     // that the stub process is unhealthy and return early. Waiting until the
     // health thread is spawn would prevent this issue.
     bi::managed_external_buffer::handle_t message;
-    RETURN_IF_ERROR(ReceiveMessageFromStub(message));
+    auto err = ReceiveMessageFromStub(message);
 
     if (stub_process_kind_ == "AUTOCOMPLETE_STUB") {
+      if (err != nullptr) {
+        throw BackendModelException(err);
+      }
       try {
         AutocompleteStubProcess();
       }
@@ -473,6 +480,7 @@ StubLauncher::Launch()
             TRITONSERVER_ErrorNew(TRITONSERVER_ERROR_INTERNAL, ex.what()));
       }
     } else if (stub_process_kind_ == "MODEL_INSTANCE_STUB") {
+      RETURN_IF_ERROR(err);
       RETURN_IF_ERROR(ModelInstanceStubProcess());
     } else {
       return TRITONSERVER_ErrorNew(

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -301,7 +301,8 @@ StubLauncher::Launch()
   // monitoring thread may take longer which can make the server process think
   // that the stub process is unhealthy and return early. Waiting until the
   // health thread is spawn would make sure would prevent this issue.
-  parent_message_queue_->Pop();
+  bi::managed_external_buffer::handle_t message;
+  RETURN_IF_ERROR(ReceiveMessageFromStub(message));
 
   if (stub_process_kind_ == "AUTOCOMPLETE_STUB") {
     try {
@@ -458,7 +459,8 @@ StubLauncher::Launch()
     // monitoring thread may take longer which can make the server process think
     // that the stub process is unhealthy and return early. Waiting until the
     // health thread is spawn would prevent this issue.
-    parent_message_queue_->Pop();
+    bi::managed_external_buffer::handle_t message;
+    RETURN_IF_ERROR(ReceiveMessageFromStub(message));
 
     if (stub_process_kind_ == "AUTOCOMPLETE_STUB") {
       try {

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -315,7 +315,9 @@ StubLauncher::Launch()
   }
 
   if (stub_process_kind_ == "AUTOCOMPLETE_STUB") {
-    THROW_IF_BACKEND_MODEL_ERROR(err);
+    if (err != nullptr) {
+      throw BackendModelException(err);
+    }
     try {
       AutocompleteStubProcess();
     }
@@ -485,7 +487,9 @@ StubLauncher::Launch()
     }
 
     if (stub_process_kind_ == "AUTOCOMPLETE_STUB") {
-      THROW_IF_BACKEND_MODEL_ERROR(err);
+      if (err != nullptr) {
+        throw BackendModelException(err);
+      }
       try {
         AutocompleteStubProcess();
       }

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -147,7 +147,8 @@ class StubLauncher {
 
   // Get a message from the stub process
   TRITONSERVER_Error* ReceiveMessageFromStub(
-      bi::managed_external_buffer::handle_t& message);
+      bi::managed_external_buffer::handle_t& message,
+      uint64_t timeout_miliseconds = 1000);
 
   // Wait for stub process
   void WaitForStubProcess();


### PR DESCRIPTION
- This change aims to prevent the server from hanging when a Python backend model fails to initialize. It replaces an indefinite wait for a message from the stub process with the `ReceiveMessageFromStub` function, which correctly detects errors from the stub process.
- Additionally, it fixes shm cleanup when a model fails to initialize (DLIS-8432).