### PR TITLE
fix: validate tensor dims_count against the shared-memory region

### DIFF
--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -655,6 +655,22 @@ PbTensor::LoadFromSharedMemory(
   AllocatedSharedMemory<char> tensor_shm = shm_pool->Load<char>(tensor_handle);
   TensorShm* tensor_shm_ptr =
       reinterpret_cast<TensorShm*>(tensor_shm.data_.get());
+
+  // Validate 'dims_count' against the shared-memory region before using it to
+  // compute offsets and read the dims array, to avoid an out-of-bounds read
+  // when the value is corrupted. The division avoids overflowing the
+  // 'sizeof(int64_t) * dims_count' product. Mirrors the MemoryShm::byte_size
+  // boundary check.
+  char* region_end = reinterpret_cast<char*>(shm_pool->GetBaseAddress()) +
+                     shm_pool->GetCurrentCapacity();
+  char* dims_begin = tensor_shm.data_.get() + sizeof(TensorShm);
+  if (dims_begin > region_end ||
+      tensor_shm_ptr->dims_count >
+          static_cast<size_t>(region_end - dims_begin) / sizeof(int64_t)) {
+    throw PythonBackendException(
+        "Attempted to load a tensor with an out-of-bounds 'dims_count'");
+  }
+
   size_t name_offset =
       sizeof(TensorShm) + sizeof(int64_t) * tensor_shm_ptr->dims_count;
   std::unique_ptr<PbString> name_shm = PbString::LoadFromSharedMemory(


### PR DESCRIPTION
This validates the tensor `dims_count` read from shared memory before it is used, extending the shared-memory boundary validation added in #405 / #406.

**Previously, `PbTensor::LoadFromSharedMemory()` took `dims_count` from the shared-memory region and used it to compute `name_offset` and to build the dims vector (`std::vector<int64_t>(dims_ptr, dims_ptr + dims_count)`) with no bounds check. A corrupted `dims_count` makes the parent process perform a large out-of-bounds read and crash the server, and the `sizeof(int64_t) * dims_count` product can overflow into a small, controlled `name_offset`. The #406 fix bounded `MemoryShm::byte_size`, but not this dimension count.**

_This change validates `dims_count` so the dims array stays within the region before it is used, throwing `PythonBackendException` otherwise. The check uses division to avoid overflowing the product, and mirrors the `MemoryShm::byte_size` boundary check. Valid tensors are unaffected._

Reproduced on `nvcr.io/nvidia/tritonserver:26.04-py3` (CPU): a model that overwrites a live output tensor's `dims_count` in the backend shared memory crashes the whole server (`Exited (139)`, SIGSEGV) within seconds, via `python_be.cc` → `InferResponse::LoadFromSharedMemory` → `PbTensor::LoadFromSharedMemory`. With this change the corrupted tensor is rejected with an error instead of faulting.

The sibling unbounded values read from shared memory have the same pattern and are worth a follow-up: `InferResponse::outputs_size`, `InferRequest::requested_output_count`/`input_count`, `PbMap::length`, `MessageQueue::Pop`'s tail, and the object handles passed to `SharedMemoryManager::Load<T>`.
