### PR TITLE
fix: Fix segfault during shutdown when using Triton metrics in Python backend

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1491,7 +1491,8 @@ Stub::GetCUDAMemoryPoolAddress(std::unique_ptr<IPCMessage>& ipc_message)
 }
 
 void
-Stub::DestroyPythonObjects() {
+Stub::DestroyPythonObjects()
+{
   // Ensure the interpreter is active before trying to clean up.
   if (Py_IsInitialized()) {
     py::gil_scoped_acquire acquire;

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1491,6 +1491,17 @@ Stub::GetCUDAMemoryPoolAddress(std::unique_ptr<IPCMessage>& ipc_message)
 }
 
 void
+Stub::DestroyPythonObjects() {
+  // Ensure the interpreter is active before trying to clean up.
+  if (Py_IsInitialized()) {
+    py::gil_scoped_acquire acquire;
+    py::object async_event_loop_local(std::move(async_event_loop_));
+    py::object background_futures_local(std::move(background_futures_));
+    py::object model_instance_local(std::move(model_instance_));
+  }
+}
+
+void
 Stub::ProcessBLSResponseDecoupled(std::unique_ptr<IPCMessage>& ipc_message)
 {
   ResponseBatch* response_batch = nullptr;
@@ -2077,6 +2088,7 @@ main(int argc, char** argv)
             non_graceful_exit = true;
 
             // Destroy stub and exit.
+            stub->DestroyPythonObjects();
             logger.reset();
             stub.reset();
             exit(1);
@@ -2110,6 +2122,7 @@ main(int argc, char** argv)
   // objects. If the scoped_interpreter is destroyed before the stub object,
   // this process will no longer hold the GIL lock and destruction of the stub
   // will result in segfault.
+  stub->DestroyPythonObjects();
   logger.reset();
   stub.reset();
 

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1088,6 +1088,11 @@ Stub::GetOrCreateInstance()
 void
 Stub::DestroyInstance()
 {
+  if (!stub_instance) {
+    return;
+  }
+
+  stub_instance->DestroyPythonObjects();
   stub_instance.reset();
 }
 
@@ -2197,7 +2202,6 @@ main(int argc, char** argv)
             non_graceful_exit = true;
 
             // Destroy stub and exit.
-            stub->DestroyPythonObjects();
             logger.reset();
             Stub::DestroyInstance();
             exit(1);
@@ -2231,7 +2235,6 @@ main(int argc, char** argv)
   // objects. If the scoped_interpreter is destroyed before the stub object,
   // this process will no longer hold the GIL lock and destruction of the stub
   // will result in segfault.
-  stub->DestroyPythonObjects();
   logger.reset();
   Stub::DestroyInstance();
 

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1065,6 +1065,8 @@ Stub::~Stub()
     py::object async_event_loop_local(std::move(async_event_loop_));
     py::object background_futures_local(std::move(background_futures_));
     py::object model_instance_local(std::move(model_instance_));
+    py::object deserialize_bytes_local(std::move(deserialize_bytes_));
+    py::object serialize_bytes_local(std::move(serialize_bytes_));
   }
 
   stub_message_queue_.reset();
@@ -1517,6 +1519,8 @@ Stub::DestroyPythonObjects()
     py::object async_event_loop_local(std::move(async_event_loop_));
     py::object background_futures_local(std::move(background_futures_));
     py::object model_instance_local(std::move(model_instance_));
+    py::object deserialize_bytes_local(std::move(deserialize_bytes_));
+    py::object serialize_bytes_local(std::move(serialize_bytes_));
   }
 }
 

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1059,15 +1059,7 @@ Stub::~Stub()
   }
 #endif
 
-  // Ensure the interpreter is active before trying to clean up.
-  if (Py_IsInitialized()) {
-    py::gil_scoped_acquire acquire;
-    py::object async_event_loop_local(std::move(async_event_loop_));
-    py::object background_futures_local(std::move(background_futures_));
-    py::object model_instance_local(std::move(model_instance_));
-    py::object deserialize_bytes_local(std::move(deserialize_bytes_));
-    py::object serialize_bytes_local(std::move(serialize_bytes_));
-  }
+  DestroyPythonObjects();
 
   stub_message_queue_.reset();
   parent_message_queue_.reset();

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -265,6 +265,11 @@ class Stub {
   /// Get the CUDA memory pool address from the parent process.
   void GetCUDAMemoryPoolAddress(std::unique_ptr<IPCMessage>& ipc_message);
 
+  /// Cleans up Python objects and must be called before the destructor.
+  /// This prevents problems that occur when Python object destructors
+  /// call Stub::GetOrCreate.
+  void DestroyPythonObjects();
+
  private:
   bi::interprocess_mutex* stub_mutex_;
   bi::interprocess_condition* stub_cond_;

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -269,7 +269,7 @@ class Stub {
 
   /// Cleans up Python objects and must be called before the destructor.
   /// This prevents problems that occur when Python object destructors
-  /// call Stub::GetOrCreate.
+  /// call Stub::GetOrCreateInstance.
   void DestroyPythonObjects();
 
   /// Calls the user's is_ready() Python method and returns its response


### PR DESCRIPTION
**Problem**
When shutting down the Triton Inference Server with Python backend while using Triton metrics, a segmentation fault occurs. This happens because Metric::Clear attempts to access the Stub singleton during the Stub destructor execution.

Stack trace:
```
#0  triton::backend::python::Metric::SaveToSharedMemory()
#1  triton::backend::python::Metric::Clear()
#2  triton::backend::python::MetricFamily::~MetricFamily()
#3  std::_Sp_counted_base<>::_M_release()
#4  pybind11::class_<MetricFamily>::dealloc()
#5  pybind11_object_dealloc()
#6  libpython3.12.so.1.0
#7  libpython3.12.so.1.0
#8  triton::backend::python::Stub::~Stub()
#9  main()
```

**Solution**
Added a new DestroyPythonObjects() method to the Stub class that explicitly releases all Python objects before the Stub destructor is invoked. This ensures proper destruction order:

DestroyPythonObjects() is called first, releasing all Python-bound objects (including MetricFamily instances)
Stub::~Stub() is called afterward, when no Python objects depend on it
This approach guarantees that MetricFamily and other Python objects are fully destroyed while Stub is still valid and accessible.

**To reproduce**
Run triton server with [custom metric example](https://github.com/aleksn7/python_backend/blob/main/examples/custom_metrics/model.py) model and shut it down by `kill -2 <main triton server process pid>`
