### PR TITLE
[r26.07] chore: Update grpcio dependency (#445)

### DIFF
--- a/inferentia/qa/Dockerfile.QA
+++ b/inferentia/qa/Dockerfile.QA
@@ -1,4 +1,4 @@
-# Copyright 2021, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+# Copyright 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 #
 # Redistribution and use in source and binary forms, with or without
 # modification, are permitted provided that the following conditions
@@ -61,7 +61,7 @@ RUN rm -f /usr/bin/python && \
     ln -s /usr/bin/python3 /usr/bin/python
 
 RUN pip3 install --upgrade wheel setuptools && \
-    pip3 install --upgrade numpy pillow attrdict future grpcio requests gsutil awscli six grpcio-channelz
+    pip3 install --upgrade numpy pillow attrdict future "grpcio>=1.81.1" requests gsutil awscli six grpcio-channelz
 
 WORKDIR /opt/tritonserver
 # Copy the entire qa repo to the /opt/tritonserver/qa repo


### PR DESCRIPTION
#### What does the PR do?
Cherry-pick of #445 onto `r26.07` — chore: Update grpcio dependency. Backport of the coordinated `grpcio` dependency update. Clean cherry-pick, no conflicts.

#### Checklist
- [x] PR title reflects the change and is of format `<commit_type>: <Title>`
- [x] Changes are described in the pull request.
- [x] Related issues are referenced.
- [x] Populated github labels field (`cherry-pick`)
- [x] Verified copyright is correct on all changed files.
- [x] All template sections are filled out.

#### Commit Type:
Cherry-pick — preserves the original commit type from #445.

#### Related PRs:
- triton-inference-server/server#8887
- triton-inference-server/client#907
- triton-inference-server/model_analyzer#1031
- triton-inference-server/third_party#78

#### Where should the reviewer start?
Changed file(s): `inferentia/qa/Dockerfile.QA`. This is a direct cherry-pick of the already-reviewed #445; the diff is identical.

#### Test plan:
Verified via existing CI on `r26.07`.
- CI Pipeline ID: N/A (clean cherry-pick of #445)

#### Caveats:
None — clean cherry-pick, no conflicts.

#### Background
Backporting the `main` `grpcio` dependency update to the `r26.07` release branch.

#### Related Issues: (use one of the action keywords Closes / Fixes / Resolves / Relates to)
- Relates to: TRI-836
