### PR TITLE
fix: ensure Python backend shm cleanup on forced shutdown

### DIFF
--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -1,4 +1,4 @@
-// Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -61,7 +61,11 @@ RegisterParentShmRegion(const std::string& shm_region_name)
     parent_shm_regions.insert(shm_region_name);
   }
   if (!parent_shm_atexit_registered.exchange(true)) {
-    std::atexit(CleanupParentShmRegions);
+    if (std::atexit(CleanupParentShmRegions) != 0) {
+      std::cerr << "python_backend: failed to register atexit shm cleanup "
+                   "handler; relying on TerminateStub for cleanup"
+                << std::endl;
+    }
   }
 }
 

--- a/src/shm_manager.cc
+++ b/src/shm_manager.cc
@@ -26,12 +26,53 @@
 
 #include "shm_manager.h"
 
+#include <atomic>
 #include <boost/interprocess/managed_external_buffer.hpp>
 #include <boost/interprocess/mapped_region.hpp>
 #include <boost/interprocess/shared_memory_object.hpp>
+#include <cstdlib>
 #include <iostream>
+#include <mutex>
+#include <unordered_set>
 
 namespace triton { namespace backend { namespace python {
+
+namespace {
+
+std::mutex parent_shm_regions_mu;
+std::unordered_set<std::string> parent_shm_regions;
+std::atomic<bool> parent_shm_atexit_registered{false};
+
+void
+CleanupParentShmRegions()
+{
+  std::lock_guard<std::mutex> lock(parent_shm_regions_mu);
+  for (const auto& region : parent_shm_regions) {
+    bi::shared_memory_object::remove(region.c_str());
+  }
+  parent_shm_regions.clear();
+}
+
+void
+RegisterParentShmRegion(const std::string& shm_region_name)
+{
+  {
+    std::lock_guard<std::mutex> lock(parent_shm_regions_mu);
+    parent_shm_regions.insert(shm_region_name);
+  }
+  if (!parent_shm_atexit_registered.exchange(true)) {
+    std::atexit(CleanupParentShmRegions);
+  }
+}
+
+void
+UnregisterParentShmRegion(const std::string& shm_region_name)
+{
+  std::lock_guard<std::mutex> lock(parent_shm_regions_mu);
+  parent_shm_regions.erase(shm_region_name);
+}
+
+}  // namespace
 
 void
 CUDAMemoryPoolManager::SetCUDAPoolAddress(
@@ -139,6 +180,7 @@ SharedMemoryManager::SharedMemoryManager(
   if (create) {
     *total_size_ = current_capacity_;
     new (shm_mutex_) bi::interprocess_mutex;
+    RegisterParentShmRegion(shm_region_name_);
   }
 }
 
@@ -227,8 +269,16 @@ SharedMemoryManager::FreeMemory()
 
 SharedMemoryManager::~SharedMemoryManager() noexcept(false)
 {
+  RemoveShmRegion();
+}
+
+void
+SharedMemoryManager::RemoveShmRegion()
+{
   if (delete_region_) {
     bi::shared_memory_object::remove(shm_region_name_.c_str());
+    UnregisterParentShmRegion(shm_region_name_);
+    delete_region_ = false;
   }
 }
 

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -1,4 +1,4 @@
-// Copyright 2021-2025, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
+// Copyright 2021-2026, NVIDIA CORPORATION & AFFILIATES. All rights reserved.
 //
 // Redistribution and use in source and binary forms, with or without
 // modification, are permitted provided that the following conditions

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -194,7 +194,7 @@ class SharedMemoryManager {
 
   void SetDeleteRegion(bool delete_region);
 
-  // Remove the parent-owned shared memory region from the filesystem.
+  // Idempotent: removes the parent-owned shm region and clears delete_region_.
   void RemoveShmRegion();
 
   std::unique_ptr<CUDAMemoryPoolManager>& GetCUDAMemoryPoolManager()

--- a/src/shm_manager.h
+++ b/src/shm_manager.h
@@ -194,6 +194,9 @@ class SharedMemoryManager {
 
   void SetDeleteRegion(bool delete_region);
 
+  // Remove the parent-owned shared memory region from the filesystem.
+  void RemoveShmRegion();
+
   std::unique_ptr<CUDAMemoryPoolManager>& GetCUDAMemoryPoolManager()
   {
     return cuda_memory_pool_manager_;

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -805,15 +805,12 @@ void
 StubLauncher::TerminateStub()
 {
   if (is_initialized_) {
-    // Enforce stub_timeout_seconds_ as a single total budget across the
-    // finalize wait and the subsequent process-exit wait; without this the
-    // healthy teardown path could take up to 2 * stub_timeout_seconds_.
+    // Single teardown budget: finalize + wait share stub_timeout_seconds_.
     bool force_kill = false;
     int64_t remaining_seconds = stub_timeout_seconds_;
     if (is_healthy_) {
       const int64_t total_timeout_ms = stub_timeout_seconds_ * 1000;
-      // MessageQueue::Pop takes `int const&`; clamp to INT_MAX so a large
-      // stub_timeout_seconds_ cannot silently narrow to a negative value.
+      // Clamp to INT_MAX; MessageQueue::Pop takes int.
       const int pop_timeout_ms = static_cast<int>(std::min<int64_t>(
           total_timeout_ms,
           static_cast<int64_t>(std::numeric_limits<int>::max())));
@@ -983,8 +980,7 @@ StubLauncher::WaitForStubProcessWithTimeout(int64_t timeout_seconds)
     sleep(1);
   }
 
-  // The process may have exited during the final sleep window; re-check once
-  // more so we don't force-kill an already-dead process.
+  // Stub may have exited during the last sleep(1); recheck before killing.
   {
     int status;
     pid_t ret = waitpid(stub_pid_, &status, WNOHANG);

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -26,7 +26,10 @@
 
 #include "stub_launcher.h"
 
+#include <algorithm>
+#include <chrono>
 #include <filesystem>
+#include <limits>
 
 #include "pb_utils.h"
 #include "python_be.h"
@@ -802,9 +805,18 @@ void
 StubLauncher::TerminateStub()
 {
   if (is_initialized_) {
+    // Enforce stub_timeout_seconds_ as a single total budget across the
+    // finalize wait and the subsequent process-exit wait; without this the
+    // healthy teardown path could take up to 2 * stub_timeout_seconds_.
     bool force_kill = false;
+    int64_t remaining_seconds = stub_timeout_seconds_;
     if (is_healthy_) {
-      const int64_t timeout_ms = stub_timeout_seconds_ * 1000;
+      const int64_t total_timeout_ms = stub_timeout_seconds_ * 1000;
+      // MessageQueue::Pop takes `int const&`; clamp to INT_MAX so a large
+      // stub_timeout_seconds_ cannot silently narrow to a negative value.
+      const int pop_timeout_ms = static_cast<int>(std::min<int64_t>(
+          total_timeout_ms,
+          static_cast<int64_t>(std::numeric_limits<int>::max())));
       // Finalize command does not have any arguments.
       std::unique_ptr<IPCMessage> ipc_message =
           IPCMessage::Create(shm_pool_, false /* inline_response */);
@@ -812,7 +824,14 @@ StubLauncher::TerminateStub()
       ipc_message->Command() = PYTHONSTUB_FinalizeRequest;
       stub_message_queue_->Push(ipc_message->ShmHandle());
       bool success = false;
-      parent_message_queue_->Pop(timeout_ms, success);
+      const auto pop_start = std::chrono::steady_clock::now();
+      parent_message_queue_->Pop(pop_timeout_ms, success);
+      const int64_t pop_elapsed_s =
+          std::chrono::duration_cast<std::chrono::seconds>(
+              std::chrono::steady_clock::now() - pop_start)
+              .count();
+      remaining_seconds =
+          std::max<int64_t>(0, stub_timeout_seconds_ - pop_elapsed_s);
       if (!success) {
         force_kill = true;
       }
@@ -826,7 +845,7 @@ StubLauncher::TerminateStub()
 
     if (force_kill) {
       KillStubProcess();
-    } else if (!WaitForStubProcessWithTimeout(stub_timeout_seconds_)) {
+    } else if (!WaitForStubProcessWithTimeout(remaining_seconds)) {
       KillStubProcess();
     }
   }
@@ -962,6 +981,17 @@ StubLauncher::WaitForStubProcessWithTimeout(int64_t timeout_seconds)
       return true;
     }
     sleep(1);
+  }
+
+  // The process may have exited during the final sleep window; re-check once
+  // more so we don't force-kill an already-dead process.
+  {
+    int status;
+    pid_t ret = waitpid(stub_pid_, &status, WNOHANG);
+    if (ret == stub_pid_ || ret == -1) {
+      stub_pid_ = 0;
+      return true;
+    }
   }
 
   return false;

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -64,8 +64,7 @@ StubLauncher::Initialize(ModelState* model_state)
   shm_growth_byte_size_ = model_state->StateForBackend()->shm_growth_byte_size;
   shm_message_queue_size_ =
       model_state->StateForBackend()->shm_message_queue_size;
-  stub_timeout_seconds_ =
-      model_state->StateForBackend()->stub_timeout_seconds;
+  stub_timeout_seconds_ = model_state->StateForBackend()->stub_timeout_seconds;
   python_execution_env_ = model_state->PythonExecutionEnv();
   python_lib_ = model_state->StateForBackend()->python_lib;
   model_state->ModelConfig().Write(&model_config_buffer_);

--- a/src/stub_launcher.cc
+++ b/src/stub_launcher.cc
@@ -42,7 +42,7 @@ namespace triton { namespace backend { namespace python {
 StubLauncher::StubLauncher(const std::string stub_process_kind)
     : parent_pid_(0), is_initialized_(false),
       stub_process_kind_(stub_process_kind), model_instance_name_(""),
-      device_id_(0), kind_("")
+      device_id_(0), kind_(""), stub_timeout_seconds_(30)
 {
 }
 
@@ -51,7 +51,7 @@ StubLauncher::StubLauncher(
     const int32_t device_id, const std::string kind)
     : is_initialized_(false), stub_process_kind_(stub_process_kind),
       model_instance_name_(model_instance_name), device_id_(device_id),
-      kind_(kind)
+      kind_(kind), stub_timeout_seconds_(30)
 {
 }
 
@@ -64,6 +64,8 @@ StubLauncher::Initialize(ModelState* model_state)
   shm_growth_byte_size_ = model_state->StateForBackend()->shm_growth_byte_size;
   shm_message_queue_size_ =
       model_state->StateForBackend()->shm_message_queue_size;
+  stub_timeout_seconds_ =
+      model_state->StateForBackend()->stub_timeout_seconds;
   python_execution_env_ = model_state->PythonExecutionEnv();
   python_lib_ = model_state->StateForBackend()->python_lib;
   model_state->ModelConfig().Write(&model_config_buffer_);
@@ -803,13 +805,18 @@ StubLauncher::TerminateStub()
   if (is_initialized_) {
     bool force_kill = false;
     if (is_healthy_) {
+      const int64_t timeout_ms = stub_timeout_seconds_ * 1000;
       // Finalize command does not have any arguments.
       std::unique_ptr<IPCMessage> ipc_message =
           IPCMessage::Create(shm_pool_, false /* inline_response */);
 
       ipc_message->Command() = PYTHONSTUB_FinalizeRequest;
       stub_message_queue_->Push(ipc_message->ShmHandle());
-      parent_message_queue_->Pop();
+      bool success = false;
+      parent_message_queue_->Pop(timeout_ms, success);
+      if (!success) {
+        force_kill = true;
+      }
 
       stub_message_queue_.reset();
       parent_message_queue_.reset();
@@ -820,9 +827,13 @@ StubLauncher::TerminateStub()
 
     if (force_kill) {
       KillStubProcess();
-    } else {
-      WaitForStubProcess();
+    } else if (!WaitForStubProcessWithTimeout(stub_timeout_seconds_)) {
+      KillStubProcess();
     }
+  }
+
+  if (shm_pool_ != nullptr) {
+    shm_pool_->RemoveShmRegion();
   }
 
   // First destroy the IPCControl. This makes sure that IPCControl is
@@ -924,7 +935,37 @@ StubLauncher::WaitForStubProcess()
     // Added this check to ensure server doesn't hang waiting after stub
     // process has already be killed and cannot be waited on
     waitpid(stub_pid_, &status, 0);
+    stub_pid_ = 0;
   }
+#endif
+}
+
+bool
+StubLauncher::WaitForStubProcessWithTimeout(int64_t timeout_seconds)
+{
+#ifdef _WIN32
+  WaitForStubProcess();
+  return true;
+#else
+  if (stub_pid_ == 0) {
+    return true;
+  }
+
+  for (int64_t elapsed = 0; elapsed < timeout_seconds; ++elapsed) {
+    int status;
+    pid_t ret = waitpid(stub_pid_, &status, WNOHANG);
+    if (ret == stub_pid_) {
+      stub_pid_ = 0;
+      return true;
+    }
+    if (ret == -1) {
+      stub_pid_ = 0;
+      return true;
+    }
+    sleep(1);
+  }
+
+  return false;
 #endif
 }
 

--- a/src/stub_launcher.h
+++ b/src/stub_launcher.h
@@ -161,6 +161,9 @@ class StubLauncher {
   // Wait for stub process
   void WaitForStubProcess();
 
+  // Wait for stub process with timeout. Returns true if the stub exited.
+  bool WaitForStubProcessWithTimeout(int64_t timeout_seconds);
+
 #ifndef _WIN32
   // FIXME [DLIS-5969]: Enable for Windows when custom execution environments
   // are supported.
@@ -199,6 +202,7 @@ class StubLauncher {
   int64_t shm_default_byte_size_;
   int64_t shm_growth_byte_size_;
   int64_t shm_message_queue_size_;
+  int64_t stub_timeout_seconds_;
 
   // Path to python execution environment
   std::string path_to_libpython_;


### PR DESCRIPTION
#### What does the PR do?

Runtime fix for orphaned `triton_python_backend_shm_region_*` files when Python backend stub shutdown exceeds the server exit timeout. Pairs with the QA-side change in `server#8881`.

#### Ticket

- Linear: [TRI-1330](https://linear.app/nvidia/issue/TRI-1330) — Phase 2 (runtime cure)
- Server-side (Phase 1, merged): https://github.com/triton-inference-server/server/pull/8881

#### Root cause

- `stub-timeout-seconds` was parsed at backend init but not applied inside `TerminateStub` — the wait on the stub was effectively unbounded.
- Parent-owned shm regions were only removed via the `SharedMemoryManager` destructor, so a forced/abnormal exit could skip cleanup and leak `/dev/shm/triton_python_backend_shm_region_*`.

#### Fix

- Wire `stub_timeout_seconds_` through `StubLauncher::TerminateStub` with a bounded pop + `WaitForStubProcessWithTimeout`; fall back to `KillStubProcess` on timeout (`src/stub_launcher.{cc,h}`).
- Add explicit `SharedMemoryManager::RemoveShmRegion()` and call it from `TerminateStub` (`src/shm_manager.{cc,h}`).
- Register parent-owned shm regions for `std::atexit` cleanup as a safety net for forced exits.

#### Test plan

- IGX-Orin GitLab job [366443271](https://gitlab-master.nvidia.com/dl/dgx/tritonserver/-/jobs/366443271): `L0_backend_python--IGX-Orin` lifecycle PASSED with this PR + `server#8881`; `/dev/shm` shm-region count unchanged before/after run.
- x86: no regression on `L0_backend_python/lifecycle`.

#### Checklist

- [x] PR title reflects the change and is of format `<type>: <description>`
- [x] Changes are described in the pull request.
- [x] Related PRs are referenced.
- [x] Added test plan and verified test passes.

#### Commit Type

- [x] fix