### PR TITLE
feat: Support user-defined `is_ready()` in Python backend readiness checks

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,7 @@ any C++ code.
         - [Async Execute](#async-execute)
       - [Request Rescheduling](#request-rescheduling)
     - [`finalize`](#finalize)
+    - [`is_model_ready`](#is_model_ready)
   - [Model Config File](#model-config-file)
   - [Inference Request Parameters](#inference-request-parameters)
   - [Inference Response Parameters](#inference-response-parameters)

--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ any C++ code.
         - [Async Execute](#async-execute)
       - [Request Rescheduling](#request-rescheduling)
     - [`finalize`](#finalize)
-    - [`is_model_ready`](#is_model_ready)
+    - [`is_ready`](#is_ready)
   - [Model Config File](#model-config-file)
   - [Inference Request Parameters](#inference-request-parameters)
   - [Inference Response Parameters](#inference-response-parameters)
@@ -368,10 +368,10 @@ class TritonPythonModel:
         """
         print('Cleaning up...')
 
-    def is_model_ready(self):
-        """`is_model_ready` is called whenever the model readiness is checked
+    def is_ready(self):
+        """`is_ready` is called whenever the model readiness is checked
         via the health endpoint (v2/models/<model>/ready). Implementing
-        `is_model_ready` is optional. If not implemented, the model is
+        `is_ready` is optional. If not implemented, the model is
         considered ready as long as the stub process is healthy. This
         function must return a boolean value. Both sync and async
         implementations are supported.
@@ -765,9 +765,9 @@ class TritonPythonModel:
 Implementing `finalize` is optional. This function allows you to do any clean
 ups necessary before the model is unloaded from Triton server.
 
-### `is_model_ready`
+### `is_ready`
 
-Implementing `is_model_ready` is optional. When defined, this function is invoked whenever the model’s readiness is verified through the
+Implementing `is_ready` is optional. When defined, this function is invoked whenever the model’s readiness is verified through the
 `v2/models/<model>/ready` health endpoint. It must return a **boolean** value
 (`True` or `False`). Both synchronous and asynchronous (`async def`)
 implementations are supported.
@@ -779,11 +779,11 @@ Common use cases include:
 - **Graceful drain** — Use an external signal (such as a file flag, environment variable, or admin endpoint) to mark the model as not ready, allowing orchestrators like Kubernetes to stop routing traffic before shutdown or maintenance.
 - **Internal state validation** — Confirm that caches, connection pools, and other runtime state required for inference are healthy.
 
-If `is_model_ready` is not implemented, the model is considered ready as long as the stub process remains healthy (the default behavior). In this case, no IPC overhead is incurred.
+If `is_ready` is not implemented, the model is considered ready as long as the stub process remains healthy (the default behavior). In this case, no IPC overhead is incurred.
 
-When `is_model_ready` is implemented, a readiness check timeout of five seconds is enforced. If the function fails to return within this period, the model is reported as not ready for that check. Only one internal readiness IPC call is executed per model instance at a given time. Concurrent readiness requests wait for the ongoing call to complete and reuse its result.
+When `is_ready` is implemented, a readiness check timeout of five seconds is enforced. If the function fails to return within this period, the model is reported as not ready for that check. Only one internal readiness IPC call is executed per model instance at a given time. Concurrent readiness requests wait for the ongoing call to complete and reuse its result.
 
-**Note:** The `is_model_ready` function should be kept as lightweight and efficient as possible. It shares an internal message queue with BLS decoupled response delivery. Although a slow readiness check does not affect standard (non‑decoupled) inference directly, it can delay the delivery of BLS decoupled streaming responses while both requests are processed. Avoid blocking operations such as long-running network calls or heavy computations inside this function.
+**Note:** The `is_ready` function should be kept as lightweight and efficient as possible. It shares an internal message queue with BLS decoupled response delivery. Although a slow readiness check does not affect standard (non‑decoupled) inference directly, it can delay the delivery of BLS decoupled streaming responses while both requests are processed. Avoid blocking operations such as long-running network calls or heavy computations inside this function.
 
 ```python
 import triton_python_backend_utils as pb_utils
@@ -794,7 +794,7 @@ class TritonPythonModel:
         # Load model resources, establish connections, etc.
         self.resource = connect_to_resource()
 
-    def is_model_ready(self):
+    def is_ready(self):
         # Perform custom readiness checks such as verifying
         # that dependent resources are available.
         return self.resource.is_available()
@@ -810,7 +810,7 @@ An asynchronous implementation is also supported:
 
 ```python
 class TritonPythonModel:
-    async def is_model_ready(self):
+    async def is_ready(self):
         status = await self.check_dependency_health()
         return status.ok
     ...

--- a/README.md
+++ b/README.md
@@ -772,6 +772,13 @@ Implementing `is_model_ready` is optional. When defined, this function is invoke
 (`True` or `False`). Both synchronous and asynchronous (`async def`)
 implementations are supported.
 
+Common use cases include:
+
+- **External dependency checks** — Verify that required databases, remote APIs, feature stores, or downstream services are reachable before accepting requests.
+- **Lazy resource loading** — Return `False` until model weights or large artifacts being downloaded or initialized in the background are fully available.
+- **Graceful drain** — Use an external signal (such as a file flag, environment variable, or admin endpoint) to mark the model as not ready, allowing orchestrators like Kubernetes to stop routing traffic before shutdown or maintenance.
+- **Internal state validation** — Confirm that caches, connection pools, and other runtime state required for inference are healthy.
+
 If `is_model_ready` is not implemented, the model is considered ready as long as the stub process remains healthy (the default behavior). In this case, no IPC overhead is incurred.
 
 When `is_model_ready` is implemented, a readiness check timeout of five seconds is enforced. If the function fails to return within this period, the model is reported as not ready for that check. Only one internal readiness IPC call is executed per model instance at a given time. Concurrent readiness requests wait for the ongoing call to complete and reuse its result.

--- a/src/ipc_message.h
+++ b/src/ipc_message.h
@@ -69,8 +69,7 @@ typedef enum PYTHONSTUB_commandtype_enum {
   PYTHONSTUB_ModelReadinessRequest,
   PYTHONSTUB_IsRequestCancelled,
   PYTHONSTUB_CancelBLSInferRequest,
-  PYTHONSTUB_UserModelReadinessRequest,
-  PYTHONSTUB_UserModelReadinessResponse
+  PYTHONSTUB_UserModelReadinessRequest
 } PYTHONSTUB_CommandType;
 
 ///

--- a/src/ipc_message.h
+++ b/src/ipc_message.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -68,7 +68,9 @@ typedef enum PYTHONSTUB_commandtype_enum {
   PYTHONSTUB_UnloadModelRequest,
   PYTHONSTUB_ModelReadinessRequest,
   PYTHONSTUB_IsRequestCancelled,
-  PYTHONSTUB_CancelBLSInferRequest
+  PYTHONSTUB_CancelBLSInferRequest,
+  PYTHONSTUB_UserModelReadinessRequest,
+  PYTHONSTUB_UserModelReadinessResponse
 } PYTHONSTUB_CommandType;
 
 ///

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1591,15 +1591,13 @@ Stub::ProcessUserModelReadinessRequest(std::unique_ptr<IPCMessage>& ipc_message)
     readiness_payload = readiness_message.data_.get();
   }
   catch (const PythonBackendException& pb_exception) {
-    LOG_ERROR
-        << "Failed to process model readiness request: "
-        << pb_exception.what();
+    LOG_ERROR << "Failed to process model readiness request: "
+              << pb_exception.what();
     return;
   }
 
   if (ipc_message->ResponseMutex() == nullptr) {
-    LOG_ERROR
-        << "Failed to process model readiness request";
+    LOG_ERROR << "Failed to process model readiness request";
     return;
   }
 

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -596,7 +596,7 @@ Stub::Initialize(bi::managed_external_buffer::handle_t map_handle)
   }
 
   // Cache whether is_model_ready() function defined in the Python model.
-  ipc_control_->stub_has_model_ready_fn =
+  ipc_control_->stub_has_user_model_readiness_fn =
       py::hasattr(model_instance_, "is_model_ready");
 
   initialized_ = true;

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1591,10 +1591,15 @@ Stub::ProcessUserModelReadinessRequest(std::unique_ptr<IPCMessage>& ipc_message)
     readiness_payload = readiness_message.data_.get();
   }
   catch (const PythonBackendException& pb_exception) {
+    LOG_ERROR
+        << "Failed to process model readiness request: "
+        << pb_exception.what();
     return;
   }
 
   if (ipc_message->ResponseMutex() == nullptr) {
+    LOG_ERROR
+        << "Failed to process model readiness request";
     return;
   }
 

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -595,9 +595,9 @@ Stub::Initialize(bi::managed_external_buffer::handle_t map_handle)
     model_instance_.attr("initialize")(model_config_params);
   }
 
-  // Cache whether is_model_ready() function defined in the Python model.
+  // Cache whether is_ready() function defined in the Python model.
   ipc_control_->stub_has_user_model_readiness_fn =
-      py::hasattr(model_instance_, "is_model_ready");
+      py::hasattr(model_instance_, "is_ready");
 
   initialized_ = true;
 }
@@ -1609,11 +1609,11 @@ Stub::ProcessUserModelReadinessRequest(std::unique_ptr<IPCMessage>& ipc_message)
   try {
     py::gil_scoped_acquire acquire;
 
-    function_exists = py::hasattr(model_instance_, "is_model_ready");
+    function_exists = py::hasattr(model_instance_, "is_ready");
     if (!function_exists) {
       is_ready = true;
     } else {
-      py::object result = model_instance_.attr("is_model_ready")();
+      py::object result = model_instance_.attr("is_ready")();
 
       bool is_coroutine = py::module::import("asyncio")
                               .attr("iscoroutine")(result)
@@ -1624,7 +1624,7 @@ Stub::ProcessUserModelReadinessRequest(std::unique_ptr<IPCMessage>& ipc_message)
 
       if (!py::isinstance<py::bool_>(result)) {
         throw PythonBackendException(
-            "is_model_ready() must return a boolean value");
+            "is_ready() must return a boolean value");
       }
 
       is_ready = result.cast<bool>();

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1623,8 +1623,7 @@ Stub::ProcessUserModelReadinessRequest(std::unique_ptr<IPCMessage>& ipc_message)
       }
 
       if (!py::isinstance<py::bool_>(result)) {
-        throw PythonBackendException(
-            "is_ready() must return a boolean value");
+        throw PythonBackendException("is_ready() must return a boolean value");
       }
 
       is_ready = result.cast<bool>();

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -264,6 +264,11 @@ class Stub {
 
   /// Get the CUDA memory pool address from the parent process.
   void GetCUDAMemoryPoolAddress(std::unique_ptr<IPCMessage>& ipc_message);
+
+  /// Calls the user's is_model_ready() Python method and returns its response
+  /// when handling model readiness check requests.
+  void ProcessUserModelReadinessRequest(
+      std::unique_ptr<IPCMessage>& ipc_message);
 
  private:
   bi::interprocess_mutex* stub_mutex_;

--- a/src/pb_stub.h
+++ b/src/pb_stub.h
@@ -265,7 +265,7 @@ class Stub {
   /// Get the CUDA memory pool address from the parent process.
   void GetCUDAMemoryPoolAddress(std::unique_ptr<IPCMessage>& ipc_message);
 
-  /// Calls the user's is_model_ready() Python method and returns its response
+  /// Calls the user's is_ready() Python method and returns its response
   /// when handling model readiness check requests.
   void ProcessUserModelReadinessRequest(
       std::unique_ptr<IPCMessage>& ipc_message);

--- a/src/pb_utils.h
+++ b/src/pb_utils.h
@@ -145,7 +145,7 @@ struct IPCControlShm {
   bool parent_health;
   bool uses_env;
   bool decoupled;
-  bool stub_has_model_ready_fn;
+  bool stub_has_user_model_readiness_fn;
   bi::interprocess_mutex parent_health_mutex;
   bi::interprocess_mutex stub_health_mutex;
   bi::managed_external_buffer::handle_t stub_message_queue;

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -1,4 +1,4 @@
-// Copyright 2020-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2020-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -893,6 +893,241 @@ ModelInstanceState::ProcessCancelBLSRequest(
       message_payload->cv.wait(lk);
     }
   }
+}
+
+void
+ModelInstanceState::SetUserModelReadinessResult(
+    const bool ready, const bool has_error, const std::string& error_message)
+{
+  std::lock_guard<std::mutex> guard(user_model_readiness_mutex_);
+  user_model_readiness_result_ = ready;
+  user_model_readiness_has_error_ = has_error;
+  user_model_readiness_error_ = error_message;
+  user_model_readiness_inflight_ = false;
+  user_model_readiness_cv_.notify_all();
+}
+
+void
+ModelInstanceState::UserModelReadinessCleanupTask(
+    std::unique_ptr<IPCMessage> ipc_message_cleanup,
+    AllocatedSharedMemory<UserModelReadinessMessage> readiness_message_cleanup)
+{
+  UserModelReadinessMessage* payload = readiness_message_cleanup.data_.get();
+  bool result_ready = false;
+  bool result_has_error = false;
+  std::string result_error_message;
+  bool abort_wait = false;
+
+  {
+    bi::scoped_lock<bi::interprocess_mutex> cleanup_lock{
+        *(ipc_message_cleanup->ResponseMutex())};
+    while (!payload->waiting_on_stub) {
+      ipc_message_cleanup->ResponseCondition()->wait(cleanup_lock);
+      if (!payload->waiting_on_stub && !IsStubProcessAlive()) {
+        abort_wait = true;
+        break;
+      }
+    }
+
+    if (!abort_wait) {
+      if (payload->has_error) {
+        result_has_error = true;
+        if (payload->is_error_set) {
+          std::unique_ptr<PbString> error_message =
+              PbString::LoadFromSharedMemory(Stub()->ShmPool(), payload->error);
+          result_error_message = error_message->String();
+        } else {
+          result_error_message =
+              "User-defined is_model_ready() failed with unknown error";
+        }
+      } else {
+        if (!payload->function_exists) {
+          result_ready = true;
+        } else {
+          result_ready = payload->is_ready;
+        }
+      }
+    }
+  }
+
+  if (abort_wait) {
+    SetUserModelReadinessResult(
+        false, true, "Stub process is not healthy during readiness cleanup");
+    return;
+  }
+
+  SetUserModelReadinessResult(
+      result_ready, result_has_error, result_error_message);
+
+  {
+    bi::scoped_lock<bi::interprocess_mutex> cleanup_lock{
+        *(ipc_message_cleanup->ResponseMutex())};
+    payload->waiting_on_stub = false;
+    ipc_message_cleanup->ResponseCondition()->notify_all();
+  }
+}
+
+void
+ModelInstanceState::ScheduleUserModelReadinessCleanupTask(
+    std::unique_ptr<IPCMessage> ipc_message,
+    AllocatedSharedMemory<UserModelReadinessMessage> readiness_message)
+{
+  auto cleanup_task = [this, ipc_message_cleanup = std::move(ipc_message),
+                       readiness_message_cleanup =
+                           std::move(readiness_message)]() mutable {
+    UserModelReadinessCleanupTask(
+        std::move(ipc_message_cleanup), std::move(readiness_message_cleanup));
+  };
+
+  // Use the instance thread pool if available
+  if (thread_pool_ != nullptr) {
+    boost::asio::post(*thread_pool_, std::move(cleanup_task));
+  } else {
+    cleanup_task();
+  }
+}
+
+TRITONSERVER_Error*
+ModelInstanceState::RunUserModelReadinessCheck(bool* is_ready)
+{
+  std::unique_lock<std::mutex> lock(user_model_readiness_mutex_);
+
+  // FAST PATH: No user-defined function - return immediately
+  // (zero IPC overhead)
+  if (!Stub()->HasUserModelReadyFunction()) {
+    *is_ready = true;
+    return nullptr;
+  }
+
+  // SLOW PATH: User-defined function exists - need to perform IPC call to stub
+
+  // If another request is already performing a readiness check, wait for it to
+  // finish and return the same result (to avoid multiple concurrent IPC calls
+  // to the stub).
+  if (user_model_readiness_inflight_) {
+    auto deadline = std::chrono::steady_clock::now() +
+                    std::chrono::milliseconds(kUserModelReadinessTimeoutMs);
+    while (user_model_readiness_inflight_) {
+      if (user_model_readiness_cv_.wait_until(lock, deadline) ==
+          std::cv_status::timeout) {
+        return TRITONSERVER_ErrorNew(
+            TRITONSERVER_ERROR_UNAVAILABLE,
+            "Timed out waiting for in-flight is_model_ready() response");
+      }
+    }
+
+    if (user_model_readiness_has_error_) {
+      return TRITONSERVER_ErrorNew(
+          TRITONSERVER_ERROR_INTERNAL, user_model_readiness_error_.c_str());
+    }
+
+    *is_ready = user_model_readiness_result_;
+    return nullptr;
+  }
+
+  user_model_readiness_inflight_ = true;
+  user_model_readiness_has_error_ = false;
+  user_model_readiness_error_.clear();
+  lock.unlock();
+
+  // Default to not ready for error cases
+  *is_ready = false;
+
+  std::unique_ptr<IPCMessage> ipc_message;
+  AllocatedSharedMemory<UserModelReadinessMessage> readiness_message;
+  UserModelReadinessMessage* readiness_payload = nullptr;
+
+  try {
+    ipc_message =
+        IPCMessage::Create(Stub()->ShmPool(), true /* inline_response */);
+    readiness_message =
+        Stub()->ShmPool()->Construct<UserModelReadinessMessage>();
+    readiness_payload = readiness_message.data_.get();
+
+    // Initialize payload fields
+    new (&(readiness_payload->mu)) bi::interprocess_mutex;
+    new (&(readiness_payload->cv)) bi::interprocess_condition;
+    readiness_payload->waiting_on_stub = false;
+    readiness_payload->has_error = false;
+    readiness_payload->is_error_set = false;
+    readiness_payload->function_exists = false;
+    readiness_payload->is_ready = false;
+    readiness_payload->error = 0;
+
+    ipc_message->Command() = PYTHONSTUB_UserModelReadinessRequest;
+    ipc_message->Args() = readiness_message.handle_;
+  }
+  catch (const PythonBackendException& pb_exception) {
+    SetUserModelReadinessResult(false, true, pb_exception.what());
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INTERNAL, pb_exception.what());
+  }
+
+  {
+    bi::scoped_lock<bi::interprocess_mutex> lock{
+        *(ipc_message->ResponseMutex())};
+    Stub()->ParentToStubMessageQueue()->Push(ipc_message->ShmHandle());
+
+    // Wait for stub response with timeout
+    boost::posix_time::ptime timeout =
+        boost::get_system_time() +
+        boost::posix_time::milliseconds(kUserModelReadinessTimeoutMs);
+
+    while (!readiness_payload->waiting_on_stub) {
+      if (!ipc_message->ResponseCondition()->timed_wait(lock, timeout)) {
+        if (!readiness_payload->waiting_on_stub) {
+          // IMPORTANT: Keep IPC message/payload alive until stub finishes,
+          // otherwise shared-memory may be deallocated before stub reads it.
+          ScheduleUserModelReadinessCleanupTask(
+              std::move(ipc_message), std::move(readiness_message));
+
+          return TRITONSERVER_ErrorNew(
+              TRITONSERVER_ERROR_UNAVAILABLE,
+              "Timed out waiting for user-defined is_model_ready() response");
+        }
+      }
+    }
+  }
+
+  bool result_ready = false;
+  bool result_has_error = false;
+  std::string result_error_message;
+
+  if (readiness_payload->has_error) {
+    result_has_error = true;
+    if (readiness_payload->is_error_set) {
+      std::unique_ptr<PbString> error_message = PbString::LoadFromSharedMemory(
+          Stub()->ShmPool(), readiness_payload->error);
+      result_error_message = error_message->String();
+    } else {
+      result_error_message =
+          "User-defined is_model_ready() failed with unknown error";
+    }
+  } else {
+    if (!readiness_payload->function_exists) {
+      result_ready = true;
+    } else {
+      result_ready = readiness_payload->is_ready;
+    }
+  }
+
+  {
+    bi::scoped_lock<bi::interprocess_mutex> lock{
+        *(ipc_message->ResponseMutex())};
+    readiness_payload->waiting_on_stub = false;
+    ipc_message->ResponseCondition()->notify_all();
+  }
+
+  SetUserModelReadinessResult(
+      result_ready, result_has_error, result_error_message);
+
+  if (result_has_error) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_INTERNAL, result_error_message.c_str());
+  }
+
+  *is_ready = result_ready;
+  return nullptr;
 }
 
 void
@@ -2430,6 +2665,18 @@ TRITONBACKEND_ModelInstanceReady(TRITONBACKEND_ModelInstance* instance)
         TRITONSERVER_ERROR_INTERNAL,
         (std::string("Stub process '") + instance_state->Name() +
          "' is not healthy.")
+            .c_str());
+  }
+
+  // Run user-defined model readiness function is_model_ready if it exists.
+  bool is_ready = true;
+  RETURN_IF_ERROR(instance_state->RunUserModelReadinessCheck(&is_ready));
+
+  if (!is_ready) {
+    return TRITONSERVER_ErrorNew(
+        TRITONSERVER_ERROR_UNAVAILABLE,
+        (std::string("Model '") + instance_state->Name() +
+         "' is not ready (user-defined check failed).")
             .c_str());
   }
 

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -994,7 +994,7 @@ ModelInstanceState::RunUserModelReadinessCheck(bool* is_ready)
 
   // FAST PATH: No user-defined function - return immediately
   // (zero IPC overhead)
-  if (!Stub()->HasUserModelReadyFunction()) {
+  if (!Stub()->HasUserModelReadinessFunction()) {
     *is_ready = true;
     return nullptr;
   }

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -938,7 +938,7 @@ ModelInstanceState::UserModelReadinessCleanupTask(
           result_error_message = error_message->String();
         } else {
           result_error_message =
-              "User-defined is_model_ready() failed with unknown error";
+              "User-defined is_ready() failed with unknown error";
         }
       } else {
         if (!payload->function_exists) {
@@ -1012,7 +1012,7 @@ ModelInstanceState::RunUserModelReadinessCheck(bool* is_ready)
           std::cv_status::timeout) {
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_UNAVAILABLE,
-            "Timed out waiting for in-flight is_model_ready() response");
+            "Timed out waiting for in-flight is_ready() response");
       }
     }
 
@@ -1080,11 +1080,11 @@ ModelInstanceState::RunUserModelReadinessCheck(bool* is_ready)
       if (!readiness_payload->waiting_on_stub && !IsStubProcessAlive()) {
         SetUserModelReadinessResult(
             false, true,
-            "Stub process is not healthy while waiting for is_model_ready()");
+            "Stub process is not healthy while waiting for is_ready()");
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_INTERNAL,
             "Stub process is not healthy while waiting for user-defined "
-            "is_model_ready() response");
+            "is_ready() response");
       }
 
       if (!wait_success && !readiness_payload->waiting_on_stub) {
@@ -1095,7 +1095,7 @@ ModelInstanceState::RunUserModelReadinessCheck(bool* is_ready)
 
         return TRITONSERVER_ErrorNew(
             TRITONSERVER_ERROR_UNAVAILABLE,
-            "Timed out waiting for user-defined is_model_ready() response");
+            "Timed out waiting for user-defined is_ready() response");
       }
     }
   }
@@ -1112,7 +1112,7 @@ ModelInstanceState::RunUserModelReadinessCheck(bool* is_ready)
       result_error_message = error_message->String();
     } else {
       result_error_message =
-          "User-defined is_model_ready() failed with unknown error";
+          "User-defined is_ready() failed with unknown error";
     }
   } else {
     if (!readiness_payload->function_exists) {
@@ -2679,7 +2679,7 @@ TRITONBACKEND_ModelInstanceReady(TRITONBACKEND_ModelInstance* instance)
             .c_str());
   }
 
-  // Run user-defined model readiness function is_model_ready if it exists.
+  // Run user-defined model readiness function is_ready if it exists.
   bool is_ready = true;
   RETURN_IF_ERROR(instance_state->RunUserModelReadinessCheck(&is_ready));
 

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -922,15 +922,15 @@ ModelInstanceState::UserModelReadinessCleanupTask(
     bi::scoped_lock<bi::interprocess_mutex> cleanup_lock{
         *(ipc_message_cleanup->ResponseMutex())};
     // Use bounded waits so cleanup can periodically re-check stub liveness
-    // and avoid blocking forever if no notification arrives.
-    constexpr int64_t kCleanupLivenessPollMs = 100;
+    // while waiting for the stub notification.
+    constexpr int64_t kCleanupLivenessPollMs = 1000;
     while (!payload->waiting_on_stub) {
       boost::posix_time::ptime timeout =
           boost::get_system_time() +
           boost::posix_time::milliseconds(kCleanupLivenessPollMs);
       ipc_message_cleanup->ResponseCondition()->timed_wait(
           cleanup_lock, timeout);
-      if (!payload->waiting_on_stub && !IsStubProcessAlive()) {
+      if (!payload->waiting_on_stub && !Stub()->StubActive()) {
         abort_wait = true;
         break;
       }

--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -921,8 +921,15 @@ ModelInstanceState::UserModelReadinessCleanupTask(
   {
     bi::scoped_lock<bi::interprocess_mutex> cleanup_lock{
         *(ipc_message_cleanup->ResponseMutex())};
+    // Use bounded waits so cleanup can periodically re-check stub liveness
+    // and avoid blocking forever if no notification arrives.
+    constexpr int64_t kCleanupLivenessPollMs = 100;
     while (!payload->waiting_on_stub) {
-      ipc_message_cleanup->ResponseCondition()->wait(cleanup_lock);
+      boost::posix_time::ptime timeout =
+          boost::get_system_time() +
+          boost::posix_time::milliseconds(kCleanupLivenessPollMs);
+      ipc_message_cleanup->ResponseCondition()->timed_wait(
+          cleanup_lock, timeout);
       if (!payload->waiting_on_stub && !IsStubProcessAlive()) {
         abort_wait = true;
         break;

--- a/src/python_be.h
+++ b/src/python_be.h
@@ -436,8 +436,9 @@ class ModelInstanceState : public BackendModelInstance {
   // Mutex to serialize concurrent model readiness check requests
   std::mutex user_model_readiness_mutex_;
 
-  // Condition variable and related members to ensure only one user model readiness
-  // IPC runs at a time, and to clean up IPC resources after completion.
+  // Condition variable and related members to ensure only one user model
+  // readiness IPC runs at a time, and to clean up IPC resources after
+  // completion.
   std::condition_variable user_model_readiness_cv_;
   bool user_model_readiness_inflight_{false};
   bool user_model_readiness_result_{true};

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -176,6 +176,9 @@ StubLauncher::Setup()
   ipc_control_->memory_manager_message_queue =
       memory_manager_message_queue->ShmHandle();
   ipc_control_->decoupled = is_decoupled_;
+
+  // Will be set by the stub during initialization
+  ipc_control_->stub_has_model_ready_fn = false;
 
   memory_manager_ =
       std::make_unique<MemoryManager>(std::move(memory_manager_message_queue));

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -178,7 +178,7 @@ StubLauncher::Setup()
   ipc_control_->decoupled = is_decoupled_;
 
   // Will be set by the stub during initialization
-  ipc_control_->stub_has_model_ready_fn = false;
+  ipc_control_->stub_has_user_model_readiness_fn = false;
 
   memory_manager_ =
       std::make_unique<MemoryManager>(std::move(memory_manager_message_queue));

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -1,4 +1,4 @@
-// Copyright 2022-2023, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2022-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions
@@ -135,6 +135,14 @@ class StubLauncher {
 
   // Is Healthy
   bool IsHealthy() { return is_healthy_; }
+
+  // Returns true if is_model_ready() is defined in the Python model.
+  // Reads directly from shared memory (set by the stub during initialization).
+  // Returns false if not set yet (safe default).
+  bool HasUserModelReadyFunction() const
+  {
+    return ipc_control_ ? ipc_control_->stub_has_model_ready_fn : false;
+  }
 
   // Destruct Stub process
   void TerminateStub();

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -139,9 +139,9 @@ class StubLauncher {
   // Returns true if is_model_ready() is defined in the Python model.
   // Reads directly from shared memory (set by the stub during initialization).
   // Returns false if not set yet (safe default).
-  bool HasUserModelReadyFunction() const
+  bool HasUserModelReadinessFunction() const
   {
-    return ipc_control_ ? ipc_control_->stub_has_model_ready_fn : false;
+    return ipc_control_ ? ipc_control_->stub_has_user_model_readiness_fn : false;
   }
 
   // Destruct Stub process

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -141,7 +141,8 @@ class StubLauncher {
   // Returns false if not set yet (safe default).
   bool HasUserModelReadinessFunction() const
   {
-    return ipc_control_ ? ipc_control_->stub_has_user_model_readiness_fn : false;
+    return ipc_control_ ? ipc_control_->stub_has_user_model_readiness_fn
+                        : false;
   }
 
   // Destruct Stub process

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -141,8 +141,7 @@ class StubLauncher {
   // Returns false if not set yet (safe default).
   bool HasUserModelReadinessFunction() const
   {
-    return ipc_control_ ? ipc_control_->stub_has_user_model_readiness_fn
-                        : false;
+    return ipc_control_ && ipc_control_->stub_has_user_model_readiness_fn;
   }
 
   // Destruct Stub process

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -136,7 +136,7 @@ class StubLauncher {
   // Is Healthy
   bool IsHealthy() { return is_healthy_; }
 
-  // Returns true if is_model_ready() is defined in the Python model.
+  // Returns true if is_ready() is defined in the Python model.
   // Reads directly from shared memory (set by the stub during initialization).
   // Returns false if not set yet (safe default).
   bool HasUserModelReadinessFunction() const


### PR DESCRIPTION
This PR adds support for user-defined `is_ready()` functions in Python backend models, allowing custom readiness checks beyond basic stub health verification. The implementation uses IPC (Inter-Process Communication) between the parent process and the Python stub to invoke the user's readiness function when `TRITONBACKEND_ModelInstanceReady` (health endpoint - `v2/models/<model>/ready`) is called.

**Changes:**
- Added IPC infrastructure for user-defined model readiness checks with a 5-second timeout
- Cached the presence of `is_ready()` function during stub initialization to optimize the common case (fast path when no custom function exists)
- Implemented thread-safe result caching to avoid multiple concurrent IPC calls for the same readiness check