### PR TITLE
fix: Strip trailing separators from --backend-directory path

### DIFF
--- a/src/python_be.cc
+++ b/src/python_be.cc
@@ -2419,6 +2419,16 @@ TRITONBACKEND_Initialize(TRITONBACKEND_Backend* backend)
 #else
   const std::string stub_executable_name = "triton_python_backend_stub";
 #endif
+  // Remove any trailing path separators from the backend directory. Otherwise a
+  // value such as `--backend-directory=/opt/tritonserver/backends/` yields
+  // `/opt/tritonserver/backends//python`, which fails the equality check with
+  // the resolved backend `location` below and prevents the default Python
+  // backend from being detected.
+  // See: https://github.com/triton-inference-server/server/issues/6730
+  while (default_backend_dir_string.size() > 1 &&
+         default_backend_dir_string.back() == os_slash) {
+    default_backend_dir_string.pop_back();
+  }
   // Check if `triton_python_backend_stub` and `triton_python_backend_utils.py`
   // are located under `location`.
   std::string default_python_backend_dir =


### PR DESCRIPTION
## What

A trailing path separator on `--backend-directory` (e.g. `--backend-directory=/opt/tritonserver/backends/`) causes **every** Python-backend model to fail to load with:

```
Internal: ModuleNotFoundError: No module named 'model'
```

## Why

In `TRITONBACKEND_Initialize` (`src/python_be.cc`), the backend directory is concatenated as `default_backend_dir_string + os_slash + "python"`. With a trailing slash this yields `/opt/tritonserver/backends//python`, which is then compared for equality against the resolved backend `location` (`/opt/tritonserver/backends/python`). The `//` vs `/` mismatch makes the check fail, so `runtime_modeldir` is set to the backend path instead of `""` (`DEFAULT`). The stub is then launched as if a custom Python-based backend runtime lives there and tries to import a module named `model`, which does not exist.

## Fix

Strip any trailing path separators from `default_backend_dir_string` before the comparison, so the default Python backend is detected regardless of a trailing slash.

## Verification

Reproduced and verified in a CPU-only `nvcr.io/nvidia/tritonserver:25.02-py3` container (arm64), rebuilding `libtriton_python.so` from this branch and loading a minimal Python model:

| `--backend-directory` | before fix | after fix |
|---|---|---|
| `/opt/tritonserver/backends/` (trailing slash) | model `UNAVAILABLE` — `ModuleNotFoundError: No module named 'model'`; stub `runtime_modeldir` = `/opt/tritonserver/backends/python` | model `READY`; `runtime_modeldir` = `DEFAULT` |
| `/opt/tritonserver/backends` (no slash) | `READY` | `READY` (no regression) |

Fixes triton-inference-server/server#6730
