### PR TITLE
Fix SIGSEGV in Python stub on non-graceful (parent death) termination

### DIFF
--- a/src/pb_stub.cc
+++ b/src/pb_stub.cc
@@ -61,6 +61,7 @@
 #include <windows.h>
 #else
 #include <sys/wait.h>
+#include <unistd.h>  // _exit
 #endif
 
 #ifdef TRITON_ENABLE_GPU
@@ -75,8 +76,6 @@ using cudaStream_t = void*;
 #endif
 
 namespace triton { namespace backend { namespace python {
-
-std::atomic<bool> non_graceful_exit = {false};
 
 void
 SignalHandler(int signum)
@@ -2162,7 +2161,7 @@ main(int argc, char** argv)
 #endif
   std::atomic<bool> background_thread_running = {true};
   std::thread background_thread =
-      std::thread([stub, &parent_pid, &background_thread_running, &logger] {
+      std::thread([stub, &parent_pid, &background_thread_running] {
         // Send a dummy message after the stub process is launched to notify the
         // parent process that the health thread has started.
         std::unique_ptr<IPCMessage> ipc_message = IPCMessage::Create(
@@ -2179,23 +2178,22 @@ main(int argc, char** argv)
           stub->UpdateHealth();
 
           if (!ParentProcessActive(parent_pid)) {
-            // When unhealthy, we should stop attempting to send
-            // messages to the backend ASAP.
-            if (stub->StubToParentServiceActive()) {
-              stub->TerminateStubToParentQueueMonitor();
-            }
-            if (stub->ParentToStubServiceActive()) {
-              stub->TerminateParentToStubQueueMonitor();
-            }
-            // Destroy Stub
+            // The parent process (tritonserver) died abruptly (e.g. SIGKILL
+            // after the termination grace period, an OOM-kill, or a crash) and
+            // could not send a Finalize command. The RunCommand loop and the
+            // model instance threads are still operating on the shared memory
+            // region and its process-shared mutexes. Running the normal
+            // teardown from this background thread is unsafe: DestroyInstance()
+            // unmaps the region (~SharedMemoryManager -> ~mapped_region ->
+            // munmap), and exit() would unmap it as well via static
+            // destructors. Doing so while those threads are still using the
+            // region is a data race that faults them with SIGSEGV inside the
+            // shm mutex (SEGV_MAPERR on the lock word). Since the process is
+            // going away and the region is owned and reclaimed by the parent
+            // (the kernel reclaims all mappings on process exit), terminate
+            // immediately with _exit() so that no destructors run.
             LOG_INFO << "Non-graceful termination detected. ";
-            background_thread_running = false;
-            non_graceful_exit = true;
-
-            // Destroy stub and exit.
-            logger.reset();
-            Stub::DestroyInstance();
-            exit(1);
+            _exit(1);
           }
         }
       });


### PR DESCRIPTION
  ## Problem
  Python backend stub processes segfault when the parent `tritonserver`
  process goes away abruptly (SIGKILL after the K8s grace period, OOM-kill, or
  a crash). In production this appears as bursts of identical crashes across
  many stubs of the same model:

      triton_python_b[...]: segfault at ...210 ip ... error 6
          in libpthread-2.31.so[...]

  `error 6` = user-mode write to an unmapped page; the fault address is the
  in-shm `bi::interprocess_mutex`.

  ## Root cause
  The stub's health-monitoring background thread (`pb_stub.cc`, `main()`) polls
  `ParentProcessActive(parent_pid)`. When the parent is gone it took the
  "Non-graceful termination detected" branch, which called
  `Stub::DestroyInstance()` and `exit(1)`. Both unmap the shared-memory region
  (`~SharedMemoryManager -> ~mapped_region -> munmap`, and again via the static
  destructors run by `exit()`), while the `RunCommand` loop and the model
  instance threads are still using that region and its process-shared
  mutexes/semaphores. Unmapping it under them is a data race that faults them
  with `SIGSEGV` (`SEGV_MAPERR`) inside `pthread_mutex_*`.

  It is intermittent because it only crashes when another thread happens to be
  in the userspace lock/unlock of the shm mutex during the window between the
  `munmap` and the process actually exiting — which matches the batchy,
  intermittent nature seen in production.


  ## Fix
  On non-graceful termination the background thread cannot safely destroy the
  region (it cannot join the main thread, which is almost always blocked on or
  holding a shm lock). Since the process is exiting and the parent owns and
  recreates the region, terminate immediately with `_exit(1)` and run no
  destructors.