### PR TITLE
fix: Prevent deadlock in decoupled BLS and use-after-free in async_exec pybind callback

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1849,7 +1849,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
             auto stub = Stub::GetOrCreateInstance();
             py::object loop =
                 py::module_::import("asyncio").attr("get_running_loop")();
-            py::cpp_function callback = [&stub, infer_request, decoupled]() {
+            py::cpp_function callback = [stub, infer_request, decoupled]() {
               std::shared_ptr<InferResponse> response =
                   infer_request->Exec(decoupled);
               py::object response_object;

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1496,8 +1496,16 @@ Stub::GetCUDAMemoryPoolAddress(std::unique_ptr<IPCMessage>& ipc_message)
         *(ipc_message->ResponseMutex())};
     cuda_pool_message_ptr->waiting_on_stub = true;
     ipc_message->ResponseCondition()->notify_all();
-    while (cuda_pool_message_ptr->waiting_on_stub) {
-      ipc_message->ResponseCondition()->wait(lock);
+    // This handler runs on the single ParentToStubMQMonitor thread,
+    // which is also the only thread that delivers decoupled BLS responses,
+    // so it must not block on the success path.
+    // It should only wait when an error message has been written to
+    // error_string_shm, so the parent can finish reading it before 
+    // this function returns and frees that shared memory.
+    if (has_exception) {
+      while (cuda_pool_message_ptr->waiting_on_stub) {
+        ipc_message->ResponseCondition()->wait(lock);
+      }
     }
   }
 #endif
@@ -1849,7 +1857,6 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
             auto stub = Stub::GetOrCreateInstance();
             py::object loop =
                 py::module_::import("asyncio").attr("get_running_loop")();
-            // Capture 'stub' by value (it is a shared_ptr).
             py::cpp_function callback = [stub, infer_request, decoupled]() {
               std::shared_ptr<InferResponse> response =
                   infer_request->Exec(decoupled);

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1500,7 +1500,7 @@ Stub::GetCUDAMemoryPoolAddress(std::unique_ptr<IPCMessage>& ipc_message)
     // which also delivers decoupled BLS responses,
     // so it must not block on the success path.
     // It should only wait when an error message has been written to
-    // error_string_shm, so the parent can finish reading it before 
+    // error_string_shm, so the parent can finish reading it before
     // this function returns and frees that shared memory.
     if (has_exception) {
       while (cuda_pool_message_ptr->waiting_on_stub) {

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1497,7 +1497,7 @@ Stub::GetCUDAMemoryPoolAddress(std::unique_ptr<IPCMessage>& ipc_message)
     cuda_pool_message_ptr->waiting_on_stub = true;
     ipc_message->ResponseCondition()->notify_all();
     // This handler runs on the single ParentToStubMQMonitor thread,
-    // which is also the only thread that delivers decoupled BLS responses,
+    // which also delivers decoupled BLS responses,
     // so it must not block on the success path.
     // It should only wait when an error message has been written to
     // error_string_shm, so the parent can finish reading it before 

--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -1849,6 +1849,7 @@ PYBIND11_EMBEDDED_MODULE(c_python_backend_utils, module)
             auto stub = Stub::GetOrCreateInstance();
             py::object loop =
                 py::module_::import("asyncio").attr("get_running_loop")();
+            // Capture 'stub' by value (it is a shared_ptr).
             py::cpp_function callback = [stub, infer_request, decoupled]() {
               std::shared_ptr<InferResponse> response =
                   infer_request->Exec(decoupled);


### PR DESCRIPTION
Fixes the following bugs in `pb_stub.cc`:

Deadlock in decoupled BLS with GPU tensors:
`Stub::GetCUDAMemoryPoolAddress` is called on the `ParentToStubMQMonitor` thread, which also delivers decoupled BLS responses (`ProcessBLSResponseDecoupled`). After notifying the parent, it unconditionally blocked waiting for an acknowledgment (`waiting_on_stub`). On the success path the parent may itself be blocked waiting for a decoupled response that this now-blocked thread is supposed to deliver, creating a circular wait. This caused occasional hangs when a BLS model first returned GPU tensors, triggering CUDA pool initialization.

Use-after-free in `async_exec` pybind callback:
The async callback lambda captures the local stub `shared_ptr` by reference (`[&stub, ...]`). Because stub is a local variable, it could be destroyed before the callback ran on the event loop, leaving a dangling reference and causing a use-after-free.

CI: https://github.com/triton-inference-server/server/pull/8830