### PR TITLE
Fix: Inconsistent doc

### DIFF
--- a/README.md
+++ b/README.md
@@ -1557,7 +1557,7 @@ inference request on itself and there are no more model instances ready to
 execute the inference request, the model will block on the inference execution
 forever.
 
-- Async BLS is not supported when running a Python model in decoupled mode.
+- Async BLS is not supported on `Python 3.6` or lower due to the `async` keyword and `asyncio.run` being introduced in Python 3.7.
 
 # Interoperability and GPU Support
 


### PR DESCRIPTION
`Note: Async BLS is not supported on Python 3.6 or lower due to the async keyword and asyncio.run being introduced in Python 3.7.` 

vs 

`Async BLS is not supported when running a Python model in decoupled mode.`