### PR TITLE
fix: Treat empty DLPack tensors as contiguous

### DIFF
--- a/src/pb_tensor.cc
+++ b/src/pb_tensor.cc
@@ -493,8 +493,20 @@ PbTensor::FromDLPackCapsule(
       dl_managed_tensor->dl_tensor.shape,
       dl_managed_tensor->dl_tensor.shape + ndim);
 
-  // Check if the input is contiguous and in C order
-  if (strides != nullptr) {
+  // Check if the input is contiguous and in C order.
+  // An empty tensor (any zero-size dimension, i.e. zero elements) has no
+  // meaningful memory layout and is trivially contiguous; skip the stride
+  // check, which can otherwise reject it because frameworks report
+  // inconsistent strides for empty tensors. See:
+  // https://github.com/triton-inference-server/server/issues/6960
+  bool is_empty = false;
+  for (auto dim : dims) {
+    if (dim == 0) {
+      is_empty = true;
+      break;
+    }
+  }
+  if (strides != nullptr && !is_empty) {
     int64_t calculated_stride{1};
     bool is_contiguous_c_order = true;
     for (size_t i = 1; i < dims.size(); i++) {


### PR DESCRIPTION
## What

`pb_utils.Tensor.from_dlpack(...)` raises:

```
DLPack tensor is not contiguous. Only contiguous DLPack tensors that are stored in C-Order are supported.
```

for an **empty** tensor (any zero-size dimension, e.g. shape `(0, 0, 0)`), even though an empty tensor is trivially contiguous.

## Why

In `PbTensor::FromDLPackCapsule` (`src/pb_tensor.cc`), the C-order contiguity check compares the DLPack strides against a calculated stride. Frameworks report inconsistent/ambiguous strides for empty tensors, so the check wrongly fails. An empty tensor has zero elements and no meaningful memory layout, so it is trivially contiguous.

## Fix

Skip the stride check when any dimension is zero (the tensor is trivially contiguous). This mirrors the existing size-1 handling added in #281.

## Verification

Built `python_backend` from this branch (CPU-only, arm64) and ran a Python model that constructs `pb_utils.Tensor.from_dlpack` from torch tensors of various shapes, inside an `nvcr.io/nvidia/tritonserver:25.02-py3` container:

| shape | before fix | after fix |
|---|---|---|
| `(0, 0, 0)` | `DLPack tensor is not contiguous` | OK |
| `(3, 4)` (normal) | OK | OK (no regression) |

## Tests

Following the precedent fix for size-1 dims (#281), this is a code-only change. Happy to add a `qa` regression test if preferred.

Fixes triton-inference-server/server#6960
